### PR TITLE
Use DenseI64ArrayAttr for ops which already specialized the printing/parsing as DenseI64ArrayAttr (copy and update of #1658)

### DIFF
--- a/stablehlo/conversions/linalg/tests/miscellaneous.mlir
+++ b/stablehlo/conversions/linalg/tests/miscellaneous.mlir
@@ -1555,7 +1555,7 @@ func.func @dynamic_update_slice_float(%target: tensor<3x3xf32>,
 // CHECK-DAG: #[[RESULT_MAP:.*]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 // CHECK: func @transpose
 func.func @transpose(%arg0: tensor<2x3x9x5xi32>) -> tensor<3x2x5x9xi32> {
-  %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>}
+  %0 = "stablehlo.transpose"(%arg0) {permutation = array<i64: 1, 0, 3, 2>}
         : (tensor<2x3x9x5xi32>) -> tensor<3x2x5x9xi32>
   func.return %0 : tensor<3x2x5x9xi32>
 }
@@ -1570,7 +1570,7 @@ func.func @transpose(%arg0: tensor<2x3x9x5xi32>) -> tensor<3x2x5x9xi32> {
 // CHECK-DAG: #[[RESULT_MAP:.*]] = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 // CHECK: func @transpose_dynamic
 func.func @transpose_dynamic(%arg0: tensor<?x?x9x?xi32>) -> tensor<?x?x?x9xi32> {
-  %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>, someattr}
+  %0 = "stablehlo.transpose"(%arg0) {permutation = array<i64: 1, 0, 3, 2>, someattr}
         : (tensor<?x?x9x?xi32>) -> tensor<?x?x?x9xi32>
   func.return %0 : tensor<?x?x?x9xi32>
 }
@@ -1603,7 +1603,7 @@ func.func @transpose_dynamic(%arg0: tensor<?x?x9x?xi32>) -> tensor<?x?x?x9xi32> 
 
 func.func @transpose_unsigned(%arg0: tensor<2x2xui32>) -> tensor<2x2xui32> {
   %0 = "stablehlo.transpose"(%arg0) {
-    permutation = dense<[1, 0]> : tensor<2xi64>,
+    permutation = array<i64: 1, 0>,
     result_layout = dense<[0, 1]> : tensor<2xindex>
   } : (tensor<2x2xui32>) -> tensor<2x2xui32>
   return %0 : tensor<2x2xui32>

--- a/stablehlo/conversions/linalg/tests/miscellaneous.mlir
+++ b/stablehlo/conversions/linalg/tests/miscellaneous.mlir
@@ -737,9 +737,9 @@ func.func @map_compare(%arg0: tensor<?xcomplex<f32>>,
 func.func @pad_cst(%arg0: tensor<12x4xf32>) -> tensor<18x12xf32> {
   %0 = arith.constant dense<0.0> : tensor<f32>
   %1 = "stablehlo.pad"(%arg0, %0) {
-    edge_padding_high = dense<[2, 3]> : tensor<2xi64>,
-    edge_padding_low = dense<[4, 5]> : tensor<2xi64>,
-    interior_padding = dense<0> : tensor<2xi64>
+    edge_padding_high = array<i64: 2, 3>,
+    edge_padding_low = array<i64: 4, 5>,
+    interior_padding = array<i64: 0, 0>
   } : (tensor<12x4xf32>, tensor<f32>) -> tensor<18x12xf32>
   func.return %1 : tensor<18x12xf32>
 }
@@ -754,9 +754,9 @@ func.func @pad_cst(%arg0: tensor<12x4xf32>) -> tensor<18x12xf32> {
 
 func.func @pad_tensor(%arg0: tensor<12x4xf32>, %arg1: tensor<f32>) -> tensor<18x12xf32> {
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<[2, 3]> : tensor<2xi64>,
-    edge_padding_low = dense<[4, 5]> : tensor<2xi64>,
-    interior_padding = dense<0> : tensor<2xi64>
+    edge_padding_high = array<i64: 2, 3>,
+    edge_padding_low = array<i64: 4, 5>,
+    interior_padding = array<i64: 0, 0>
   } : (tensor<12x4xf32>, tensor<f32>) -> tensor<18x12xf32>
   func.return %0 : tensor<18x12xf32>
 }
@@ -773,9 +773,9 @@ func.func @pad_tensor(%arg0: tensor<12x4xf32>, %arg1: tensor<f32>) -> tensor<18x
 func.func @pad_interior(%arg0: tensor<12x4xui32>, %arg1: tensor<ui32>) -> tensor<29x15xui32> {
   %0 = arith.constant dense<0> : tensor<ui32>
   %1 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<[2, 3]> : tensor<2xi64>,
-    edge_padding_low = dense<[4, 5]> : tensor<2xi64>,
-    interior_padding = dense<[1, 1]> : tensor<2xi64>
+    edge_padding_high = array<i64: 2, 3>,
+    edge_padding_low = array<i64: 4, 5>,
+    interior_padding = array<i64: 1, 1>
   } : (tensor<12x4xui32>, tensor<ui32>) -> tensor<29x15xui32>
   func.return %1 : tensor<29x15xui32>
 }
@@ -794,9 +794,9 @@ func.func @pad_interior(%arg0: tensor<12x4xui32>, %arg1: tensor<ui32>) -> tensor
 func.func @pad_interior_negative(%arg0: tensor<12x4xui32>, %arg1: tensor<ui32>) -> tensor<25x9xui32> {
   %0 = arith.constant dense<0> : tensor<ui32>
   %1 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<[-2, 3]> : tensor<2xi64>,
-    edge_padding_low = dense<[4, -1]> : tensor<2xi64>,
-    interior_padding = dense<[1, 1]> : tensor<2xi64>
+    edge_padding_high = array<i64: -2, 3>,
+    edge_padding_low = array<i64: 4, -1>,
+    interior_padding = array<i64: 1, 1>
   } : (tensor<12x4xui32>, tensor<ui32>) -> tensor<25x9xui32>
   func.return %1 : tensor<25x9xui32>
 }

--- a/stablehlo/conversions/linalg/tests/miscellaneous.mlir
+++ b/stablehlo/conversions/linalg/tests/miscellaneous.mlir
@@ -1395,7 +1395,7 @@ func.func @slice_with_empty_result(%arg0: tensor<3x3x5xf64>) -> tensor<3x0x5xf64
 // CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]*]]
 func.func @dynamic_slice(%arg: tensor<3x4xf32>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<1x4xf32> {
   %0 = "stablehlo.dynamic_slice"(%arg, %start1, %start2) {
-    slice_sizes = dense<[1, 4]> : tensor<2xi64>
+    slice_sizes = array<i64: 1, 4>
   } : (tensor<3x4xf32>, tensor<i64>, tensor<i64>) -> tensor<1x4xf32>
   func.return %0 : tensor<1x4xf32>
 }
@@ -1418,7 +1418,7 @@ func.func @dynamic_slice_unsigned_index(
     %arg: tensor<3x4xui32>, %start1: tensor<ui64>, %start2: tensor<ui64>)
     -> tensor<1x4xui32> {
   %0 = "stablehlo.dynamic_slice"(%arg, %start1, %start2) {
-    slice_sizes = dense<[1, 4]> : tensor<2xi64>
+    slice_sizes = array<i64: 1, 4>
   } : (tensor<3x4xui32>, tensor<ui64>, tensor<ui64>) -> tensor<1x4xui32>
   func.return %0 : tensor<1x4xui32>
 }
@@ -1434,7 +1434,7 @@ func.func @dynamic_slice_unsigned_index(
 // CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]*]]
 func.func @dynamic_slice_unsigned(%arg: tensor<3x4xui32>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<1x4xui32> {
   %0 = "stablehlo.dynamic_slice"(%arg, %start1, %start2) {
-    slice_sizes = dense<[1, 4]> : tensor<2xi64>
+    slice_sizes = array<i64: 1, 4>
   } : (tensor<3x4xui32>, tensor<i64>, tensor<i64>) -> tensor<1x4xui32>
   func.return %0 : tensor<1x4xui32>
 }

--- a/stablehlo/conversions/linalg/tests/miscellaneous.mlir
+++ b/stablehlo/conversions/linalg/tests/miscellaneous.mlir
@@ -1328,9 +1328,9 @@ func.func @torch_index_select_dynamic(%input: tensor<?x?x?x?xf32>,
 //       CHECK:   tensor.extract_slice %{{.*}}[1, 0] [1, 4] [1, 1] : tensor<3x4xi32> to tensor<1x4xi32>
 func.func @slice_whole_stride(%arg0: tensor<3x4xi32>) -> tensor<1x4xi32> {
   %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<[1, 0]> : tensor<2xi64>,
-    limit_indices = dense<[2, 4]> : tensor<2xi64>,
-    strides = dense<1> : tensor<2xi64>
+    start_indices = array<i64: 1, 0>,
+    limit_indices = array<i64: 2, 4>,
+    strides = array<i64: 1, 1>
   } : (tensor<3x4xi32>) -> tensor<1x4xi32>
   func.return %0 : tensor<1x4xi32>
 }
@@ -1341,9 +1341,9 @@ func.func @slice_whole_stride(%arg0: tensor<3x4xi32>) -> tensor<1x4xi32> {
 //       CHECK:   tensor.extract_slice %{{.*}}[1, 1] [1, 2] [1, 1]  : tensor<3x4xi32> to tensor<1x2xi32>
 func.func @slice_stride_part(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
   %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<[1, 1]> : tensor<2xi64>,
-    limit_indices = dense<[2, 3]> : tensor<2xi64>,
-    strides = dense<1> : tensor<2xi64>
+    start_indices = array<i64: 1, 1>,
+    limit_indices = array<i64: 2, 3>,
+    strides = array<i64: 1, 1>
   } : (tensor<3x4xi32>) -> tensor<1x2xi32>
   func.return %0 : tensor<1x2xi32>
 }
@@ -1354,9 +1354,9 @@ func.func @slice_stride_part(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
 //       CHECK:   tensor.extract_slice %{{.*}}[0] [6] [2] : tensor<13xi32> to tensor<6xi32>
 func.func @slice_with_strides(%arg0: tensor<13xi32>) -> tensor<6xi32> {
   %0 = "stablehlo.slice"(%arg0) {
-    limit_indices = dense<12> : tensor<1xi64>,
-    start_indices = dense<0> : tensor<1xi64>,
-    strides = dense<2> : tensor<1xi64>
+    limit_indices = array<i64: 12>,
+    start_indices = array<i64: 0>,
+    strides = array<i64: 2>
   } : (tensor<13xi32>) -> tensor<6xi32>
   func.return %0 : tensor<6xi32>
 }
@@ -1367,9 +1367,9 @@ func.func @slice_with_strides(%arg0: tensor<13xi32>) -> tensor<6xi32> {
 //       CHECK:   tensor.extract_slice %{{.*}}[0] [3] [2] : tensor<6xi32> to tensor<3xi32>
 func.func @slice_with_strides2(%arg0: tensor<6xi32>) -> tensor<3xi32> {
   %0 = "stablehlo.slice"(%arg0) {
-    limit_indices = dense<5> : tensor<1xi64>,
-    start_indices = dense<0> : tensor<1xi64>,
-    strides = dense<2> : tensor<1xi64>
+    limit_indices = array<i64: 5>,
+    start_indices = array<i64: 0>,
+    strides = array<i64: 2>
   } : (tensor<6xi32>) -> tensor<3xi32>
   func.return %0 : tensor<3xi32>
 }
@@ -1380,9 +1380,9 @@ func.func @slice_with_strides2(%arg0: tensor<6xi32>) -> tensor<3xi32> {
 //       CHECK:   tensor.extract_slice %{{.*}}[0, 2, 0] [3, 0, 5] [1, 2, 1] : tensor<3x3x5xf64> to tensor<3x0x5xf64>
 func.func @slice_with_empty_result(%arg0: tensor<3x3x5xf64>) -> tensor<3x0x5xf64> {
   %0 = "stablehlo.slice"(%arg0) {
-    limit_indices = dense<[3, 2, 5]> : tensor<3xi64>,
-    start_indices = dense<[0, 2, 0]> : tensor<3xi64>,
-    strides = dense<[1, 2, 1]> : tensor<3xi64>
+    limit_indices = array<i64: 3, 2, 5>,
+    start_indices = array<i64: 0, 2, 0>,
+    strides = array<i64: 1, 2, 1>
   } : (tensor<3x3x5xf64>) -> tensor<3x0x5xf64>
   func.return %0 : tensor<3x0x5xf64>
 }

--- a/stablehlo/conversions/linalg/tests/miscellaneous.mlir
+++ b/stablehlo/conversions/linalg/tests/miscellaneous.mlir
@@ -480,7 +480,7 @@ func.func @broadcast_in_dim_scalar(%operand: tensor<f32>) -> tensor<7x10x6xf32> 
 // CHECK-DAG: #[[RESULT_MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
 // CHECK: func @broadcast_scalar
 func.func @broadcast_scalar(%arg: tensor<f32>) -> tensor<4x2x1xf32> {
-  %0 = "stablehlo.broadcast"(%arg) {broadcast_sizes = dense<[4, 2, 1]> : tensor<3xi64>} : (tensor<f32>) -> tensor<4x2x1xf32>
+  %0 = "stablehlo.broadcast"(%arg) {broadcast_sizes = array<i64: 4, 2, 1>} : (tensor<f32>) -> tensor<4x2x1xf32>
   func.return %0: tensor<4x2x1xf32>
 }
 // CHECK: tensor.empty() : tensor<4x2x1xf32>
@@ -501,7 +501,7 @@ func.func @broadcast_scalar(%arg: tensor<f32>) -> tensor<4x2x1xf32> {
 // CHECK-DAG: #[[RESULT_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4, d5)>
 // CHECK: func @broadcast
 func.func @broadcast(%arg: tensor<4x?x16xf32>) -> tensor<4x2x1x4x?x16xf32> {
-  %0 = "stablehlo.broadcast"(%arg) {broadcast_sizes = dense<[4, 2, 1]> : tensor<3xi64>} : (tensor<4x?x16xf32>) -> tensor<4x2x1x4x?x16xf32>
+  %0 = "stablehlo.broadcast"(%arg) {broadcast_sizes = array<i64: 4, 2, 1>} : (tensor<4x?x16xf32>) -> tensor<4x2x1x4x?x16xf32>
   func.return %0: tensor<4x2x1x4x?x16xf32>
 }
 // CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index

--- a/stablehlo/conversions/linalg/tests/miscellaneous.mlir
+++ b/stablehlo/conversions/linalg/tests/miscellaneous.mlir
@@ -1062,7 +1062,7 @@ func.func @reshape_empty(%arg0: tensor<7x0xf64>) -> tensor<0x42x101xf64> {
 // CHECK: func @reverse
 func.func @reverse(%input: tensor<2x3xf32>) -> tensor<2x3xf32> {
   %result = "stablehlo.reverse"(%input) {
-    dimensions = dense<1> : tensor<1xi64>, someattr
+    dimensions = array<i64: 1>, someattr
   } : (tensor<2x3xf32>) -> tensor<2x3xf32>
   func.return %result : tensor<2x3xf32>
 }

--- a/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
@@ -1422,9 +1422,9 @@ struct SliceConverter final : OpConversionPattern<mlir::stablehlo::SliceOp> {
     }
 
     SmallVector<OpFoldResult, 3> offsets, sizes, strides;
-    auto startIndices = sliceOp.getStartIndices().getValues<int64_t>();
-    auto limitIndices = sliceOp.getLimitIndices().getValues<int64_t>();
-    auto sliceStrides = sliceOp.getStrides().getValues<int64_t>();
+    auto startIndices = sliceOp.getStartIndices();
+    auto limitIndices = sliceOp.getLimitIndices();
+    auto sliceStrides = sliceOp.getStrides();
 
     for (int64_t i = 0, e = argType.getRank(); i < e; ++i) {
       int64_t start = startIndices[i];

--- a/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
@@ -1470,7 +1470,7 @@ struct DynamicSliceConverter final
         dynamicSliceOp.getStartIndices().front().getType());
     for (auto [idx, start, size] :
          llvm::enumerate(adaptor.getStartIndices(),
-                         dynamicSliceOp.getSliceSizes().getValues<int64_t>())) {
+                         dynamicSliceOp.getSliceSizes())) {
       sizes.push_back(rewriter.getI64IntegerAttr(size));
 
       // By stablehlo.DynamicSlice definition:

--- a/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
@@ -1398,11 +1398,10 @@ struct ReverseConverter final
     inputExprs.reserve(nloops);
     for (int64_t i = 0; i < nloops; ++i)
       inputExprs.push_back(b->getAffineDimExpr(i));
-    for (const APInt &dim : op.getDimensions()) {
-      int i = dim.getZExtValue();
-      if (resultType.isDynamicDim(i)) return {};
-      int n = resultType.getShape()[i];
-      inputExprs[i] = b->getAffineConstantExpr(n - 1) - inputExprs[i];
+    for (const auto &dim : op.getDimensions()) {
+      if (resultType.isDynamicDim(dim)) return {};
+      int n = resultType.getShape()[dim];
+      inputExprs[dim] = b->getAffineConstantExpr(n - 1) - inputExprs[dim];
     }
     return {
         AffineMap::get(nloops, /*symbolCount=*/0, inputExprs, b->getContext()),

--- a/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
@@ -553,7 +553,7 @@ Value transposeBroadcastOperand(PatternRewriter &rewriter, Location loc,
   return rewriter.create<mlir::stablehlo::TransposeOp>(
       loc,
       RankedTensorType::get(transposedOperandShape, operandTy.getElementType()),
-      operand, rewriter.getI64VectorAttr(permutation));
+      operand, rewriter.getDenseI64ArrayAttr(permutation));
 }
 
 struct BroadcastInDimOpToBroadcastConverter final
@@ -818,7 +818,7 @@ struct TransposeConverter final
     SmallVector<AffineExpr, 2> inputExprs;
     inputExprs.resize(resultType.getRank());
     for (auto [idx, value] : llvm::enumerate(op.getPermutation())) {
-      inputExprs[value.getZExtValue()] = b->getAffineDimExpr(idx);
+      inputExprs[value] = b->getAffineDimExpr(idx);
     }
     return {
         AffineMap::get(nloops, /*symbolCount=*/0, inputExprs, b->getContext()),
@@ -842,7 +842,7 @@ struct TransposeOpToTransposeConverter final
         getEmptyTensorFor(rewriter, loc, resultTy, op, adaptor.getOperands());
 
     auto permutation = rewriter.getDenseI64ArrayAttr(
-        llvm::to_vector(op.getPermutation().getValues<int64_t>()));
+        llvm::to_vector(op.getPermutation()));
 
     rewriter.replaceOpWithNewOp<linalg::TransposeOp>(
         op, adaptor.getOperand(), emptyTensor, permutation,

--- a/stablehlo/conversions/linalg/transforms/StablehloToLinalgConvolution.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloToLinalgConvolution.cpp
@@ -105,10 +105,7 @@ Value applyConvolutionReversal(Location loc, OpBuilder &b,
   }
 
   return b.create<mlir::stablehlo::ReverseOp>(
-      loc, filter,
-      mlir::DenseIntElementsAttr::get(
-          RankedTensorType::get(reversedDims.size(), b.getI64Type()),
-          reversedDims));
+      loc, filter, b.getDenseI64ArrayAttr(reversedDims));
 }
 
 /// Returns true if the given `dimensionNumbers` from a stablehlo.convolution op

--- a/stablehlo/conversions/linalg/transforms/StablehloToLinalgConvolution.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloToLinalgConvolution.cpp
@@ -65,9 +65,6 @@ Value applyConvolutionPadding(Location loc, Value input,
     }
   }
 
-  IntegerType indexType = rewriter.getIntegerType(64);
-  auto attrType = RankedTensorType::get({rank}, indexType);
-
   Value zero;
   if (auto complexType = dyn_cast<ComplexType>(inputType.getElementType())) {
     auto zeroElement = rewriter.getZeroAttr(complexType.getElementType());
@@ -82,9 +79,9 @@ Value applyConvolutionPadding(Location loc, Value input,
   }
 
   return rewriter.create<mlir::stablehlo::PadOp>(
-      loc, input, zero, DenseIntElementsAttr::get(attrType, padLow),
-      DenseIntElementsAttr::get(attrType, padHigh),
-      DenseIntElementsAttr::get(attrType, padInterior));
+      loc, input, zero, padLow,
+      padHigh,
+      padInterior);
 }
 
 /// If the ConvolutionOp has a window reversal, applies it to the filter.

--- a/stablehlo/conversions/linalg/transforms/StablehloToLinalgConvolution.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloToLinalgConvolution.cpp
@@ -78,10 +78,8 @@ Value applyConvolutionPadding(Location loc, Value input,
                  RankedTensorType::get({}, inputType.getElementType())));
   }
 
-  return rewriter.create<mlir::stablehlo::PadOp>(
-      loc, input, zero, padLow,
-      padHigh,
-      padInterior);
+  return rewriter.create<mlir::stablehlo::PadOp>(loc, input, zero, padLow,
+                                                 padHigh, padInterior);
 }
 
 /// If the ConvolutionOp has a window reversal, applies it to the filter.

--- a/stablehlo/conversions/linalg/transforms/StablehloToLinalgRandom.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloToLinalgRandom.cpp
@@ -428,9 +428,7 @@ LogicalResult generateLinalgThreeFry32(OpBuilder &builder, Location loc,
   llvm::SmallVector<int64_t> offset(resultTy.getRank(), 0);
   llvm::SmallVector<int64_t> stride(resultTy.getRank(), 1);
   Value slice = builder.create<mlir::stablehlo::SliceOp>(
-      loc, resultTy, reshape, offset,
-      resultTy.getShape(),
-      stride);
+      loc, resultTy, reshape, offset, resultTy.getShape(), stride);
 
   // Set the new tensor values.
   store = setState64(builder, loc, store, newState);
@@ -637,9 +635,8 @@ LogicalResult generateLinalgPhilox32(OpBuilder &builder, Location loc,
   llvm::SmallVector<int64_t> offset(collapseShape.size(), 0);
   llvm::SmallVector<int64_t> stride(collapseShape.size(), 1);
   Value slice = builder.create<mlir::stablehlo::SliceOp>(
-      loc, intermediateType.clone(collapseShape), reshapeIntermediate,
-      offset, collapseShape,
-      stride);
+      loc, intermediateType.clone(collapseShape), reshapeIntermediate, offset,
+      collapseShape, stride);
   Value reshapeResult =
       builder.create<mlir::stablehlo::ReshapeOp>(loc, resultTy, slice);
 
@@ -726,9 +723,8 @@ LogicalResult generateLinalgPhilox64(OpBuilder &builder, Location loc,
   llvm::SmallVector<int64_t> offset(collapseShape.size(), 0);
   llvm::SmallVector<int64_t> stride(collapseShape.size(), 1);
   Value slice = builder.create<mlir::stablehlo::SliceOp>(
-      loc, intermediateType.clone(collapseShape), reshapeIntermediate,
-      offset, collapseShape,
-      stride);
+      loc, intermediateType.clone(collapseShape), reshapeIntermediate, offset,
+      collapseShape, stride);
   Value reshapeResult =
       builder.create<mlir::stablehlo::ReshapeOp>(loc, resultTy, slice);
 

--- a/stablehlo/conversions/linalg/transforms/StablehloToLinalgRandom.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloToLinalgRandom.cpp
@@ -428,9 +428,9 @@ LogicalResult generateLinalgThreeFry32(OpBuilder &builder, Location loc,
   llvm::SmallVector<int64_t> offset(resultTy.getRank(), 0);
   llvm::SmallVector<int64_t> stride(resultTy.getRank(), 1);
   Value slice = builder.create<mlir::stablehlo::SliceOp>(
-      loc, resultTy, reshape, builder.getI64TensorAttr(offset),
-      builder.getI64TensorAttr(resultTy.getShape()),
-      builder.getI64TensorAttr(stride));
+      loc, resultTy, reshape, offset,
+      resultTy.getShape(),
+      stride);
 
   // Set the new tensor values.
   store = setState64(builder, loc, store, newState);
@@ -634,12 +634,12 @@ LogicalResult generateLinalgPhilox32(OpBuilder &builder, Location loc,
   // Slice to only the required results.
   collapseShape[0] = resultTy.getNumElements();
 
-  llvm::SmallVector<int64_t> offset(resultTy.getRank(), 0);
-  llvm::SmallVector<int64_t> stride(resultTy.getRank(), 1);
+  llvm::SmallVector<int64_t> offset(collapseShape.size(), 0);
+  llvm::SmallVector<int64_t> stride(collapseShape.size(), 1);
   Value slice = builder.create<mlir::stablehlo::SliceOp>(
       loc, intermediateType.clone(collapseShape), reshapeIntermediate,
-      builder.getI64TensorAttr(offset), builder.getI64TensorAttr(collapseShape),
-      builder.getI64TensorAttr(stride));
+      offset, collapseShape,
+      stride);
   Value reshapeResult =
       builder.create<mlir::stablehlo::ReshapeOp>(loc, resultTy, slice);
 
@@ -723,12 +723,12 @@ LogicalResult generateLinalgPhilox64(OpBuilder &builder, Location loc,
   // Slice to only the required results.
   collapseShape[0] = resultTy.getNumElements();
 
-  llvm::SmallVector<int64_t> offset(resultTy.getRank(), 0);
-  llvm::SmallVector<int64_t> stride(resultTy.getRank(), 1);
+  llvm::SmallVector<int64_t> offset(collapseShape.size(), 0);
+  llvm::SmallVector<int64_t> stride(collapseShape.size(), 1);
   Value slice = builder.create<mlir::stablehlo::SliceOp>(
       loc, intermediateType.clone(collapseShape), reshapeIntermediate,
-      builder.getI64TensorAttr(offset), builder.getI64TensorAttr(collapseShape),
-      builder.getI64TensorAttr(stride));
+      offset, collapseShape,
+      stride);
   Value reshapeResult =
       builder.create<mlir::stablehlo::ReshapeOp>(loc, resultTy, slice);
 

--- a/stablehlo/conversions/linalg/transforms/StablehloToLinalgReduce.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloToLinalgReduce.cpp
@@ -430,16 +430,9 @@ struct ReduceWindowOpOnTensorsGenericConversion final
         staticInteriors[idx] = dilation - 1;
       }
 
-      auto padAttrType =
-          RankedTensorType::get({rank}, rewriter.getIntegerType(64));
-      auto padLows = DenseIntElementsAttr::get(padAttrType, staticLows);
-      auto padHighs = DenseIntElementsAttr::get(padAttrType, staticHighs);
-      auto padInteriors =
-          DenseIntElementsAttr::get(padAttrType, staticInteriors);
-
       for (auto [input, initValue] : llvm::zip(inputs, initValues)) {
         input = rewriter.create<mlir::stablehlo::PadOp>(
-            loc, input, initValue, padLows, padHighs, padInteriors);
+            loc, input, initValue, staticLows, staticHighs, staticInteriors);
       }
     }
 

--- a/stablehlo/conversions/linalg/transforms/StablehloToLinalgReduce.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloToLinalgReduce.cpp
@@ -408,7 +408,7 @@ struct ReduceWindowOpOnTensorsGenericConversion final
       auto resultTy = llvm::cast<ShapedType>(resultTypes[i]);
       if (!resultTy.hasStaticShape()) return failure();
 
-      auto broadcastSizes = rewriter.getI64TensorAttr(resultTy.getShape());
+      auto broadcastSizes = rewriter.getDenseI64ArrayAttr(resultTy.getShape());
       broadcastValues.push_back(rewriter.create<mlir::stablehlo::BroadcastOp>(
           loc, resultTy, initValue, broadcastSizes));
     }

--- a/stablehlo/conversions/tosa/tests/unary.mlir
+++ b/stablehlo/conversions/tosa/tests/unary.mlir
@@ -81,9 +81,9 @@ func.func @negate(%arg : tensor<10xf32>) -> tensor<10xf32> {
 func.func @slice(%arg : tensor<4x3xf32>) -> tensor<2x2xf32> {
   // CHECK: tosa.slice %arg0 {size = array<i64: 2, 2>, start = array<i64: 2, 1>}
   %0 = "stablehlo.slice"(%arg) {
-    start_indices = dense<[2, 1]> : tensor<2xi64>,
-    limit_indices = dense<[4, 3]> : tensor<2xi64>,
-    strides = dense<1> : tensor<2xi64>
+    start_indices = array<i64: 2, 1>,
+    limit_indices = array<i64: 4, 3>,
+    strides = array<i64: 1, 1>
   } : (tensor<4x3xf32>) -> tensor<2x2xf32>
   return %0 : tensor<2x2xf32>
 }
@@ -93,9 +93,9 @@ func.func @slice_stride_not_one(%arg : tensor<4x3xf32>) -> tensor<2x1xf32> {
   // tosa.slice only supports strides of 1, so this should not legalize.
   // CHECK: stablehlo.slice
   %0 = "stablehlo.slice"(%arg) {
-    start_indices = dense<[2, 1]> : tensor<2xi64>,
-    limit_indices = dense<[4, 3]> : tensor<2xi64>,
-    strides = dense<[1, 2]> : tensor<2xi64>
+    start_indices = array<i64: 2, 1>,
+    limit_indices = array<i64: 4, 3>,
+    strides = array<i64: 1, 2>
   } : (tensor<4x3xf32>) -> tensor<2x1xf32>
   return %0 : tensor<2x1xf32>
 }
@@ -105,9 +105,9 @@ func.func @slice_rank_seven(%arg : tensor<2x3x4x5x6x7x8xf32>) -> tensor<1x2x3x4x
   // tosa.slice only supports 1D to 6D tensors, so this should not legalize.
   // CHECK: stablehlo.slice
   %0 = "stablehlo.slice"(%arg) {
-    start_indices = dense<[1, 1, 1, 1, 1, 1, 1]> : tensor<7xi64>,
-    limit_indices = dense<[2, 3, 4, 5, 6, 7, 8]> : tensor<7xi64>,
-    strides = dense<[1, 1, 1, 1, 1, 1, 1]> : tensor<7xi64>
+    start_indices = array<i64: 1, 1, 1, 1, 1, 1, 1>,
+    limit_indices = array<i64: 2, 3, 4, 5, 6, 7, 8>,
+    strides = array<i64: 1, 1, 1, 1, 1, 1, 1>
   } : (tensor<2x3x4x5x6x7x8xf32>) -> tensor<1x2x3x4x5x6x7xf32>
   return %0 : tensor<1x2x3x4x5x6x7xf32>
 }

--- a/stablehlo/conversions/tosa/tests/unary.mlir
+++ b/stablehlo/conversions/tosa/tests/unary.mlir
@@ -123,7 +123,7 @@ func.func @tanh(%arg : tensor<10xf32>) -> tensor<10xf32> {
 func.func @transpose(%arg0: tensor<1x2x3xf32>) -> tensor<3x2x1xf32> {
   // CHECK-DAG: %[[VAR0:.*]] = "tosa.const"() <{value = dense<[2, 1, 0]> : tensor<3xi64>}> : () -> tensor<3xi64>
   // CHECK-DAG: %[[VAR1:.*]] = tosa.transpose %arg0, %[[VAR0]]
-  %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[2, 1, 0]> : tensor<3xi64>} : (tensor<1x2x3xf32>) -> tensor<3x2x1xf32>
+  %0 = "stablehlo.transpose"(%arg0) {permutation = array<i64: 2, 1, 0>} : (tensor<1x2x3xf32>) -> tensor<3x2x1xf32>
   return %0 : tensor<3x2x1xf32>
 }
 

--- a/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.cpp
+++ b/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.cpp
@@ -393,7 +393,7 @@ struct ConvertStablehloSliceOp : public OpRewritePattern<stablehlo::SliceOp> {
           op, "tosa.slice only supports 1D to 6D tensors");
     }
 
-    auto strides = op.getStrides().getValues<int64_t>();
+    auto strides = op.getStrides();
     for (auto stride : strides) {
       if (stride != 1) {
         return rewriter.notifyMatchFailure(
@@ -401,8 +401,8 @@ struct ConvertStablehloSliceOp : public OpRewritePattern<stablehlo::SliceOp> {
       }
     }
 
-    auto startIndices = op.getStartIndices().getValues<int64_t>();
-    auto endIndices = op.getLimitIndices().getValues<int64_t>();
+    auto startIndices = op.getStartIndices();
+    auto endIndices = op.getLimitIndices();
 
     llvm::SmallVector<int64_t, 2> size;
     size.resize(startIndices.size());

--- a/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.cpp
+++ b/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.cpp
@@ -435,9 +435,10 @@ struct ConvertStablehloTransposeOp
     }
 
     auto perms = op.getPermutation();
+    auto type = RankedTensorType::get({static_cast<int64_t>(perms.size())},
+                                      rewriter.getI64Type());
     auto constOp = rewriter.create<tosa::ConstOp>(
-        op->getLoc(),
-        RankedTensorType::get({perms.size()}, rewriter.getI64Type()), perms);
+        op->getLoc(), type, DenseIntElementsAttr::get(type, perms));
     rewriter.replaceOpWithNewOp<tosa::TransposeOp>(op, op.getResult().getType(),
                                                    op.getOperand(), constOp);
     return success();

--- a/stablehlo/dialect/AssemblyFormat.h
+++ b/stablehlo/dialect/AssemblyFormat.h
@@ -188,14 +188,14 @@ ParseResult parseDenseI64Array(OpAsmParser& parser, DenseIntElementsAttr& attr);
 
 // SliceRanges - Used to print multi-dimensional ranges for slice.
 void printSliceRanges(OpAsmPrinter& p, Operation* op,
-                      DenseIntElementsAttr startIndices,
-                      DenseIntElementsAttr limitIndices,
-                      DenseIntElementsAttr strides);
+                      ArrayRef<int64_t> startIndices,
+                      ArrayRef<int64_t> limitIndices,
+                      ArrayRef<int64_t> strides);
 
 ParseResult parseSliceRanges(OpAsmParser& parser,
-                             DenseIntElementsAttr& startIndices,
-                             DenseIntElementsAttr& limitIndices,
-                             DenseIntElementsAttr& strides);
+                             DenseI64ArrayAttr& startIndices,
+                             DenseI64ArrayAttr& limitIndices,
+                             DenseI64ArrayAttr& strides);
 
 // DimSizes - Print an array of ints. Dynamic dimensions printed as `?`.
 //

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1954,26 +1954,9 @@ LogicalResult PadOp::reifyReturnTypeShapes(
   Value operand = adaptor.getOperand();
   auto operandTy = operand.getType().cast<RankedTensorType>();
 
-  llvm::SmallVector<int32_t> padHigh;
-  llvm::SmallVector<int32_t> padLow;
-  llvm::SmallVector<int32_t> padInterior;
-
-  auto padHighAttr = adaptor.getEdgePaddingHigh();
-  auto padLowAttr = adaptor.getEdgePaddingLow();
-  auto padInteriorAttr = adaptor.getInteriorPadding();
-
-  padHigh.reserve(padHighAttr.getNumElements());
-  padLow.reserve(padLowAttr.getNumElements());
-  padInterior.reserve(padInteriorAttr.getNumElements());
-
-  for (const APInt& val : padHighAttr.getValues<APInt>())
-    padHigh.push_back(val.getSExtValue());
-
-  for (const APInt& val : padLowAttr.getValues<APInt>())
-    padLow.push_back(val.getSExtValue());
-
-  for (const APInt& val : padInteriorAttr.getValues<APInt>())
-    padInterior.push_back(val.getSExtValue());
+  auto padHigh = adaptor.getEdgePaddingHigh();
+  auto padLow = adaptor.getEdgePaddingLow();
+  auto padInterior = adaptor.getInteriorPadding();
 
   Value one = builder.create<arith::ConstantIndexOp>(loc, 1).getResult();
   Value zero = builder.create<arith::ConstantIndexOp>(loc, 0).getResult();

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1026,7 +1026,7 @@ LogicalResult BroadcastOp::reifyReturnTypeShapes(
   // Collect the broadcast sizes.
   for (const auto& size : getBroadcastSizes())
     shapeValues.push_back(
-        builder.create<arith::ConstantIndexOp>(loc, size.getZExtValue()));
+        builder.create<arith::ConstantIndexOp>(loc, size));
 
   // Collect the operand sizes.
   for (auto index : llvm::seq<int64_t>(0, operandType.getRank()))

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2195,8 +2195,7 @@ LogicalResult TransposeOp::reifyReturnTypeShapes(
   if (!operandType) return failure();
 
   Location loc = this->getLoc();
-  SmallVector<int64_t, 4> permutation(
-      this->getPermutation().getValues<int64_t>());
+  SmallVector<int64_t, 4> permutation(this->getPermutation());
   SmallVector<Value, 4> shapeValues(permutation.size());
 
   Type shapeScalarType = builder.getIndexType();

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1025,8 +1025,7 @@ LogicalResult BroadcastOp::reifyReturnTypeShapes(
 
   // Collect the broadcast sizes.
   for (const auto& size : getBroadcastSizes())
-    shapeValues.push_back(
-        builder.create<arith::ConstantIndexOp>(loc, size));
+    shapeValues.push_back(builder.create<arith::ConstantIndexOp>(loc, size));
 
   // Collect the operand sizes.
   for (auto index : llvm::seq<int64_t>(0, operandType.getRank()))

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2733,8 +2733,9 @@ def StableHLO_ReverseOp: StableHLO_Op<"reverse",
 
 def StableHLO_PadOp: StableHLO_ShapedInterfaceOp<"pad",
       [Pure, SameOperandsAndResultElementType /*pad_c1*/,
-      AllTypesMatch<["edge_padding_low", "edge_padding_high",
-      "interior_padding"]> /*pad_c2, pad_i3, pad_i4, pad_i5*/,
+      /*pad_c2, pad_i3, pad_i4, pad_i5*/
+      AllMatchSameOperatorTrait<["edge_padding_low", "edge_padding_high",
+      "interior_padding"], "$_self.size()", "size">,
       DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "Pad operation";
   let description = [{
@@ -2753,18 +2754,18 @@ def StableHLO_PadOp: StableHLO_ShapedInterfaceOp<"pad",
   let arguments = (ins
     HLO_Tensor:$operand /*pad_i1*/,
     HLO_Tensor:$padding_value /*pad_i2*/,
-    I64ElementsAttr:$edge_padding_low /*pad_i3*/,
-    I64ElementsAttr:$edge_padding_high /*pad_i4*/,
-    I64ElementsAttr:$interior_padding /*pad_i5*/
+    DenseI64ArrayAttr:$edge_padding_low /*pad_i3*/,
+    DenseI64ArrayAttr:$edge_padding_high /*pad_i4*/,
+    DenseI64ArrayAttr:$interior_padding /*pad_i5*/
   );
 
   let results = (outs HLO_Tensor);
 
   let assemblyFormat = [{
     $operand `,` $padding_value `,`
-      `low` `=` custom<DenseI64Array>($edge_padding_low) `,`
-      `high` `=` custom<DenseI64Array>($edge_padding_high) `,`
-      `interior` `=` custom<DenseI64Array>($interior_padding)
+      `low` `=` $edge_padding_low `,`
+      `high` `=` $edge_padding_high `,`
+      `interior` `=` $interior_padding
       attr-dict `:` functional-type(operands, results)
   }];
 }

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1843,13 +1843,13 @@ def StableHLO_BroadcastOp : StableHLO_ShapedInterfaceOp<"broadcast",
   }];
   let arguments = (ins
     HLO_Tensor:$operand,
-    I64ElementsAttr:$broadcast_sizes
+    DenseI64ArrayAttr:$broadcast_sizes
   );
 
   let results = (outs HLO_Tensor);
 
   let assemblyFormat = [{
-    $operand `,` `sizes` `=` custom<DenseI64Array>($broadcast_sizes)
+    $operand `,` `sizes` `=` $broadcast_sizes
       attr-dict `:` functional-type(operands, results)
   }];
 }

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1646,14 +1646,14 @@ def StableHLO_DynamicSliceOp: StableHLO_Op<"dynamic_slice",
   let arguments = (ins
     HLO_Tensor:$operand /*dynamic_slice_i1*/,
     Variadic<HLO_ScalarIntTensor>:$start_indices /*dynamic_slice_i2*/,
-    I64ElementsAttr:$slice_sizes /*dynamic_slice_i3*/
+    DenseI64ArrayAttr:$slice_sizes /*dynamic_slice_i3*/
   );
 
   let results = (outs HLO_Tensor:$result);
 
   let assemblyFormat = [{
     $operand `,` custom<VariadicOperandWithAttribute>($start_indices)
-      `sizes` `=` custom<DenseI64Array>($slice_sizes)
+      `sizes` `=` $slice_sizes
       attr-dict `:` functional-type(operands, results)
   }];
 }

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2717,7 +2717,7 @@ def StableHLO_ReverseOp: StableHLO_Op<"reverse",
   }];
   let arguments = (ins
     HLO_Tensor:$operand,
-    I64ElementsAttr:$dimensions
+    DenseI64ArrayAttr:$dimensions
   );
 
   let hasVerifier = 1;
@@ -2725,7 +2725,7 @@ def StableHLO_ReverseOp: StableHLO_Op<"reverse",
   let results = (outs HLO_Tensor:$result);
 
   let assemblyFormat = [{
-    $operand `,` `dims` `=` custom<DenseI64Array>($dimensions)
+    $operand `,` `dims` `=` $dimensions
       attr-dict `:` custom<SameOperandsAndResultType>(type($operand), type($result))
   }];
 }

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2808,12 +2808,12 @@ def StableHLO_TransposeOp: StableHLO_ShapedInterfaceOp<"transpose",
   }];
   let arguments = (ins
     HLO_Tensor:$operand,
-    I64ElementsAttr:$permutation
+    DenseI64ArrayAttr:$permutation
   );
   let results = (outs HLO_Tensor);
 
   let assemblyFormat = [{
-    $operand `,` `dims` `=` custom<DenseI64Array>($permutation)
+    $operand `,` `dims` `=` $permutation
       attr-dict `:` functional-type(operands, results)
   }];
 }

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1584,7 +1584,8 @@ def StableHLO_CompareOp: StableHLO_Op<"compare", [Pure, Elementwise,
 def StableHLO_SliceOp: StableHLO_Op<
       "slice",
       [Pure, SameOperandsAndResultElementType /*slice_c1*/,
-       AllTypesMatch<["start_indices", "limit_indices", "strides"]> /*slice_c2*/,
+      AllMatchSameOperatorTrait<["start_indices", "limit_indices",
+      "strides"], "$_self.size()", "size"> /*slice_c2*/,
        DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "Slice operation";
   let description = [{
@@ -1613,9 +1614,9 @@ def StableHLO_SliceOp: StableHLO_Op<
 
   let arguments = (ins
     HLO_Tensor:$operand,
-    I64ElementsAttr:$start_indices,
-    I64ElementsAttr:$limit_indices,
-    I64ElementsAttr:$strides
+    DenseI64ArrayAttr:$start_indices,
+    DenseI64ArrayAttr:$limit_indices,
+    DenseI64ArrayAttr:$strides
   );
 
   let assemblyFormat = [{

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2359,13 +2359,13 @@ def StableHLO_FftOp: StableHLO_Op<"fft", [InferTensorType, Pure]> {
   let arguments = (ins
     HLO_FpOrComplexTensor:$operand,
     StableHLO_FftTypeAttr:$fft_type,
-    I64ElementsAttr:$fft_length
+    DenseI64ArrayAttr:$fft_length
   );
 
   let results = (outs HLO_Tensor);
 
   let assemblyFormat = [{
-    $operand `,` `type` `=` $fft_type `,` `length` `=` custom<DenseI64Array>($fft_length)
+    $operand `,` `type` `=` $fft_type `,` `length` `=` $fft_length
       attr-dict `:` functional-type(operands, results)
   }];
 }

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -3918,20 +3918,14 @@ LogicalResult verifyReshapeOp(std::optional<Location> location, Value operand,
 }
 
 LogicalResult verifyReverseOp(std::optional<Location> location, Value operand,
-                              DenseIntElementsAttr dimensions) {
-  // reverse_i2
-  if (dimensions.getType().getRank() != 1)
-    return emitOptionalError(location, "dimensions has rank ",
-                             dimensions.getType().getRank(),
-                             " instead of required rank 1.");
-  auto dims = dimensions.getValues<int64_t>();
-  llvm::SmallDenseSet<int64_t> uniqueDims(dims.begin(), dims.end());
+                              ArrayRef<int64_t> dimensions) {
+  llvm::SmallDenseSet<int64_t> uniqueDims(dimensions.begin(), dimensions.end());
   // reverse_c2
-  if (uniqueDims.size() != dims.size())
+  if (uniqueDims.size() != dimensions.size())
     return emitOptionalError(location,
-                             "dimensions should be unique. Got: ", dims);
+                             "dimensions should be unique. Got: ", dimensions);
   auto operandTy = operand.getType().dyn_cast<RankedTensorType>();
-  for (int64_t dim : uniqueDims) {
+  for (int64_t dim : dimensions) {
     // reverse_c3
     if (dim < 0)
       return emitOptionalError(

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2921,7 +2921,7 @@ LogicalResult inferTopKOp(
 }
 
 LogicalResult inferTransposeOp(std::optional<Location> loc, Value operand,
-                               DenseIntElementsAttr permutation,
+                               ArrayRef<int64_t> permutation,
                                SmallVectorImpl<Type>& inferredReturnTypes) {
   auto type = operand.getType();
   auto rankedTy = type.dyn_cast<RankedTensorType>();
@@ -2930,12 +2930,7 @@ LogicalResult inferTransposeOp(std::optional<Location> loc, Value operand,
     return success();
   }
   int64_t rank = rankedTy.getRank();
-  if (permutation.getType().getRank() != 1)
-    return emitOptionalError(loc, "TransposeOp permutation has rank ",
-                             permutation.getType().getRank(),
-                             " instead of rank 1");
-
-  if (permutation.size() != rank)
+  if (static_cast<int64_t>(permutation.size()) != rank)
     return emitOptionalError(loc, "TransposeOp operand rank ", rank,
                              " does not match permutation size ",
                              permutation.size());
@@ -2952,7 +2947,7 @@ LogicalResult inferTransposeOp(std::optional<Location> loc, Value operand,
   SmallVector<int64_t> resultShape;
   SmallVector<int64_t> resultBounds;
   ArrayRef<int64_t> inputShape = rankedTy.getShape();
-  for (int64_t dim : permutation.getValues<int64_t>()) {
+  for (int64_t dim : permutation) {
     resultShape.push_back(inputShape[dim]);
     if (!inputBounds.empty()) resultBounds.push_back(inputBounds[dim]);
   }

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2046,15 +2046,10 @@ LogicalResult inferDynamicGatherOp(
 
 LogicalResult inferDynamicSliceOp(
     std::optional<Location> location, Type operandType,
-    TypeRange startIndicesTypes, DenseIntElementsAttr sliceSizes,
+    TypeRange startIndicesTypes, ArrayRef<int64_t> sliceSizes,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
-  // dynamic_slice_i3
-  if (sliceSizes.getType().getRank() != 1)
-    return emitOptionalError(location,
-                             "slice_sizes should be rank 1, but got rank ",
-                             sliceSizes.getType().getRank(), ".");
   // dynamic_slice_c2
-  int numSliceSizes = sliceSizes.getNumElements();
+  int numSliceSizes = sliceSizes.size();
   int numStartIndices = startIndicesTypes.size();
   if (numStartIndices != numSliceSizes)
     return emitOptionalError(location, "has mismatched number of slice sizes (",
@@ -2075,7 +2070,7 @@ LogicalResult inferDynamicSliceOp(
 
   // dynamic_slice_c4
   for (int i = 0; i < numSliceSizes; ++i) {
-    int64_t sliceSize = sliceSizes.getValues<int64_t>()[i];
+    int64_t sliceSize = sliceSizes[i];
     if (sliceSize < 0)
       return emitOptionalError(
           location, "has negative size index to dynamic slice: ", sliceSize);
@@ -2089,7 +2084,7 @@ LogicalResult inferDynamicSliceOp(
   }
 
   // dynamic_slice_c5
-  inferredReturnShapes.emplace_back(sliceSizes.getValues<int64_t>(),
+  inferredReturnShapes.emplace_back(sliceSizes,
                                     rankedOperandType.getElementType());
   return success();
 }

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2162,9 +2162,9 @@ LogicalResult inferDynamicUpdateSliceOp(
 // P3. Operand shape dimensions agree with fft_length for the given fft_type
 LogicalResult inferFftOp(
     std::optional<Location> location, Value operand, bool isFftTypeRfft,
-    bool isFftTypeIrfft, DenseIntElementsAttr fftLength,
+    bool isFftTypeIrfft, ArrayRef<int64_t> fftLength,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
-  auto fftLengthValues = fftLength.getValues<int64_t>();
+  auto fftLengthValues = fftLength;
   int64_t fftRank = fftLength.size();
 
   // P1.

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -223,7 +223,7 @@ LogicalResult inferDynamicUpdateSliceOp(
 
 LogicalResult inferFftOp(
     std::optional<Location> location, Value operand, bool isFftTypeRfft,
-    bool isFftTypeIrfft, DenseIntElementsAttr fftLength,
+    bool isFftTypeIrfft, ArrayRef<int64_t> fftLength,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferGatherOp(

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -328,9 +328,9 @@ LogicalResult inferSetDimensionSizeOp(
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferSliceOp(std::optional<Location> location, Type operandType,
-                           DenseIntElementsAttr startIndices,
-                           DenseIntElementsAttr limitIndices,
-                           DenseIntElementsAttr strides,
+                           ArrayRef<int64_t> startIndices,
+                           ArrayRef<int64_t> limitIndices,
+                           ArrayRef<int64_t> strides,
                            SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferSortOp(

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -213,7 +213,7 @@ LogicalResult inferDynamicGatherOp(
 
 LogicalResult inferDynamicSliceOp(
     std::optional<Location> location, Type operandType,
-    TypeRange startIndicesTypes, DenseIntElementsAttr sliceSizes,
+    TypeRange startIndicesTypes, ArrayRef<int64_t> sliceSizes,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferDynamicUpdateSliceOp(

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -342,7 +342,7 @@ LogicalResult inferTopKOp(
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferTransposeOp(std::optional<Location> loc, Value operand,
-                               DenseIntElementsAttr permutation,
+                               ArrayRef<int64_t> permutation,
                                SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferTriangularSolveOp(

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -484,7 +484,7 @@ LogicalResult verifyReshapeOp(std::optional<Location> location, Value operand,
                               Value result);
 
 LogicalResult verifyReverseOp(std::optional<Location> location, Value operand,
-                              DenseIntElementsAttr dimensions);
+                              llvm::ArrayRef<int64_t> dimensions);
 
 LogicalResult verifyRngBitGeneratorOp(std::optional<Location> location,
                                       Value initialState, Value outputState);

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -267,9 +267,9 @@ LogicalResult inferOutfeedOp(HloDialectInterface* dialect,
 
 LogicalResult inferPadOp(std::optional<Location> location, Type operandType,
                          Type paddingValueType,
-                         DenseIntElementsAttr edgePaddingLow,
-                         DenseIntElementsAttr edgePaddingHigh,
-                         DenseIntElementsAttr interiorPadding,
+                         ArrayRef<int64_t> edgePaddingLow,
+                         ArrayRef<int64_t> edgePaddingHigh,
+                         ArrayRef<int64_t> interiorPadding,
                          SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferPartitionIdOp(MLIRContext* context,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -137,7 +137,7 @@ LogicalResult inferBatchNormTrainingOp(
 
 LogicalResult inferBroadcastOp(
     std::optional<Location> location, Value operand,
-    DenseIntElementsAttr broadcastSizes,
+    ArrayRef<int64_t> broadcastSizes,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferCaseOp(std::optional<Location> location, Value index,

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -58,11 +58,9 @@ Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
                  const Sizes &interiorPadding) {
   SmallVector<Type> inferredTypes;
   Builder builder(operand.getType().getContext());
-  auto inferStatus =
-      hlo::inferPadOp({}, operand.getType(), paddingValue.getType(),
-                      builder.getI64TensorAttr(edgePaddingLow),
-                      builder.getI64TensorAttr(edgePaddingHigh),
-                      builder.getI64TensorAttr(interiorPadding), inferredTypes);
+  auto inferStatus = hlo::inferPadOp(
+      {}, operand.getType(), paddingValue.getType(), edgePaddingLow,
+      edgePaddingHigh, interiorPadding, inferredTypes);
   if (failed(inferStatus))
     report_fatal_error(invalidArgument("Could not infer PadOp's return type"));
   return evalPadOp(operand, paddingValue, edgePaddingLow, interiorPadding,

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -104,10 +104,8 @@ Tensor evalSliceOp(const Tensor &operand, const Sizes &startIndices,
                    const Sizes &limitIndices, const Sizes &strides) {
   SmallVector<Type> inferredTypes;
   Builder builder(operand.getType().getContext());
-  auto inferStatus = hlo::inferSliceOp(
-      {}, operand.getType(), builder.getI64TensorAttr(startIndices),
-      builder.getI64TensorAttr(limitIndices), builder.getI64TensorAttr(strides),
-      inferredTypes);
+  auto inferStatus = hlo::inferSliceOp({}, operand.getType(), startIndices,
+                                       limitIndices, strides, inferredTypes);
   if (failed(inferStatus))
     report_fatal_error(
         invalidArgument("Could not infer SliceOp's return type"));

--- a/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cumlogsumexp(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %2 = call @logaddexp(%0, %1) : (tensor<4x9xf32>, tensor<4x9xf32>) -> tensor<4x9xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %5 = call @logaddexp_0(%3, %4) : (tensor<2x9xf32>, tensor<2x9xf32>) -> tensor<2x9xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %8 = call @logaddexp_1(%6, %7) : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %11 = call @logaddexp_2(%9, %10) : (tensor<0x9xf32>, tensor<0x9xf32>) -> tensor<0x9xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %21 = call @logaddexp_3(%19, %20) : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %31 = call @logaddexp_4(%29, %30) : (tensor<3x9xf32>, tensor<3x9xf32>) -> tensor<3x9xf32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
@@ -20,38 +20,38 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cumlogsumexp(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<8> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 8>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
     %2 = call @logaddexp(%0, %1) : (tensor<8x4xf32>, tensor<8x4xf32>) -> tensor<8x4xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 3]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 4]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 3>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 4>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
     %5 = call @logaddexp_0(%3, %4) : (tensor<8x2xf32>, tensor<8x2xf32>) -> tensor<8x2xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 2]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 2>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
     %8 = call @logaddexp_1(%6, %7) : (tensor<8x1xf32>, tensor<8x1xf32>) -> tensor<8x1xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[8, 0]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x1xf32>) -> tensor<8x0xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 2]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x0xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 8, 0>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x1xf32>) -> tensor<8x0xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 2>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x0xf32>
     %11 = call @logaddexp_2(%9, %10) : (tensor<8x0xf32>, tensor<8x0xf32>) -> tensor<8x0xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 1 : (tensor<8x1xf32>, tensor<8x0xf32>) -> tensor<8x1xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [0, 1], interior = [0, 1] : (tensor<8x1xf32>, tensor<f32>) -> tensor<8x2xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [0, 1], high = [0, 0], interior = [0, 1] : (tensor<8x1xf32>, tensor<f32>) -> tensor<8x2xf32>
     %18 = stablehlo.add %15, %17 : tensor<8x2xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 4]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 4>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
     %21 = call @logaddexp_3(%19, %20) : (tensor<8x1xf32>, tensor<8x1xf32>) -> tensor<8x1xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 1 : (tensor<8x1xf32>, tensor<8x1xf32>) -> tensor<8x2xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [0, 1], interior = [0, 1] : (tensor<8x2xf32>, tensor<f32>) -> tensor<8x4xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [0, 1], high = [0, 0], interior = [0, 1] : (tensor<8x2xf32>, tensor<f32>) -> tensor<8x4xf32>
     %28 = stablehlo.add %25, %27 : tensor<8x4xf32>
-    %29 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %29 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
     %30 = call @logaddexp_4(%28, %29) : (tensor<8x4xf32>, tensor<8x4xf32>) -> tensor<8x4xf32>
-    %31 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x1xf32>
+    %31 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<8x1xf32>
     %32 = stablehlo.concatenate %31, %30, dim = 1 : (tensor<8x1xf32>, tensor<8x4xf32>) -> tensor<8x5xf32>
     %33 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %34 = stablehlo.pad %32, %33, low = [0, 0], high = [0, 0], interior = [0, 1] : (tensor<8x5xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cumlogsumexp(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %2 = call @logaddexp(%0, %1) : (tensor<4x9xf32>, tensor<4x9xf32>) -> tensor<4x9xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %5 = call @logaddexp_0(%3, %4) : (tensor<2x9xf32>, tensor<2x9xf32>) -> tensor<2x9xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %8 = call @logaddexp_1(%6, %7) : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %11 = call @logaddexp_2(%9, %10) : (tensor<0x9xf32>, tensor<0x9xf32>) -> tensor<0x9xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %21 = call @logaddexp_3(%19, %20) : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %31 = call @logaddexp_4(%29, %30) : (tensor<3x9xf32>, tensor<3x9xf32>) -> tensor<3x9xf32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
@@ -20,38 +20,38 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cumlogsumexp(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<8> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 8>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
     %2 = call @logaddexp(%0, %1) : (tensor<8x4xf32>, tensor<8x4xf32>) -> tensor<8x4xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 3]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 4]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 3>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 4>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
     %5 = call @logaddexp_0(%3, %4) : (tensor<8x2xf32>, tensor<8x2xf32>) -> tensor<8x2xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 2]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 2>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
     %8 = call @logaddexp_1(%6, %7) : (tensor<8x1xf32>, tensor<8x1xf32>) -> tensor<8x1xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[8, 0]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x1xf32>) -> tensor<8x0xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 2]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x0xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 8, 0>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x1xf32>) -> tensor<8x0xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 2>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x0xf32>
     %11 = call @logaddexp_2(%9, %10) : (tensor<8x0xf32>, tensor<8x0xf32>) -> tensor<8x0xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 1 : (tensor<8x1xf32>, tensor<8x0xf32>) -> tensor<8x1xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [0, 1], interior = [0, 1] : (tensor<8x1xf32>, tensor<f32>) -> tensor<8x2xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [0, 1], high = [0, 0], interior = [0, 1] : (tensor<8x1xf32>, tensor<f32>) -> tensor<8x2xf32>
     %18 = stablehlo.add %15, %17 : tensor<8x2xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 4]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 4>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
     %21 = call @logaddexp_3(%19, %20) : (tensor<8x1xf32>, tensor<8x1xf32>) -> tensor<8x1xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 1 : (tensor<8x1xf32>, tensor<8x1xf32>) -> tensor<8x2xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [0, 1], interior = [0, 1] : (tensor<8x2xf32>, tensor<f32>) -> tensor<8x4xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [0, 1], high = [0, 0], interior = [0, 1] : (tensor<8x2xf32>, tensor<f32>) -> tensor<8x4xf32>
     %28 = stablehlo.add %25, %27 : tensor<8x4xf32>
-    %29 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %29 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
     %30 = call @logaddexp_4(%28, %29) : (tensor<8x4xf32>, tensor<8x4xf32>) -> tensor<8x4xf32>
-    %31 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x1xf32>
+    %31 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<8x1xf32>
     %32 = stablehlo.concatenate %31, %30, dim = 1 : (tensor<8x1xf32>, tensor<8x4xf32>) -> tensor<8x5xf32>
     %33 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %34 = stablehlo.pad %32, %33, low = [0, 0], high = [0, 0], interior = [0, 1] : (tensor<8x5xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf16>
   }
   func.func private @cumlogsumexp(%arg0: tensor<8x9xf16>) -> tensor<8x9xf16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
     %2 = call @logaddexp(%0, %1) : (tensor<4x9xf16>, tensor<4x9xf16>) -> tensor<4x9xf16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
     %5 = call @logaddexp_0(%3, %4) : (tensor<2x9xf16>, tensor<2x9xf16>) -> tensor<2x9xf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
     %8 = call @logaddexp_1(%6, %7) : (tensor<1x9xf16>, tensor<1x9xf16>) -> tensor<1x9xf16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf16>) -> tensor<0x9xf16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<0x9xf16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf16>) -> tensor<0x9xf16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<0x9xf16>
     %11 = call @logaddexp_2(%9, %10) : (tensor<0x9xf16>, tensor<0x9xf16>) -> tensor<0x9xf16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf16>, tensor<0x9xf16>) -> tensor<1x9xf16>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf16>, tensor<f16>) -> tensor<2x9xf16>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf16>, tensor<f16>) -> tensor<2x9xf16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
     %21 = call @logaddexp_3(%19, %20) : (tensor<1x9xf16>, tensor<1x9xf16>) -> tensor<1x9xf16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf16>, tensor<1x9xf16>) -> tensor<2x9xf16>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf16>, tensor<f16>) -> tensor<4x9xf16>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf16>, tensor<f16>) -> tensor<4x9xf16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<3x9xf16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<3x9xf16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf16>) -> tensor<3x9xf16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<3x9xf16>
     %31 = call @logaddexp_4(%29, %30) : (tensor<3x9xf16>, tensor<3x9xf16>) -> tensor<3x9xf16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<1x9xf16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf16>) -> tensor<1x9xf16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf16>, tensor<3x9xf16>) -> tensor<4x9xf16>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf16>, tensor<f16>) -> tensor<8x9xf16>

--- a/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float16_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf16>
   }
   func.func private @cumlogsumexp(%arg0: tensor<8x9xf16>) -> tensor<8x9xf16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
     %2 = call @logaddexp(%0, %1) : (tensor<4x9xf16>, tensor<4x9xf16>) -> tensor<4x9xf16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
     %5 = call @logaddexp_0(%3, %4) : (tensor<2x9xf16>, tensor<2x9xf16>) -> tensor<2x9xf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
     %8 = call @logaddexp_1(%6, %7) : (tensor<1x9xf16>, tensor<1x9xf16>) -> tensor<1x9xf16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf16>) -> tensor<0x9xf16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<0x9xf16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf16>) -> tensor<0x9xf16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<0x9xf16>
     %11 = call @logaddexp_2(%9, %10) : (tensor<0x9xf16>, tensor<0x9xf16>) -> tensor<0x9xf16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf16>, tensor<0x9xf16>) -> tensor<1x9xf16>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf16>, tensor<f16>) -> tensor<2x9xf16>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf16>, tensor<f16>) -> tensor<2x9xf16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
     %21 = call @logaddexp_3(%19, %20) : (tensor<1x9xf16>, tensor<1x9xf16>) -> tensor<1x9xf16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf16>, tensor<1x9xf16>) -> tensor<2x9xf16>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf16>, tensor<f16>) -> tensor<4x9xf16>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf16>, tensor<f16>) -> tensor<4x9xf16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<3x9xf16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<3x9xf16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf16>) -> tensor<3x9xf16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<3x9xf16>
     %31 = call @logaddexp_4(%29, %30) : (tensor<3x9xf16>, tensor<3x9xf16>) -> tensor<3x9xf16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<1x9xf16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf16>) -> tensor<1x9xf16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf16>, tensor<3x9xf16>) -> tensor<4x9xf16>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf16>, tensor<f16>) -> tensor<8x9xf16>

--- a/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cumlogsumexp(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %2 = call @logaddexp(%0, %1) : (tensor<4x9xf32>, tensor<4x9xf32>) -> tensor<4x9xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %5 = call @logaddexp_0(%3, %4) : (tensor<2x9xf32>, tensor<2x9xf32>) -> tensor<2x9xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %8 = call @logaddexp_1(%6, %7) : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %11 = call @logaddexp_2(%9, %10) : (tensor<0x9xf32>, tensor<0x9xf32>) -> tensor<0x9xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %21 = call @logaddexp_3(%19, %20) : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %31 = call @logaddexp_4(%29, %30) : (tensor<3x9xf32>, tensor<3x9xf32>) -> tensor<3x9xf32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumlogsumexp_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cumlogsumexp(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %2 = call @logaddexp(%0, %1) : (tensor<4x9xf32>, tensor<4x9xf32>) -> tensor<4x9xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %5 = call @logaddexp_0(%3, %4) : (tensor<2x9xf32>, tensor<2x9xf32>) -> tensor<2x9xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %8 = call @logaddexp_1(%6, %7) : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %11 = call @logaddexp_2(%9, %10) : (tensor<0x9xf32>, tensor<0x9xf32>) -> tensor<0x9xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %21 = call @logaddexp_3(%19, %20) : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %31 = call @logaddexp_4(%29, %30) : (tensor<3x9xf32>, tensor<3x9xf32>) -> tensor<3x9xf32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumlogsumexp_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cumlogsumexp_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
@@ -21,39 +21,39 @@ module @jit_testcase {
   }
   func.func private @cumlogsumexp(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
     %0 = stablehlo.reverse %arg0, dims = [0] : tensor<8x9xf32>
-    %1 = "stablehlo.slice"(%0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %3 = call @logaddexp(%1, %2) : (tensor<4x9xf32>, tensor<4x9xf32>) -> tensor<4x9xf32>
-    %4 = "stablehlo.slice"(%3) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %5 = "stablehlo.slice"(%3) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%3) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %5 = "stablehlo.slice"(%3) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %6 = call @logaddexp_0(%4, %5) : (tensor<2x9xf32>, tensor<2x9xf32>) -> tensor<2x9xf32>
-    %7 = "stablehlo.slice"(%6) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %8 = "stablehlo.slice"(%6) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%6) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %8 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %9 = call @logaddexp_1(%7, %8) : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xf32>
-    %10 = "stablehlo.slice"(%9) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%9) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %12 = call @logaddexp_2(%10, %11) : (tensor<0x9xf32>, tensor<0x9xf32>) -> tensor<0x9xf32>
-    %13 = "stablehlo.slice"(%6) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %13 = "stablehlo.slice"(%6) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.concatenate %13, %12, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %15 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %16 = stablehlo.pad %14, %15, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %17 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %18 = stablehlo.pad %9, %17, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %19 = stablehlo.add %16, %18 : tensor<2x9xf32>
-    %20 = "stablehlo.slice"(%19) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %21 = "stablehlo.slice"(%3) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%19) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %21 = "stablehlo.slice"(%3) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %22 = call @logaddexp_3(%20, %21) : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xf32>
-    %23 = "stablehlo.slice"(%3) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %23 = "stablehlo.slice"(%3) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %24 = stablehlo.concatenate %23, %22, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %25 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %26 = stablehlo.pad %24, %25, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %27 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %28 = stablehlo.pad %19, %27, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %29 = stablehlo.add %26, %28 : tensor<4x9xf32>
-    %30 = "stablehlo.slice"(%29) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %31 = "stablehlo.slice"(%0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%29) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %31 = "stablehlo.slice"(%0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %32 = call @logaddexp_4(%30, %31) : (tensor<3x9xf32>, tensor<3x9xf32>) -> tensor<3x9xf32>
-    %33 = "stablehlo.slice"(%0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %33 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %34 = stablehlo.concatenate %33, %32, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %35 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %36 = stablehlo.pad %34, %35, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumlogsumexp_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cumlogsumexp_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
@@ -21,39 +21,39 @@ module @jit_testcase {
   }
   func.func private @cumlogsumexp(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
     %0 = stablehlo.reverse %arg0, dims = [0] : tensor<8x9xf32>
-    %1 = "stablehlo.slice"(%0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %3 = call @logaddexp(%1, %2) : (tensor<4x9xf32>, tensor<4x9xf32>) -> tensor<4x9xf32>
-    %4 = "stablehlo.slice"(%3) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %5 = "stablehlo.slice"(%3) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%3) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %5 = "stablehlo.slice"(%3) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %6 = call @logaddexp_0(%4, %5) : (tensor<2x9xf32>, tensor<2x9xf32>) -> tensor<2x9xf32>
-    %7 = "stablehlo.slice"(%6) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %8 = "stablehlo.slice"(%6) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%6) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %8 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %9 = call @logaddexp_1(%7, %8) : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xf32>
-    %10 = "stablehlo.slice"(%9) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%9) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %12 = call @logaddexp_2(%10, %11) : (tensor<0x9xf32>, tensor<0x9xf32>) -> tensor<0x9xf32>
-    %13 = "stablehlo.slice"(%6) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %13 = "stablehlo.slice"(%6) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.concatenate %13, %12, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %15 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %16 = stablehlo.pad %14, %15, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %17 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %18 = stablehlo.pad %9, %17, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %19 = stablehlo.add %16, %18 : tensor<2x9xf32>
-    %20 = "stablehlo.slice"(%19) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %21 = "stablehlo.slice"(%3) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%19) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %21 = "stablehlo.slice"(%3) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %22 = call @logaddexp_3(%20, %21) : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xf32>
-    %23 = "stablehlo.slice"(%3) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %23 = "stablehlo.slice"(%3) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %24 = stablehlo.concatenate %23, %22, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %25 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %26 = stablehlo.pad %24, %25, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %27 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %28 = stablehlo.pad %19, %27, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %29 = stablehlo.add %26, %28 : tensor<4x9xf32>
-    %30 = "stablehlo.slice"(%29) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %31 = "stablehlo.slice"(%0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%29) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %31 = "stablehlo.slice"(%0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %32 = call @logaddexp_4(%30, %31) : (tensor<3x9xf32>, tensor<3x9xf32>) -> tensor<3x9xf32>
-    %33 = "stablehlo.slice"(%0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %33 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %34 = stablehlo.concatenate %33, %32, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %35 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %36 = stablehlo.pad %34, %35, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cummax_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cummax(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %2 = stablehlo.maximum %0, %1 : tensor<4x9xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %5 = stablehlo.maximum %3, %4 : tensor<2x9xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %8 = stablehlo.maximum %6, %7 : tensor<1x9xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %11 = stablehlo.maximum %9, %10 : tensor<0x9xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %21 = stablehlo.maximum %19, %20 : tensor<1x9xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %31 = stablehlo.maximum %29, %30 : tensor<3x9xf32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cummax_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
@@ -20,38 +20,38 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cummax(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<8> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 8>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
     %2 = stablehlo.maximum %0, %1 : tensor<8x4xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 3]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 4]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 3>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 4>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
     %5 = stablehlo.maximum %3, %4 : tensor<8x2xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 2]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 2>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
     %8 = stablehlo.maximum %6, %7 : tensor<8x1xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[8, 0]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x1xf32>) -> tensor<8x0xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 2]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x0xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 8, 0>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x1xf32>) -> tensor<8x0xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 2>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x0xf32>
     %11 = stablehlo.maximum %9, %10 : tensor<8x0xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 1 : (tensor<8x1xf32>, tensor<8x0xf32>) -> tensor<8x1xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [0, 1], interior = [0, 1] : (tensor<8x1xf32>, tensor<f32>) -> tensor<8x2xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [0, 1], high = [0, 0], interior = [0, 1] : (tensor<8x1xf32>, tensor<f32>) -> tensor<8x2xf32>
     %18 = stablehlo.add %15, %17 : tensor<8x2xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 4]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 4>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
     %21 = stablehlo.maximum %19, %20 : tensor<8x1xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 1 : (tensor<8x1xf32>, tensor<8x1xf32>) -> tensor<8x2xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [0, 1], interior = [0, 1] : (tensor<8x2xf32>, tensor<f32>) -> tensor<8x4xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [0, 1], high = [0, 0], interior = [0, 1] : (tensor<8x2xf32>, tensor<f32>) -> tensor<8x4xf32>
     %28 = stablehlo.add %25, %27 : tensor<8x4xf32>
-    %29 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %29 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
     %30 = stablehlo.maximum %28, %29 : tensor<8x4xf32>
-    %31 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x1xf32>
+    %31 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<8x1xf32>
     %32 = stablehlo.concatenate %31, %30, dim = 1 : (tensor<8x1xf32>, tensor<8x4xf32>) -> tensor<8x5xf32>
     %33 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %34 = stablehlo.pad %32, %33, low = [0, 0], high = [0, 0], interior = [0, 1] : (tensor<8x5xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cummax_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cummax(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %2 = stablehlo.maximum %0, %1 : tensor<4x9xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %5 = stablehlo.maximum %3, %4 : tensor<2x9xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %8 = stablehlo.maximum %6, %7 : tensor<1x9xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %11 = stablehlo.maximum %9, %10 : tensor<0x9xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %21 = stablehlo.maximum %19, %20 : tensor<1x9xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %31 = stablehlo.maximum %29, %30 : tensor<3x9xf32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cummax_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
@@ -20,38 +20,38 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cummax(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<8> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 8>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
     %2 = stablehlo.maximum %0, %1 : tensor<8x4xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 3]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 4]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 3>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 4>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
     %5 = stablehlo.maximum %3, %4 : tensor<8x2xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 2]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 2>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
     %8 = stablehlo.maximum %6, %7 : tensor<8x1xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[8, 0]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x1xf32>) -> tensor<8x0xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 2]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x0xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 8, 0>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x1xf32>) -> tensor<8x0xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 2>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x0xf32>
     %11 = stablehlo.maximum %9, %10 : tensor<8x0xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 1 : (tensor<8x1xf32>, tensor<8x0xf32>) -> tensor<8x1xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [0, 1], interior = [0, 1] : (tensor<8x1xf32>, tensor<f32>) -> tensor<8x2xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [0, 1], high = [0, 0], interior = [0, 1] : (tensor<8x1xf32>, tensor<f32>) -> tensor<8x2xf32>
     %18 = stablehlo.add %15, %17 : tensor<8x2xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 4]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 4>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
     %21 = stablehlo.maximum %19, %20 : tensor<8x1xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 1 : (tensor<8x1xf32>, tensor<8x1xf32>) -> tensor<8x2xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [0, 1], interior = [0, 1] : (tensor<8x2xf32>, tensor<f32>) -> tensor<8x4xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [0, 1], high = [0, 0], interior = [0, 1] : (tensor<8x2xf32>, tensor<f32>) -> tensor<8x4xf32>
     %28 = stablehlo.add %25, %27 : tensor<8x4xf32>
-    %29 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %29 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
     %30 = stablehlo.maximum %28, %29 : tensor<8x4xf32>
-    %31 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x1xf32>
+    %31 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<8x1xf32>
     %32 = stablehlo.concatenate %31, %30, dim = 1 : (tensor<8x1xf32>, tensor<8x4xf32>) -> tensor<8x5xf32>
     %33 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %34 = stablehlo.pad %32, %33, low = [0, 0], high = [0, 0], interior = [0, 1] : (tensor<8x5xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_bfloat16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_bfloat16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xbf16>
   }
   func.func private @cummax(%arg0: tensor<8x9xbf16>) -> tensor<8x9xbf16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
     %2 = stablehlo.maximum %0, %1 : tensor<4x9xbf16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
     %5 = stablehlo.maximum %3, %4 : tensor<2x9xbf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
     %8 = stablehlo.maximum %6, %7 : tensor<1x9xbf16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xbf16>) -> tensor<0x9xbf16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<0x9xbf16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xbf16>) -> tensor<0x9xbf16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<0x9xbf16>
     %11 = stablehlo.maximum %9, %10 : tensor<0x9xbf16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xbf16>, tensor<0x9xbf16>) -> tensor<1x9xbf16>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xbf16>, tensor<bf16>) -> tensor<2x9xbf16>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xbf16>, tensor<bf16>) -> tensor<2x9xbf16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xbf16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
     %21 = stablehlo.maximum %19, %20 : tensor<1x9xbf16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xbf16>, tensor<1x9xbf16>) -> tensor<2x9xbf16>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xbf16>, tensor<bf16>) -> tensor<4x9xbf16>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xbf16>, tensor<bf16>) -> tensor<4x9xbf16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xbf16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<3x9xbf16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<3x9xbf16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xbf16>) -> tensor<3x9xbf16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<3x9xbf16>
     %31 = stablehlo.maximum %29, %30 : tensor<3x9xbf16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<1x9xbf16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xbf16>) -> tensor<1x9xbf16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xbf16>, tensor<3x9xbf16>) -> tensor<4x9xbf16>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xbf16>, tensor<bf16>) -> tensor<8x9xbf16>

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_bfloat16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_bfloat16_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xbf16>
   }
   func.func private @cummax(%arg0: tensor<8x9xbf16>) -> tensor<8x9xbf16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
     %2 = stablehlo.maximum %0, %1 : tensor<4x9xbf16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
     %5 = stablehlo.maximum %3, %4 : tensor<2x9xbf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
     %8 = stablehlo.maximum %6, %7 : tensor<1x9xbf16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xbf16>) -> tensor<0x9xbf16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<0x9xbf16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xbf16>) -> tensor<0x9xbf16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<0x9xbf16>
     %11 = stablehlo.maximum %9, %10 : tensor<0x9xbf16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xbf16>, tensor<0x9xbf16>) -> tensor<1x9xbf16>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xbf16>, tensor<bf16>) -> tensor<2x9xbf16>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xbf16>, tensor<bf16>) -> tensor<2x9xbf16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xbf16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
     %21 = stablehlo.maximum %19, %20 : tensor<1x9xbf16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xbf16>, tensor<1x9xbf16>) -> tensor<2x9xbf16>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xbf16>, tensor<bf16>) -> tensor<4x9xbf16>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xbf16>, tensor<bf16>) -> tensor<4x9xbf16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xbf16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<3x9xbf16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<3x9xbf16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xbf16>) -> tensor<3x9xbf16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<3x9xbf16>
     %31 = stablehlo.maximum %29, %30 : tensor<3x9xbf16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<1x9xbf16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xbf16>) -> tensor<1x9xbf16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xbf16>, tensor<3x9xbf16>) -> tensor<4x9xbf16>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xbf16>, tensor<bf16>) -> tensor<8x9xbf16>

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_complex64_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_complex64_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,8 +20,8 @@ module @jit_testcase {
     return %0 : tensor<8x9xcomplex<f32>>
   }
   func.func private @cummax(%arg0: tensor<8x9xcomplex<f32>>) -> tensor<8x9xcomplex<f32>> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
     %2 = stablehlo.real %0 : (tensor<4x9xcomplex<f32>>) -> tensor<4x9xf32>
     %3 = stablehlo.real %1 : (tensor<4x9xcomplex<f32>>) -> tensor<4x9xf32>
     %4 = stablehlo.compare  EQ, %2, %3,  FLOAT : (tensor<4x9xf32>, tensor<4x9xf32>) -> tensor<4x9xi1>
@@ -31,8 +31,8 @@ module @jit_testcase {
     %8 = stablehlo.compare  GT, %6, %7,  FLOAT : (tensor<4x9xf32>, tensor<4x9xf32>) -> tensor<4x9xi1>
     %9 = stablehlo.select %4, %8, %5 : tensor<4x9xi1>, tensor<4x9xi1>
     %10 = stablehlo.select %9, %0, %1 : tensor<4x9xi1>, tensor<4x9xcomplex<f32>>
-    %11 = "stablehlo.slice"(%10) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
-    %12 = "stablehlo.slice"(%10) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
+    %11 = "stablehlo.slice"(%10) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
+    %12 = "stablehlo.slice"(%10) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
     %13 = stablehlo.real %11 : (tensor<2x9xcomplex<f32>>) -> tensor<2x9xf32>
     %14 = stablehlo.real %12 : (tensor<2x9xcomplex<f32>>) -> tensor<2x9xf32>
     %15 = stablehlo.compare  EQ, %13, %14,  FLOAT : (tensor<2x9xf32>, tensor<2x9xf32>) -> tensor<2x9xi1>
@@ -42,8 +42,8 @@ module @jit_testcase {
     %19 = stablehlo.compare  GT, %17, %18,  FLOAT : (tensor<2x9xf32>, tensor<2x9xf32>) -> tensor<2x9xi1>
     %20 = stablehlo.select %15, %19, %16 : tensor<2x9xi1>, tensor<2x9xi1>
     %21 = stablehlo.select %20, %11, %12 : tensor<2x9xi1>, tensor<2x9xcomplex<f32>>
-    %22 = "stablehlo.slice"(%21) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
-    %23 = "stablehlo.slice"(%21) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %22 = "stablehlo.slice"(%21) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %23 = "stablehlo.slice"(%21) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %24 = stablehlo.real %22 : (tensor<1x9xcomplex<f32>>) -> tensor<1x9xf32>
     %25 = stablehlo.real %23 : (tensor<1x9xcomplex<f32>>) -> tensor<1x9xf32>
     %26 = stablehlo.compare  EQ, %24, %25,  FLOAT : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xi1>
@@ -53,8 +53,8 @@ module @jit_testcase {
     %30 = stablehlo.compare  GT, %28, %29,  FLOAT : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xi1>
     %31 = stablehlo.select %26, %30, %27 : tensor<1x9xi1>, tensor<1x9xi1>
     %32 = stablehlo.select %31, %22, %23 : tensor<1x9xi1>, tensor<1x9xcomplex<f32>>
-    %33 = "stablehlo.slice"(%32) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
-    %34 = "stablehlo.slice"(%21) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
+    %33 = "stablehlo.slice"(%32) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
+    %34 = "stablehlo.slice"(%21) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
     %35 = stablehlo.real %33 : (tensor<0x9xcomplex<f32>>) -> tensor<0x9xf32>
     %36 = stablehlo.real %34 : (tensor<0x9xcomplex<f32>>) -> tensor<0x9xf32>
     %37 = stablehlo.compare  EQ, %35, %36,  FLOAT : (tensor<0x9xf32>, tensor<0x9xf32>) -> tensor<0x9xi1>
@@ -64,15 +64,15 @@ module @jit_testcase {
     %41 = stablehlo.compare  GT, %39, %40,  FLOAT : (tensor<0x9xf32>, tensor<0x9xf32>) -> tensor<0x9xi1>
     %42 = stablehlo.select %37, %41, %38 : tensor<0x9xi1>, tensor<0x9xi1>
     %43 = stablehlo.select %42, %33, %34 : tensor<0x9xi1>, tensor<0x9xcomplex<f32>>
-    %44 = "stablehlo.slice"(%21) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %44 = "stablehlo.slice"(%21) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %45 = stablehlo.concatenate %44, %43, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<0x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %46 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %47 = stablehlo.pad %45, %46, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<2x9xcomplex<f32>>
     %48 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %49 = stablehlo.pad %32, %48, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<2x9xcomplex<f32>>
     %50 = stablehlo.add %47, %49 : tensor<2x9xcomplex<f32>>
-    %51 = "stablehlo.slice"(%50) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
-    %52 = "stablehlo.slice"(%10) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %51 = "stablehlo.slice"(%50) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %52 = "stablehlo.slice"(%10) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %53 = stablehlo.real %51 : (tensor<1x9xcomplex<f32>>) -> tensor<1x9xf32>
     %54 = stablehlo.real %52 : (tensor<1x9xcomplex<f32>>) -> tensor<1x9xf32>
     %55 = stablehlo.compare  EQ, %53, %54,  FLOAT : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xi1>
@@ -82,15 +82,15 @@ module @jit_testcase {
     %59 = stablehlo.compare  GT, %57, %58,  FLOAT : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xi1>
     %60 = stablehlo.select %55, %59, %56 : tensor<1x9xi1>, tensor<1x9xi1>
     %61 = stablehlo.select %60, %51, %52 : tensor<1x9xi1>, tensor<1x9xcomplex<f32>>
-    %62 = "stablehlo.slice"(%10) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %62 = "stablehlo.slice"(%10) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %63 = stablehlo.concatenate %62, %61, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<1x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
     %64 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %65 = stablehlo.pad %63, %64, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<4x9xcomplex<f32>>
     %66 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %67 = stablehlo.pad %50, %66, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<4x9xcomplex<f32>>
     %68 = stablehlo.add %65, %67 : tensor<4x9xcomplex<f32>>
-    %69 = "stablehlo.slice"(%68) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
-    %70 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
+    %69 = "stablehlo.slice"(%68) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
+    %70 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
     %71 = stablehlo.real %69 : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xf32>
     %72 = stablehlo.real %70 : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xf32>
     %73 = stablehlo.compare  EQ, %71, %72,  FLOAT : (tensor<3x9xf32>, tensor<3x9xf32>) -> tensor<3x9xi1>
@@ -100,7 +100,7 @@ module @jit_testcase {
     %77 = stablehlo.compare  GT, %75, %76,  FLOAT : (tensor<3x9xf32>, tensor<3x9xf32>) -> tensor<3x9xi1>
     %78 = stablehlo.select %73, %77, %74 : tensor<3x9xi1>, tensor<3x9xi1>
     %79 = stablehlo.select %78, %69, %70 : tensor<3x9xi1>, tensor<3x9xcomplex<f32>>
-    %80 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %80 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %81 = stablehlo.concatenate %80, %79, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<3x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
     %82 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %83 = stablehlo.pad %81, %82, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<8x9xcomplex<f32>>

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_complex64_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_complex64_8_9__axis_0_reverse_False.mlir
@@ -20,8 +20,8 @@ module @jit_testcase {
     return %0 : tensor<8x9xcomplex<f32>>
   }
   func.func private @cummax(%arg0: tensor<8x9xcomplex<f32>>) -> tensor<8x9xcomplex<f32>> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
     %2 = stablehlo.real %0 : (tensor<4x9xcomplex<f32>>) -> tensor<4x9xf32>
     %3 = stablehlo.real %1 : (tensor<4x9xcomplex<f32>>) -> tensor<4x9xf32>
     %4 = stablehlo.compare  EQ, %2, %3,  FLOAT : (tensor<4x9xf32>, tensor<4x9xf32>) -> tensor<4x9xi1>
@@ -31,8 +31,8 @@ module @jit_testcase {
     %8 = stablehlo.compare  GT, %6, %7,  FLOAT : (tensor<4x9xf32>, tensor<4x9xf32>) -> tensor<4x9xi1>
     %9 = stablehlo.select %4, %8, %5 : tensor<4x9xi1>, tensor<4x9xi1>
     %10 = stablehlo.select %9, %0, %1 : tensor<4x9xi1>, tensor<4x9xcomplex<f32>>
-    %11 = "stablehlo.slice"(%10) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
-    %12 = "stablehlo.slice"(%10) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
+    %11 = "stablehlo.slice"(%10) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
+    %12 = "stablehlo.slice"(%10) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
     %13 = stablehlo.real %11 : (tensor<2x9xcomplex<f32>>) -> tensor<2x9xf32>
     %14 = stablehlo.real %12 : (tensor<2x9xcomplex<f32>>) -> tensor<2x9xf32>
     %15 = stablehlo.compare  EQ, %13, %14,  FLOAT : (tensor<2x9xf32>, tensor<2x9xf32>) -> tensor<2x9xi1>
@@ -42,8 +42,8 @@ module @jit_testcase {
     %19 = stablehlo.compare  GT, %17, %18,  FLOAT : (tensor<2x9xf32>, tensor<2x9xf32>) -> tensor<2x9xi1>
     %20 = stablehlo.select %15, %19, %16 : tensor<2x9xi1>, tensor<2x9xi1>
     %21 = stablehlo.select %20, %11, %12 : tensor<2x9xi1>, tensor<2x9xcomplex<f32>>
-    %22 = "stablehlo.slice"(%21) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
-    %23 = "stablehlo.slice"(%21) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %22 = "stablehlo.slice"(%21) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %23 = "stablehlo.slice"(%21) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %24 = stablehlo.real %22 : (tensor<1x9xcomplex<f32>>) -> tensor<1x9xf32>
     %25 = stablehlo.real %23 : (tensor<1x9xcomplex<f32>>) -> tensor<1x9xf32>
     %26 = stablehlo.compare  EQ, %24, %25,  FLOAT : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xi1>
@@ -53,8 +53,8 @@ module @jit_testcase {
     %30 = stablehlo.compare  GT, %28, %29,  FLOAT : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xi1>
     %31 = stablehlo.select %26, %30, %27 : tensor<1x9xi1>, tensor<1x9xi1>
     %32 = stablehlo.select %31, %22, %23 : tensor<1x9xi1>, tensor<1x9xcomplex<f32>>
-    %33 = "stablehlo.slice"(%32) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
-    %34 = "stablehlo.slice"(%21) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
+    %33 = "stablehlo.slice"(%32) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
+    %34 = "stablehlo.slice"(%21) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
     %35 = stablehlo.real %33 : (tensor<0x9xcomplex<f32>>) -> tensor<0x9xf32>
     %36 = stablehlo.real %34 : (tensor<0x9xcomplex<f32>>) -> tensor<0x9xf32>
     %37 = stablehlo.compare  EQ, %35, %36,  FLOAT : (tensor<0x9xf32>, tensor<0x9xf32>) -> tensor<0x9xi1>
@@ -64,15 +64,15 @@ module @jit_testcase {
     %41 = stablehlo.compare  GT, %39, %40,  FLOAT : (tensor<0x9xf32>, tensor<0x9xf32>) -> tensor<0x9xi1>
     %42 = stablehlo.select %37, %41, %38 : tensor<0x9xi1>, tensor<0x9xi1>
     %43 = stablehlo.select %42, %33, %34 : tensor<0x9xi1>, tensor<0x9xcomplex<f32>>
-    %44 = "stablehlo.slice"(%21) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %44 = "stablehlo.slice"(%21) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %45 = stablehlo.concatenate %44, %43, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<0x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %46 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %47 = stablehlo.pad %45, %46, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<2x9xcomplex<f32>>
     %48 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %49 = stablehlo.pad %32, %48, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<2x9xcomplex<f32>>
     %50 = stablehlo.add %47, %49 : tensor<2x9xcomplex<f32>>
-    %51 = "stablehlo.slice"(%50) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
-    %52 = "stablehlo.slice"(%10) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %51 = "stablehlo.slice"(%50) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %52 = "stablehlo.slice"(%10) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %53 = stablehlo.real %51 : (tensor<1x9xcomplex<f32>>) -> tensor<1x9xf32>
     %54 = stablehlo.real %52 : (tensor<1x9xcomplex<f32>>) -> tensor<1x9xf32>
     %55 = stablehlo.compare  EQ, %53, %54,  FLOAT : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xi1>
@@ -82,15 +82,15 @@ module @jit_testcase {
     %59 = stablehlo.compare  GT, %57, %58,  FLOAT : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xi1>
     %60 = stablehlo.select %55, %59, %56 : tensor<1x9xi1>, tensor<1x9xi1>
     %61 = stablehlo.select %60, %51, %52 : tensor<1x9xi1>, tensor<1x9xcomplex<f32>>
-    %62 = "stablehlo.slice"(%10) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %62 = "stablehlo.slice"(%10) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %63 = stablehlo.concatenate %62, %61, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<1x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
     %64 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %65 = stablehlo.pad %63, %64, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<4x9xcomplex<f32>>
     %66 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %67 = stablehlo.pad %50, %66, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<4x9xcomplex<f32>>
     %68 = stablehlo.add %65, %67 : tensor<4x9xcomplex<f32>>
-    %69 = "stablehlo.slice"(%68) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
-    %70 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
+    %69 = "stablehlo.slice"(%68) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
+    %70 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
     %71 = stablehlo.real %69 : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xf32>
     %72 = stablehlo.real %70 : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xf32>
     %73 = stablehlo.compare  EQ, %71, %72,  FLOAT : (tensor<3x9xf32>, tensor<3x9xf32>) -> tensor<3x9xi1>
@@ -100,7 +100,7 @@ module @jit_testcase {
     %77 = stablehlo.compare  GT, %75, %76,  FLOAT : (tensor<3x9xf32>, tensor<3x9xf32>) -> tensor<3x9xi1>
     %78 = stablehlo.select %73, %77, %74 : tensor<3x9xi1>, tensor<3x9xi1>
     %79 = stablehlo.select %78, %69, %70 : tensor<3x9xi1>, tensor<3x9xcomplex<f32>>
-    %80 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %80 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %81 = stablehlo.concatenate %80, %79, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<3x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
     %82 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %83 = stablehlo.pad %81, %82, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<8x9xcomplex<f32>>

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf16>
   }
   func.func private @cummax(%arg0: tensor<8x9xf16>) -> tensor<8x9xf16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
     %2 = stablehlo.maximum %0, %1 : tensor<4x9xf16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
     %5 = stablehlo.maximum %3, %4 : tensor<2x9xf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
     %8 = stablehlo.maximum %6, %7 : tensor<1x9xf16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf16>) -> tensor<0x9xf16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<0x9xf16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf16>) -> tensor<0x9xf16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<0x9xf16>
     %11 = stablehlo.maximum %9, %10 : tensor<0x9xf16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf16>, tensor<0x9xf16>) -> tensor<1x9xf16>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf16>, tensor<f16>) -> tensor<2x9xf16>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf16>, tensor<f16>) -> tensor<2x9xf16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
     %21 = stablehlo.maximum %19, %20 : tensor<1x9xf16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf16>, tensor<1x9xf16>) -> tensor<2x9xf16>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf16>, tensor<f16>) -> tensor<4x9xf16>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf16>, tensor<f16>) -> tensor<4x9xf16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<3x9xf16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<3x9xf16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf16>) -> tensor<3x9xf16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<3x9xf16>
     %31 = stablehlo.maximum %29, %30 : tensor<3x9xf16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<1x9xf16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf16>) -> tensor<1x9xf16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf16>, tensor<3x9xf16>) -> tensor<4x9xf16>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf16>, tensor<f16>) -> tensor<8x9xf16>

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_float16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_float16_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf16>
   }
   func.func private @cummax(%arg0: tensor<8x9xf16>) -> tensor<8x9xf16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
     %2 = stablehlo.maximum %0, %1 : tensor<4x9xf16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
     %5 = stablehlo.maximum %3, %4 : tensor<2x9xf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
     %8 = stablehlo.maximum %6, %7 : tensor<1x9xf16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf16>) -> tensor<0x9xf16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<0x9xf16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf16>) -> tensor<0x9xf16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<0x9xf16>
     %11 = stablehlo.maximum %9, %10 : tensor<0x9xf16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf16>, tensor<0x9xf16>) -> tensor<1x9xf16>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf16>, tensor<f16>) -> tensor<2x9xf16>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf16>, tensor<f16>) -> tensor<2x9xf16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
     %21 = stablehlo.maximum %19, %20 : tensor<1x9xf16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf16>, tensor<1x9xf16>) -> tensor<2x9xf16>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf16>, tensor<f16>) -> tensor<4x9xf16>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf16>, tensor<f16>) -> tensor<4x9xf16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<3x9xf16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<3x9xf16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf16>) -> tensor<3x9xf16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<3x9xf16>
     %31 = stablehlo.maximum %29, %30 : tensor<3x9xf16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<1x9xf16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf16>) -> tensor<1x9xf16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf16>, tensor<3x9xf16>) -> tensor<4x9xf16>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf16>, tensor<f16>) -> tensor<8x9xf16>

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cummax(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %2 = stablehlo.maximum %0, %1 : tensor<4x9xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %5 = stablehlo.maximum %3, %4 : tensor<2x9xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %8 = stablehlo.maximum %6, %7 : tensor<1x9xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %11 = stablehlo.maximum %9, %10 : tensor<0x9xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %21 = stablehlo.maximum %19, %20 : tensor<1x9xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %31 = stablehlo.maximum %29, %30 : tensor<3x9xf32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cummax(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %2 = stablehlo.maximum %0, %1 : tensor<4x9xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %5 = stablehlo.maximum %3, %4 : tensor<2x9xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %8 = stablehlo.maximum %6, %7 : tensor<1x9xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %11 = stablehlo.maximum %9, %10 : tensor<0x9xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %21 = stablehlo.maximum %19, %20 : tensor<1x9xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %31 = stablehlo.maximum %29, %30 : tensor<3x9xf32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_int16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_int16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi16>
   }
   func.func private @cummax(%arg0: tensor<8x9xi16>) -> tensor<8x9xi16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
     %2 = stablehlo.maximum %0, %1 : tensor<4x9xi16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
     %5 = stablehlo.maximum %3, %4 : tensor<2x9xi16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
     %8 = stablehlo.maximum %6, %7 : tensor<1x9xi16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi16>) -> tensor<0x9xi16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<0x9xi16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi16>) -> tensor<0x9xi16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<0x9xi16>
     %11 = stablehlo.maximum %9, %10 : tensor<0x9xi16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi16>, tensor<0x9xi16>) -> tensor<1x9xi16>
     %14 = stablehlo.constant dense<0> : tensor<i16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi16>, tensor<i16>) -> tensor<2x9xi16>
     %16 = stablehlo.constant dense<0> : tensor<i16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi16>, tensor<i16>) -> tensor<2x9xi16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
     %21 = stablehlo.maximum %19, %20 : tensor<1x9xi16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi16>, tensor<1x9xi16>) -> tensor<2x9xi16>
     %24 = stablehlo.constant dense<0> : tensor<i16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi16>, tensor<i16>) -> tensor<4x9xi16>
     %26 = stablehlo.constant dense<0> : tensor<i16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi16>, tensor<i16>) -> tensor<4x9xi16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<3x9xi16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<3x9xi16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi16>) -> tensor<3x9xi16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<3x9xi16>
     %31 = stablehlo.maximum %29, %30 : tensor<3x9xi16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<1x9xi16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi16>) -> tensor<1x9xi16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi16>, tensor<3x9xi16>) -> tensor<4x9xi16>
     %34 = stablehlo.constant dense<0> : tensor<i16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi16>, tensor<i16>) -> tensor<8x9xi16>

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_int16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_int16_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi16>
   }
   func.func private @cummax(%arg0: tensor<8x9xi16>) -> tensor<8x9xi16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
     %2 = stablehlo.maximum %0, %1 : tensor<4x9xi16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
     %5 = stablehlo.maximum %3, %4 : tensor<2x9xi16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
     %8 = stablehlo.maximum %6, %7 : tensor<1x9xi16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi16>) -> tensor<0x9xi16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<0x9xi16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi16>) -> tensor<0x9xi16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<0x9xi16>
     %11 = stablehlo.maximum %9, %10 : tensor<0x9xi16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi16>, tensor<0x9xi16>) -> tensor<1x9xi16>
     %14 = stablehlo.constant dense<0> : tensor<i16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi16>, tensor<i16>) -> tensor<2x9xi16>
     %16 = stablehlo.constant dense<0> : tensor<i16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi16>, tensor<i16>) -> tensor<2x9xi16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
     %21 = stablehlo.maximum %19, %20 : tensor<1x9xi16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi16>, tensor<1x9xi16>) -> tensor<2x9xi16>
     %24 = stablehlo.constant dense<0> : tensor<i16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi16>, tensor<i16>) -> tensor<4x9xi16>
     %26 = stablehlo.constant dense<0> : tensor<i16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi16>, tensor<i16>) -> tensor<4x9xi16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<3x9xi16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<3x9xi16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi16>) -> tensor<3x9xi16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<3x9xi16>
     %31 = stablehlo.maximum %29, %30 : tensor<3x9xi16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<1x9xi16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi16>) -> tensor<1x9xi16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi16>, tensor<3x9xi16>) -> tensor<4x9xi16>
     %34 = stablehlo.constant dense<0> : tensor<i16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi16>, tensor<i16>) -> tensor<8x9xi16>

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_int32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_int32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi32>
   }
   func.func private @cummax(%arg0: tensor<8x9xi32>) -> tensor<8x9xi32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
     %2 = stablehlo.maximum %0, %1 : tensor<4x9xi32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
     %5 = stablehlo.maximum %3, %4 : tensor<2x9xi32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
     %8 = stablehlo.maximum %6, %7 : tensor<1x9xi32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi32>) -> tensor<0x9xi32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<0x9xi32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi32>) -> tensor<0x9xi32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<0x9xi32>
     %11 = stablehlo.maximum %9, %10 : tensor<0x9xi32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi32>, tensor<0x9xi32>) -> tensor<1x9xi32>
     %14 = stablehlo.constant dense<0> : tensor<i32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi32>, tensor<i32>) -> tensor<2x9xi32>
     %16 = stablehlo.constant dense<0> : tensor<i32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi32>, tensor<i32>) -> tensor<2x9xi32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
     %21 = stablehlo.maximum %19, %20 : tensor<1x9xi32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi32>, tensor<1x9xi32>) -> tensor<2x9xi32>
     %24 = stablehlo.constant dense<0> : tensor<i32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi32>, tensor<i32>) -> tensor<4x9xi32>
     %26 = stablehlo.constant dense<0> : tensor<i32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi32>, tensor<i32>) -> tensor<4x9xi32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<3x9xi32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<3x9xi32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi32>) -> tensor<3x9xi32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<3x9xi32>
     %31 = stablehlo.maximum %29, %30 : tensor<3x9xi32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<1x9xi32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi32>) -> tensor<1x9xi32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi32>, tensor<3x9xi32>) -> tensor<4x9xi32>
     %34 = stablehlo.constant dense<0> : tensor<i32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi32>, tensor<i32>) -> tensor<8x9xi32>

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_int32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_int32_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi32>
   }
   func.func private @cummax(%arg0: tensor<8x9xi32>) -> tensor<8x9xi32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
     %2 = stablehlo.maximum %0, %1 : tensor<4x9xi32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
     %5 = stablehlo.maximum %3, %4 : tensor<2x9xi32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
     %8 = stablehlo.maximum %6, %7 : tensor<1x9xi32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi32>) -> tensor<0x9xi32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<0x9xi32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi32>) -> tensor<0x9xi32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<0x9xi32>
     %11 = stablehlo.maximum %9, %10 : tensor<0x9xi32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi32>, tensor<0x9xi32>) -> tensor<1x9xi32>
     %14 = stablehlo.constant dense<0> : tensor<i32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi32>, tensor<i32>) -> tensor<2x9xi32>
     %16 = stablehlo.constant dense<0> : tensor<i32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi32>, tensor<i32>) -> tensor<2x9xi32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
     %21 = stablehlo.maximum %19, %20 : tensor<1x9xi32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi32>, tensor<1x9xi32>) -> tensor<2x9xi32>
     %24 = stablehlo.constant dense<0> : tensor<i32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi32>, tensor<i32>) -> tensor<4x9xi32>
     %26 = stablehlo.constant dense<0> : tensor<i32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi32>, tensor<i32>) -> tensor<4x9xi32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<3x9xi32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<3x9xi32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi32>) -> tensor<3x9xi32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<3x9xi32>
     %31 = stablehlo.maximum %29, %30 : tensor<3x9xi32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<1x9xi32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi32>) -> tensor<1x9xi32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi32>, tensor<3x9xi32>) -> tensor<4x9xi32>
     %34 = stablehlo.constant dense<0> : tensor<i32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi32>, tensor<i32>) -> tensor<8x9xi32>

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_int8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_int8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi8>
   }
   func.func private @cummax(%arg0: tensor<8x9xi8>) -> tensor<8x9xi8> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
     %2 = stablehlo.maximum %0, %1 : tensor<4x9xi8>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
     %5 = stablehlo.maximum %3, %4 : tensor<2x9xi8>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
     %8 = stablehlo.maximum %6, %7 : tensor<1x9xi8>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi8>) -> tensor<0x9xi8>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<0x9xi8>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi8>) -> tensor<0x9xi8>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<0x9xi8>
     %11 = stablehlo.maximum %9, %10 : tensor<0x9xi8>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi8>, tensor<0x9xi8>) -> tensor<1x9xi8>
     %14 = stablehlo.constant dense<0> : tensor<i8>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi8>, tensor<i8>) -> tensor<2x9xi8>
     %16 = stablehlo.constant dense<0> : tensor<i8>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi8>, tensor<i8>) -> tensor<2x9xi8>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi8>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
     %21 = stablehlo.maximum %19, %20 : tensor<1x9xi8>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi8>, tensor<1x9xi8>) -> tensor<2x9xi8>
     %24 = stablehlo.constant dense<0> : tensor<i8>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi8>, tensor<i8>) -> tensor<4x9xi8>
     %26 = stablehlo.constant dense<0> : tensor<i8>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi8>, tensor<i8>) -> tensor<4x9xi8>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi8>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<3x9xi8>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<3x9xi8>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi8>) -> tensor<3x9xi8>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<3x9xi8>
     %31 = stablehlo.maximum %29, %30 : tensor<3x9xi8>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<1x9xi8>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi8>) -> tensor<1x9xi8>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi8>, tensor<3x9xi8>) -> tensor<4x9xi8>
     %34 = stablehlo.constant dense<0> : tensor<i8>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi8>, tensor<i8>) -> tensor<8x9xi8>

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_int8_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_int8_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi8>
   }
   func.func private @cummax(%arg0: tensor<8x9xi8>) -> tensor<8x9xi8> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
     %2 = stablehlo.maximum %0, %1 : tensor<4x9xi8>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
     %5 = stablehlo.maximum %3, %4 : tensor<2x9xi8>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
     %8 = stablehlo.maximum %6, %7 : tensor<1x9xi8>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi8>) -> tensor<0x9xi8>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<0x9xi8>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi8>) -> tensor<0x9xi8>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<0x9xi8>
     %11 = stablehlo.maximum %9, %10 : tensor<0x9xi8>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi8>, tensor<0x9xi8>) -> tensor<1x9xi8>
     %14 = stablehlo.constant dense<0> : tensor<i8>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi8>, tensor<i8>) -> tensor<2x9xi8>
     %16 = stablehlo.constant dense<0> : tensor<i8>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi8>, tensor<i8>) -> tensor<2x9xi8>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi8>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
     %21 = stablehlo.maximum %19, %20 : tensor<1x9xi8>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi8>, tensor<1x9xi8>) -> tensor<2x9xi8>
     %24 = stablehlo.constant dense<0> : tensor<i8>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi8>, tensor<i8>) -> tensor<4x9xi8>
     %26 = stablehlo.constant dense<0> : tensor<i8>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi8>, tensor<i8>) -> tensor<4x9xi8>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi8>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<3x9xi8>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<3x9xi8>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi8>) -> tensor<3x9xi8>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<3x9xi8>
     %31 = stablehlo.maximum %29, %30 : tensor<3x9xi8>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<1x9xi8>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi8>) -> tensor<1x9xi8>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi8>, tensor<3x9xi8>) -> tensor<4x9xi8>
     %34 = stablehlo.constant dense<0> : tensor<i8>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi8>, tensor<i8>) -> tensor<8x9xi8>

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_uint16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_uint16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui16>
   }
   func.func private @cummax(%arg0: tensor<8x9xui16>) -> tensor<8x9xui16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
     %2 = stablehlo.maximum %0, %1 : tensor<4x9xui16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
     %5 = stablehlo.maximum %3, %4 : tensor<2x9xui16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
     %8 = stablehlo.maximum %6, %7 : tensor<1x9xui16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui16>) -> tensor<0x9xui16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<0x9xui16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui16>) -> tensor<0x9xui16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<0x9xui16>
     %11 = stablehlo.maximum %9, %10 : tensor<0x9xui16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui16>, tensor<0x9xui16>) -> tensor<1x9xui16>
     %14 = stablehlo.constant dense<0> : tensor<ui16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui16>, tensor<ui16>) -> tensor<2x9xui16>
     %16 = stablehlo.constant dense<0> : tensor<ui16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui16>, tensor<ui16>) -> tensor<2x9xui16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
     %21 = stablehlo.maximum %19, %20 : tensor<1x9xui16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui16>, tensor<1x9xui16>) -> tensor<2x9xui16>
     %24 = stablehlo.constant dense<0> : tensor<ui16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui16>, tensor<ui16>) -> tensor<4x9xui16>
     %26 = stablehlo.constant dense<0> : tensor<ui16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui16>, tensor<ui16>) -> tensor<4x9xui16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<3x9xui16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<3x9xui16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui16>) -> tensor<3x9xui16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<3x9xui16>
     %31 = stablehlo.maximum %29, %30 : tensor<3x9xui16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<1x9xui16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui16>) -> tensor<1x9xui16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui16>, tensor<3x9xui16>) -> tensor<4x9xui16>
     %34 = stablehlo.constant dense<0> : tensor<ui16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui16>, tensor<ui16>) -> tensor<8x9xui16>

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_uint16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_uint16_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui16>
   }
   func.func private @cummax(%arg0: tensor<8x9xui16>) -> tensor<8x9xui16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
     %2 = stablehlo.maximum %0, %1 : tensor<4x9xui16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
     %5 = stablehlo.maximum %3, %4 : tensor<2x9xui16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
     %8 = stablehlo.maximum %6, %7 : tensor<1x9xui16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui16>) -> tensor<0x9xui16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<0x9xui16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui16>) -> tensor<0x9xui16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<0x9xui16>
     %11 = stablehlo.maximum %9, %10 : tensor<0x9xui16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui16>, tensor<0x9xui16>) -> tensor<1x9xui16>
     %14 = stablehlo.constant dense<0> : tensor<ui16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui16>, tensor<ui16>) -> tensor<2x9xui16>
     %16 = stablehlo.constant dense<0> : tensor<ui16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui16>, tensor<ui16>) -> tensor<2x9xui16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
     %21 = stablehlo.maximum %19, %20 : tensor<1x9xui16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui16>, tensor<1x9xui16>) -> tensor<2x9xui16>
     %24 = stablehlo.constant dense<0> : tensor<ui16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui16>, tensor<ui16>) -> tensor<4x9xui16>
     %26 = stablehlo.constant dense<0> : tensor<ui16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui16>, tensor<ui16>) -> tensor<4x9xui16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<3x9xui16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<3x9xui16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui16>) -> tensor<3x9xui16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<3x9xui16>
     %31 = stablehlo.maximum %29, %30 : tensor<3x9xui16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<1x9xui16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui16>) -> tensor<1x9xui16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui16>, tensor<3x9xui16>) -> tensor<4x9xui16>
     %34 = stablehlo.constant dense<0> : tensor<ui16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui16>, tensor<ui16>) -> tensor<8x9xui16>

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_uint32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_uint32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui32>
   }
   func.func private @cummax(%arg0: tensor<8x9xui32>) -> tensor<8x9xui32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
     %2 = stablehlo.maximum %0, %1 : tensor<4x9xui32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
     %5 = stablehlo.maximum %3, %4 : tensor<2x9xui32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
     %8 = stablehlo.maximum %6, %7 : tensor<1x9xui32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui32>) -> tensor<0x9xui32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<0x9xui32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui32>) -> tensor<0x9xui32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<0x9xui32>
     %11 = stablehlo.maximum %9, %10 : tensor<0x9xui32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui32>, tensor<0x9xui32>) -> tensor<1x9xui32>
     %14 = stablehlo.constant dense<0> : tensor<ui32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui32>, tensor<ui32>) -> tensor<2x9xui32>
     %16 = stablehlo.constant dense<0> : tensor<ui32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui32>, tensor<ui32>) -> tensor<2x9xui32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
     %21 = stablehlo.maximum %19, %20 : tensor<1x9xui32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui32>, tensor<1x9xui32>) -> tensor<2x9xui32>
     %24 = stablehlo.constant dense<0> : tensor<ui32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui32>, tensor<ui32>) -> tensor<4x9xui32>
     %26 = stablehlo.constant dense<0> : tensor<ui32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui32>, tensor<ui32>) -> tensor<4x9xui32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<3x9xui32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<3x9xui32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui32>) -> tensor<3x9xui32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<3x9xui32>
     %31 = stablehlo.maximum %29, %30 : tensor<3x9xui32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<1x9xui32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui32>) -> tensor<1x9xui32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui32>, tensor<3x9xui32>) -> tensor<4x9xui32>
     %34 = stablehlo.constant dense<0> : tensor<ui32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui32>, tensor<ui32>) -> tensor<8x9xui32>

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_uint32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_uint32_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui32>
   }
   func.func private @cummax(%arg0: tensor<8x9xui32>) -> tensor<8x9xui32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
     %2 = stablehlo.maximum %0, %1 : tensor<4x9xui32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
     %5 = stablehlo.maximum %3, %4 : tensor<2x9xui32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
     %8 = stablehlo.maximum %6, %7 : tensor<1x9xui32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui32>) -> tensor<0x9xui32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<0x9xui32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui32>) -> tensor<0x9xui32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<0x9xui32>
     %11 = stablehlo.maximum %9, %10 : tensor<0x9xui32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui32>, tensor<0x9xui32>) -> tensor<1x9xui32>
     %14 = stablehlo.constant dense<0> : tensor<ui32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui32>, tensor<ui32>) -> tensor<2x9xui32>
     %16 = stablehlo.constant dense<0> : tensor<ui32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui32>, tensor<ui32>) -> tensor<2x9xui32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
     %21 = stablehlo.maximum %19, %20 : tensor<1x9xui32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui32>, tensor<1x9xui32>) -> tensor<2x9xui32>
     %24 = stablehlo.constant dense<0> : tensor<ui32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui32>, tensor<ui32>) -> tensor<4x9xui32>
     %26 = stablehlo.constant dense<0> : tensor<ui32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui32>, tensor<ui32>) -> tensor<4x9xui32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<3x9xui32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<3x9xui32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui32>) -> tensor<3x9xui32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<3x9xui32>
     %31 = stablehlo.maximum %29, %30 : tensor<3x9xui32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<1x9xui32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui32>) -> tensor<1x9xui32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui32>, tensor<3x9xui32>) -> tensor<4x9xui32>
     %34 = stablehlo.constant dense<0> : tensor<ui32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui32>, tensor<ui32>) -> tensor<8x9xui32>

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_uint8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_uint8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui8>
   }
   func.func private @cummax(%arg0: tensor<8x9xui8>) -> tensor<8x9xui8> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
     %2 = stablehlo.maximum %0, %1 : tensor<4x9xui8>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
     %5 = stablehlo.maximum %3, %4 : tensor<2x9xui8>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
     %8 = stablehlo.maximum %6, %7 : tensor<1x9xui8>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui8>) -> tensor<0x9xui8>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<0x9xui8>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui8>) -> tensor<0x9xui8>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<0x9xui8>
     %11 = stablehlo.maximum %9, %10 : tensor<0x9xui8>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui8>, tensor<0x9xui8>) -> tensor<1x9xui8>
     %14 = stablehlo.constant dense<0> : tensor<ui8>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui8>, tensor<ui8>) -> tensor<2x9xui8>
     %16 = stablehlo.constant dense<0> : tensor<ui8>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui8>, tensor<ui8>) -> tensor<2x9xui8>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui8>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
     %21 = stablehlo.maximum %19, %20 : tensor<1x9xui8>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui8>, tensor<1x9xui8>) -> tensor<2x9xui8>
     %24 = stablehlo.constant dense<0> : tensor<ui8>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui8>, tensor<ui8>) -> tensor<4x9xui8>
     %26 = stablehlo.constant dense<0> : tensor<ui8>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui8>, tensor<ui8>) -> tensor<4x9xui8>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui8>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<3x9xui8>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<3x9xui8>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui8>) -> tensor<3x9xui8>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<3x9xui8>
     %31 = stablehlo.maximum %29, %30 : tensor<3x9xui8>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<1x9xui8>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui8>) -> tensor<1x9xui8>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui8>, tensor<3x9xui8>) -> tensor<4x9xui8>
     %34 = stablehlo.constant dense<0> : tensor<ui8>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui8>, tensor<ui8>) -> tensor<8x9xui8>

--- a/stablehlo/testdata/cummax_dtype_by_fun_shape_uint8_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummax_dtype_by_fun_shape_uint8_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui8>
   }
   func.func private @cummax(%arg0: tensor<8x9xui8>) -> tensor<8x9xui8> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
     %2 = stablehlo.maximum %0, %1 : tensor<4x9xui8>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
     %5 = stablehlo.maximum %3, %4 : tensor<2x9xui8>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
     %8 = stablehlo.maximum %6, %7 : tensor<1x9xui8>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui8>) -> tensor<0x9xui8>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<0x9xui8>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui8>) -> tensor<0x9xui8>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<0x9xui8>
     %11 = stablehlo.maximum %9, %10 : tensor<0x9xui8>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui8>, tensor<0x9xui8>) -> tensor<1x9xui8>
     %14 = stablehlo.constant dense<0> : tensor<ui8>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui8>, tensor<ui8>) -> tensor<2x9xui8>
     %16 = stablehlo.constant dense<0> : tensor<ui8>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui8>, tensor<ui8>) -> tensor<2x9xui8>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui8>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
     %21 = stablehlo.maximum %19, %20 : tensor<1x9xui8>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui8>, tensor<1x9xui8>) -> tensor<2x9xui8>
     %24 = stablehlo.constant dense<0> : tensor<ui8>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui8>, tensor<ui8>) -> tensor<4x9xui8>
     %26 = stablehlo.constant dense<0> : tensor<ui8>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui8>, tensor<ui8>) -> tensor<4x9xui8>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui8>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<3x9xui8>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<3x9xui8>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui8>) -> tensor<3x9xui8>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<3x9xui8>
     %31 = stablehlo.maximum %29, %30 : tensor<3x9xui8>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<1x9xui8>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui8>) -> tensor<1x9xui8>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui8>, tensor<3x9xui8>) -> tensor<4x9xui8>
     %34 = stablehlo.constant dense<0> : tensor<ui8>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui8>, tensor<ui8>) -> tensor<8x9xui8>

--- a/stablehlo/testdata/cummax_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cummax_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
@@ -21,39 +21,39 @@ module @jit_testcase {
   }
   func.func private @cummax(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
     %0 = stablehlo.reverse %arg0, dims = [0] : tensor<8x9xf32>
-    %1 = "stablehlo.slice"(%0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %3 = stablehlo.maximum %1, %2 : tensor<4x9xf32>
-    %4 = "stablehlo.slice"(%3) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %5 = "stablehlo.slice"(%3) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%3) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %5 = "stablehlo.slice"(%3) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %6 = stablehlo.maximum %4, %5 : tensor<2x9xf32>
-    %7 = "stablehlo.slice"(%6) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %8 = "stablehlo.slice"(%6) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%6) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %8 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %9 = stablehlo.maximum %7, %8 : tensor<1x9xf32>
-    %10 = "stablehlo.slice"(%9) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%9) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %12 = stablehlo.maximum %10, %11 : tensor<0x9xf32>
-    %13 = "stablehlo.slice"(%6) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %13 = "stablehlo.slice"(%6) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.concatenate %13, %12, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %15 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %16 = stablehlo.pad %14, %15, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %17 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %18 = stablehlo.pad %9, %17, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %19 = stablehlo.add %16, %18 : tensor<2x9xf32>
-    %20 = "stablehlo.slice"(%19) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %21 = "stablehlo.slice"(%3) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%19) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %21 = "stablehlo.slice"(%3) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %22 = stablehlo.maximum %20, %21 : tensor<1x9xf32>
-    %23 = "stablehlo.slice"(%3) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %23 = "stablehlo.slice"(%3) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %24 = stablehlo.concatenate %23, %22, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %25 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %26 = stablehlo.pad %24, %25, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %27 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %28 = stablehlo.pad %19, %27, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %29 = stablehlo.add %26, %28 : tensor<4x9xf32>
-    %30 = "stablehlo.slice"(%29) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %31 = "stablehlo.slice"(%0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%29) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %31 = "stablehlo.slice"(%0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %32 = stablehlo.maximum %30, %31 : tensor<3x9xf32>
-    %33 = "stablehlo.slice"(%0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %33 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %34 = stablehlo.concatenate %33, %32, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %35 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %36 = stablehlo.pad %34, %35, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cummax_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cummax_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
@@ -21,39 +21,39 @@ module @jit_testcase {
   }
   func.func private @cummax(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
     %0 = stablehlo.reverse %arg0, dims = [0] : tensor<8x9xf32>
-    %1 = "stablehlo.slice"(%0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %3 = stablehlo.maximum %1, %2 : tensor<4x9xf32>
-    %4 = "stablehlo.slice"(%3) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %5 = "stablehlo.slice"(%3) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%3) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %5 = "stablehlo.slice"(%3) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %6 = stablehlo.maximum %4, %5 : tensor<2x9xf32>
-    %7 = "stablehlo.slice"(%6) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %8 = "stablehlo.slice"(%6) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%6) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %8 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %9 = stablehlo.maximum %7, %8 : tensor<1x9xf32>
-    %10 = "stablehlo.slice"(%9) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%9) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %12 = stablehlo.maximum %10, %11 : tensor<0x9xf32>
-    %13 = "stablehlo.slice"(%6) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %13 = "stablehlo.slice"(%6) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.concatenate %13, %12, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %15 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %16 = stablehlo.pad %14, %15, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %17 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %18 = stablehlo.pad %9, %17, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %19 = stablehlo.add %16, %18 : tensor<2x9xf32>
-    %20 = "stablehlo.slice"(%19) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %21 = "stablehlo.slice"(%3) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%19) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %21 = "stablehlo.slice"(%3) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %22 = stablehlo.maximum %20, %21 : tensor<1x9xf32>
-    %23 = "stablehlo.slice"(%3) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %23 = "stablehlo.slice"(%3) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %24 = stablehlo.concatenate %23, %22, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %25 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %26 = stablehlo.pad %24, %25, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %27 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %28 = stablehlo.pad %19, %27, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %29 = stablehlo.add %26, %28 : tensor<4x9xf32>
-    %30 = "stablehlo.slice"(%29) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %31 = "stablehlo.slice"(%0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%29) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %31 = "stablehlo.slice"(%0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %32 = stablehlo.maximum %30, %31 : tensor<3x9xf32>
-    %33 = "stablehlo.slice"(%0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %33 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %34 = stablehlo.concatenate %33, %32, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %35 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %36 = stablehlo.pad %34, %35, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cummin_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cummin(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %2 = stablehlo.minimum %0, %1 : tensor<4x9xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %5 = stablehlo.minimum %3, %4 : tensor<2x9xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %8 = stablehlo.minimum %6, %7 : tensor<1x9xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %11 = stablehlo.minimum %9, %10 : tensor<0x9xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %21 = stablehlo.minimum %19, %20 : tensor<1x9xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %31 = stablehlo.minimum %29, %30 : tensor<3x9xf32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cummin_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
@@ -20,38 +20,38 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cummin(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<8> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 8>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
     %2 = stablehlo.minimum %0, %1 : tensor<8x4xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 3]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 4]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 3>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 4>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
     %5 = stablehlo.minimum %3, %4 : tensor<8x2xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 2]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 2>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
     %8 = stablehlo.minimum %6, %7 : tensor<8x1xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[8, 0]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x1xf32>) -> tensor<8x0xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 2]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x0xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 8, 0>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x1xf32>) -> tensor<8x0xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 2>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x0xf32>
     %11 = stablehlo.minimum %9, %10 : tensor<8x0xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 1 : (tensor<8x1xf32>, tensor<8x0xf32>) -> tensor<8x1xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [0, 1], interior = [0, 1] : (tensor<8x1xf32>, tensor<f32>) -> tensor<8x2xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [0, 1], high = [0, 0], interior = [0, 1] : (tensor<8x1xf32>, tensor<f32>) -> tensor<8x2xf32>
     %18 = stablehlo.add %15, %17 : tensor<8x2xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 4]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 4>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
     %21 = stablehlo.minimum %19, %20 : tensor<8x1xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 1 : (tensor<8x1xf32>, tensor<8x1xf32>) -> tensor<8x2xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [0, 1], interior = [0, 1] : (tensor<8x2xf32>, tensor<f32>) -> tensor<8x4xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [0, 1], high = [0, 0], interior = [0, 1] : (tensor<8x2xf32>, tensor<f32>) -> tensor<8x4xf32>
     %28 = stablehlo.add %25, %27 : tensor<8x4xf32>
-    %29 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %29 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
     %30 = stablehlo.minimum %28, %29 : tensor<8x4xf32>
-    %31 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x1xf32>
+    %31 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<8x1xf32>
     %32 = stablehlo.concatenate %31, %30, dim = 1 : (tensor<8x1xf32>, tensor<8x4xf32>) -> tensor<8x5xf32>
     %33 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %34 = stablehlo.pad %32, %33, low = [0, 0], high = [0, 0], interior = [0, 1] : (tensor<8x5xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cummin_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cummin(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %2 = stablehlo.minimum %0, %1 : tensor<4x9xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %5 = stablehlo.minimum %3, %4 : tensor<2x9xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %8 = stablehlo.minimum %6, %7 : tensor<1x9xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %11 = stablehlo.minimum %9, %10 : tensor<0x9xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %21 = stablehlo.minimum %19, %20 : tensor<1x9xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %31 = stablehlo.minimum %29, %30 : tensor<3x9xf32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cummin_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
@@ -20,38 +20,38 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cummin(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<8> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 8>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
     %2 = stablehlo.minimum %0, %1 : tensor<8x4xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 3]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 4]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 3>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 4>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
     %5 = stablehlo.minimum %3, %4 : tensor<8x2xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 2]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 2>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
     %8 = stablehlo.minimum %6, %7 : tensor<8x1xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[8, 0]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x1xf32>) -> tensor<8x0xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 2]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x0xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 8, 0>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x1xf32>) -> tensor<8x0xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 2>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x0xf32>
     %11 = stablehlo.minimum %9, %10 : tensor<8x0xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 1 : (tensor<8x1xf32>, tensor<8x0xf32>) -> tensor<8x1xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [0, 1], interior = [0, 1] : (tensor<8x1xf32>, tensor<f32>) -> tensor<8x2xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [0, 1], high = [0, 0], interior = [0, 1] : (tensor<8x1xf32>, tensor<f32>) -> tensor<8x2xf32>
     %18 = stablehlo.add %15, %17 : tensor<8x2xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 4]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 4>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
     %21 = stablehlo.minimum %19, %20 : tensor<8x1xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 1 : (tensor<8x1xf32>, tensor<8x1xf32>) -> tensor<8x2xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [0, 1], interior = [0, 1] : (tensor<8x2xf32>, tensor<f32>) -> tensor<8x4xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [0, 1], high = [0, 0], interior = [0, 1] : (tensor<8x2xf32>, tensor<f32>) -> tensor<8x4xf32>
     %28 = stablehlo.add %25, %27 : tensor<8x4xf32>
-    %29 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %29 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
     %30 = stablehlo.minimum %28, %29 : tensor<8x4xf32>
-    %31 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x1xf32>
+    %31 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<8x1xf32>
     %32 = stablehlo.concatenate %31, %30, dim = 1 : (tensor<8x1xf32>, tensor<8x4xf32>) -> tensor<8x5xf32>
     %33 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %34 = stablehlo.pad %32, %33, low = [0, 0], high = [0, 0], interior = [0, 1] : (tensor<8x5xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_bfloat16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_bfloat16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xbf16>
   }
   func.func private @cummin(%arg0: tensor<8x9xbf16>) -> tensor<8x9xbf16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
     %2 = stablehlo.minimum %0, %1 : tensor<4x9xbf16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
     %5 = stablehlo.minimum %3, %4 : tensor<2x9xbf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
     %8 = stablehlo.minimum %6, %7 : tensor<1x9xbf16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xbf16>) -> tensor<0x9xbf16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<0x9xbf16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xbf16>) -> tensor<0x9xbf16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<0x9xbf16>
     %11 = stablehlo.minimum %9, %10 : tensor<0x9xbf16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xbf16>, tensor<0x9xbf16>) -> tensor<1x9xbf16>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xbf16>, tensor<bf16>) -> tensor<2x9xbf16>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xbf16>, tensor<bf16>) -> tensor<2x9xbf16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xbf16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
     %21 = stablehlo.minimum %19, %20 : tensor<1x9xbf16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xbf16>, tensor<1x9xbf16>) -> tensor<2x9xbf16>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xbf16>, tensor<bf16>) -> tensor<4x9xbf16>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xbf16>, tensor<bf16>) -> tensor<4x9xbf16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xbf16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<3x9xbf16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<3x9xbf16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xbf16>) -> tensor<3x9xbf16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<3x9xbf16>
     %31 = stablehlo.minimum %29, %30 : tensor<3x9xbf16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<1x9xbf16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xbf16>) -> tensor<1x9xbf16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xbf16>, tensor<3x9xbf16>) -> tensor<4x9xbf16>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xbf16>, tensor<bf16>) -> tensor<8x9xbf16>

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_bfloat16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_bfloat16_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xbf16>
   }
   func.func private @cummin(%arg0: tensor<8x9xbf16>) -> tensor<8x9xbf16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
     %2 = stablehlo.minimum %0, %1 : tensor<4x9xbf16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
     %5 = stablehlo.minimum %3, %4 : tensor<2x9xbf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
     %8 = stablehlo.minimum %6, %7 : tensor<1x9xbf16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xbf16>) -> tensor<0x9xbf16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<0x9xbf16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xbf16>) -> tensor<0x9xbf16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<0x9xbf16>
     %11 = stablehlo.minimum %9, %10 : tensor<0x9xbf16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xbf16>, tensor<0x9xbf16>) -> tensor<1x9xbf16>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xbf16>, tensor<bf16>) -> tensor<2x9xbf16>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xbf16>, tensor<bf16>) -> tensor<2x9xbf16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xbf16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
     %21 = stablehlo.minimum %19, %20 : tensor<1x9xbf16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xbf16>, tensor<1x9xbf16>) -> tensor<2x9xbf16>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xbf16>, tensor<bf16>) -> tensor<4x9xbf16>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xbf16>, tensor<bf16>) -> tensor<4x9xbf16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xbf16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<3x9xbf16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<3x9xbf16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xbf16>) -> tensor<3x9xbf16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<3x9xbf16>
     %31 = stablehlo.minimum %29, %30 : tensor<3x9xbf16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<1x9xbf16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xbf16>) -> tensor<1x9xbf16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xbf16>, tensor<3x9xbf16>) -> tensor<4x9xbf16>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xbf16>, tensor<bf16>) -> tensor<8x9xbf16>

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_complex64_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_complex64_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,8 +20,8 @@ module @jit_testcase {
     return %0 : tensor<8x9xcomplex<f32>>
   }
   func.func private @cummin(%arg0: tensor<8x9xcomplex<f32>>) -> tensor<8x9xcomplex<f32>> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
     %2 = stablehlo.real %0 : (tensor<4x9xcomplex<f32>>) -> tensor<4x9xf32>
     %3 = stablehlo.real %1 : (tensor<4x9xcomplex<f32>>) -> tensor<4x9xf32>
     %4 = stablehlo.compare  EQ, %2, %3,  FLOAT : (tensor<4x9xf32>, tensor<4x9xf32>) -> tensor<4x9xi1>
@@ -31,8 +31,8 @@ module @jit_testcase {
     %8 = stablehlo.compare  LT, %6, %7,  FLOAT : (tensor<4x9xf32>, tensor<4x9xf32>) -> tensor<4x9xi1>
     %9 = stablehlo.select %4, %8, %5 : tensor<4x9xi1>, tensor<4x9xi1>
     %10 = stablehlo.select %9, %0, %1 : tensor<4x9xi1>, tensor<4x9xcomplex<f32>>
-    %11 = "stablehlo.slice"(%10) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
-    %12 = "stablehlo.slice"(%10) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
+    %11 = "stablehlo.slice"(%10) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
+    %12 = "stablehlo.slice"(%10) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
     %13 = stablehlo.real %11 : (tensor<2x9xcomplex<f32>>) -> tensor<2x9xf32>
     %14 = stablehlo.real %12 : (tensor<2x9xcomplex<f32>>) -> tensor<2x9xf32>
     %15 = stablehlo.compare  EQ, %13, %14,  FLOAT : (tensor<2x9xf32>, tensor<2x9xf32>) -> tensor<2x9xi1>
@@ -42,8 +42,8 @@ module @jit_testcase {
     %19 = stablehlo.compare  LT, %17, %18,  FLOAT : (tensor<2x9xf32>, tensor<2x9xf32>) -> tensor<2x9xi1>
     %20 = stablehlo.select %15, %19, %16 : tensor<2x9xi1>, tensor<2x9xi1>
     %21 = stablehlo.select %20, %11, %12 : tensor<2x9xi1>, tensor<2x9xcomplex<f32>>
-    %22 = "stablehlo.slice"(%21) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
-    %23 = "stablehlo.slice"(%21) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %22 = "stablehlo.slice"(%21) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %23 = "stablehlo.slice"(%21) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %24 = stablehlo.real %22 : (tensor<1x9xcomplex<f32>>) -> tensor<1x9xf32>
     %25 = stablehlo.real %23 : (tensor<1x9xcomplex<f32>>) -> tensor<1x9xf32>
     %26 = stablehlo.compare  EQ, %24, %25,  FLOAT : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xi1>
@@ -53,8 +53,8 @@ module @jit_testcase {
     %30 = stablehlo.compare  LT, %28, %29,  FLOAT : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xi1>
     %31 = stablehlo.select %26, %30, %27 : tensor<1x9xi1>, tensor<1x9xi1>
     %32 = stablehlo.select %31, %22, %23 : tensor<1x9xi1>, tensor<1x9xcomplex<f32>>
-    %33 = "stablehlo.slice"(%32) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
-    %34 = "stablehlo.slice"(%21) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
+    %33 = "stablehlo.slice"(%32) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
+    %34 = "stablehlo.slice"(%21) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
     %35 = stablehlo.real %33 : (tensor<0x9xcomplex<f32>>) -> tensor<0x9xf32>
     %36 = stablehlo.real %34 : (tensor<0x9xcomplex<f32>>) -> tensor<0x9xf32>
     %37 = stablehlo.compare  EQ, %35, %36,  FLOAT : (tensor<0x9xf32>, tensor<0x9xf32>) -> tensor<0x9xi1>
@@ -64,15 +64,15 @@ module @jit_testcase {
     %41 = stablehlo.compare  LT, %39, %40,  FLOAT : (tensor<0x9xf32>, tensor<0x9xf32>) -> tensor<0x9xi1>
     %42 = stablehlo.select %37, %41, %38 : tensor<0x9xi1>, tensor<0x9xi1>
     %43 = stablehlo.select %42, %33, %34 : tensor<0x9xi1>, tensor<0x9xcomplex<f32>>
-    %44 = "stablehlo.slice"(%21) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %44 = "stablehlo.slice"(%21) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %45 = stablehlo.concatenate %44, %43, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<0x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %46 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %47 = stablehlo.pad %45, %46, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<2x9xcomplex<f32>>
     %48 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %49 = stablehlo.pad %32, %48, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<2x9xcomplex<f32>>
     %50 = stablehlo.add %47, %49 : tensor<2x9xcomplex<f32>>
-    %51 = "stablehlo.slice"(%50) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
-    %52 = "stablehlo.slice"(%10) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %51 = "stablehlo.slice"(%50) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %52 = "stablehlo.slice"(%10) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %53 = stablehlo.real %51 : (tensor<1x9xcomplex<f32>>) -> tensor<1x9xf32>
     %54 = stablehlo.real %52 : (tensor<1x9xcomplex<f32>>) -> tensor<1x9xf32>
     %55 = stablehlo.compare  EQ, %53, %54,  FLOAT : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xi1>
@@ -82,15 +82,15 @@ module @jit_testcase {
     %59 = stablehlo.compare  LT, %57, %58,  FLOAT : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xi1>
     %60 = stablehlo.select %55, %59, %56 : tensor<1x9xi1>, tensor<1x9xi1>
     %61 = stablehlo.select %60, %51, %52 : tensor<1x9xi1>, tensor<1x9xcomplex<f32>>
-    %62 = "stablehlo.slice"(%10) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %62 = "stablehlo.slice"(%10) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %63 = stablehlo.concatenate %62, %61, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<1x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
     %64 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %65 = stablehlo.pad %63, %64, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<4x9xcomplex<f32>>
     %66 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %67 = stablehlo.pad %50, %66, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<4x9xcomplex<f32>>
     %68 = stablehlo.add %65, %67 : tensor<4x9xcomplex<f32>>
-    %69 = "stablehlo.slice"(%68) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
-    %70 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
+    %69 = "stablehlo.slice"(%68) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
+    %70 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
     %71 = stablehlo.real %69 : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xf32>
     %72 = stablehlo.real %70 : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xf32>
     %73 = stablehlo.compare  EQ, %71, %72,  FLOAT : (tensor<3x9xf32>, tensor<3x9xf32>) -> tensor<3x9xi1>
@@ -100,7 +100,7 @@ module @jit_testcase {
     %77 = stablehlo.compare  LT, %75, %76,  FLOAT : (tensor<3x9xf32>, tensor<3x9xf32>) -> tensor<3x9xi1>
     %78 = stablehlo.select %73, %77, %74 : tensor<3x9xi1>, tensor<3x9xi1>
     %79 = stablehlo.select %78, %69, %70 : tensor<3x9xi1>, tensor<3x9xcomplex<f32>>
-    %80 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %80 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %81 = stablehlo.concatenate %80, %79, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<3x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
     %82 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %83 = stablehlo.pad %81, %82, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<8x9xcomplex<f32>>

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_complex64_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_complex64_8_9__axis_0_reverse_False.mlir
@@ -20,8 +20,8 @@ module @jit_testcase {
     return %0 : tensor<8x9xcomplex<f32>>
   }
   func.func private @cummin(%arg0: tensor<8x9xcomplex<f32>>) -> tensor<8x9xcomplex<f32>> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
     %2 = stablehlo.real %0 : (tensor<4x9xcomplex<f32>>) -> tensor<4x9xf32>
     %3 = stablehlo.real %1 : (tensor<4x9xcomplex<f32>>) -> tensor<4x9xf32>
     %4 = stablehlo.compare  EQ, %2, %3,  FLOAT : (tensor<4x9xf32>, tensor<4x9xf32>) -> tensor<4x9xi1>
@@ -31,8 +31,8 @@ module @jit_testcase {
     %8 = stablehlo.compare  LT, %6, %7,  FLOAT : (tensor<4x9xf32>, tensor<4x9xf32>) -> tensor<4x9xi1>
     %9 = stablehlo.select %4, %8, %5 : tensor<4x9xi1>, tensor<4x9xi1>
     %10 = stablehlo.select %9, %0, %1 : tensor<4x9xi1>, tensor<4x9xcomplex<f32>>
-    %11 = "stablehlo.slice"(%10) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
-    %12 = "stablehlo.slice"(%10) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
+    %11 = "stablehlo.slice"(%10) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
+    %12 = "stablehlo.slice"(%10) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
     %13 = stablehlo.real %11 : (tensor<2x9xcomplex<f32>>) -> tensor<2x9xf32>
     %14 = stablehlo.real %12 : (tensor<2x9xcomplex<f32>>) -> tensor<2x9xf32>
     %15 = stablehlo.compare  EQ, %13, %14,  FLOAT : (tensor<2x9xf32>, tensor<2x9xf32>) -> tensor<2x9xi1>
@@ -42,8 +42,8 @@ module @jit_testcase {
     %19 = stablehlo.compare  LT, %17, %18,  FLOAT : (tensor<2x9xf32>, tensor<2x9xf32>) -> tensor<2x9xi1>
     %20 = stablehlo.select %15, %19, %16 : tensor<2x9xi1>, tensor<2x9xi1>
     %21 = stablehlo.select %20, %11, %12 : tensor<2x9xi1>, tensor<2x9xcomplex<f32>>
-    %22 = "stablehlo.slice"(%21) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
-    %23 = "stablehlo.slice"(%21) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %22 = "stablehlo.slice"(%21) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %23 = "stablehlo.slice"(%21) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %24 = stablehlo.real %22 : (tensor<1x9xcomplex<f32>>) -> tensor<1x9xf32>
     %25 = stablehlo.real %23 : (tensor<1x9xcomplex<f32>>) -> tensor<1x9xf32>
     %26 = stablehlo.compare  EQ, %24, %25,  FLOAT : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xi1>
@@ -53,8 +53,8 @@ module @jit_testcase {
     %30 = stablehlo.compare  LT, %28, %29,  FLOAT : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xi1>
     %31 = stablehlo.select %26, %30, %27 : tensor<1x9xi1>, tensor<1x9xi1>
     %32 = stablehlo.select %31, %22, %23 : tensor<1x9xi1>, tensor<1x9xcomplex<f32>>
-    %33 = "stablehlo.slice"(%32) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
-    %34 = "stablehlo.slice"(%21) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
+    %33 = "stablehlo.slice"(%32) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
+    %34 = "stablehlo.slice"(%21) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
     %35 = stablehlo.real %33 : (tensor<0x9xcomplex<f32>>) -> tensor<0x9xf32>
     %36 = stablehlo.real %34 : (tensor<0x9xcomplex<f32>>) -> tensor<0x9xf32>
     %37 = stablehlo.compare  EQ, %35, %36,  FLOAT : (tensor<0x9xf32>, tensor<0x9xf32>) -> tensor<0x9xi1>
@@ -64,15 +64,15 @@ module @jit_testcase {
     %41 = stablehlo.compare  LT, %39, %40,  FLOAT : (tensor<0x9xf32>, tensor<0x9xf32>) -> tensor<0x9xi1>
     %42 = stablehlo.select %37, %41, %38 : tensor<0x9xi1>, tensor<0x9xi1>
     %43 = stablehlo.select %42, %33, %34 : tensor<0x9xi1>, tensor<0x9xcomplex<f32>>
-    %44 = "stablehlo.slice"(%21) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %44 = "stablehlo.slice"(%21) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %45 = stablehlo.concatenate %44, %43, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<0x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %46 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %47 = stablehlo.pad %45, %46, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<2x9xcomplex<f32>>
     %48 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %49 = stablehlo.pad %32, %48, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<2x9xcomplex<f32>>
     %50 = stablehlo.add %47, %49 : tensor<2x9xcomplex<f32>>
-    %51 = "stablehlo.slice"(%50) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
-    %52 = "stablehlo.slice"(%10) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %51 = "stablehlo.slice"(%50) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %52 = "stablehlo.slice"(%10) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %53 = stablehlo.real %51 : (tensor<1x9xcomplex<f32>>) -> tensor<1x9xf32>
     %54 = stablehlo.real %52 : (tensor<1x9xcomplex<f32>>) -> tensor<1x9xf32>
     %55 = stablehlo.compare  EQ, %53, %54,  FLOAT : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xi1>
@@ -82,15 +82,15 @@ module @jit_testcase {
     %59 = stablehlo.compare  LT, %57, %58,  FLOAT : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<1x9xi1>
     %60 = stablehlo.select %55, %59, %56 : tensor<1x9xi1>, tensor<1x9xi1>
     %61 = stablehlo.select %60, %51, %52 : tensor<1x9xi1>, tensor<1x9xcomplex<f32>>
-    %62 = "stablehlo.slice"(%10) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %62 = "stablehlo.slice"(%10) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %63 = stablehlo.concatenate %62, %61, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<1x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
     %64 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %65 = stablehlo.pad %63, %64, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<4x9xcomplex<f32>>
     %66 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %67 = stablehlo.pad %50, %66, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<4x9xcomplex<f32>>
     %68 = stablehlo.add %65, %67 : tensor<4x9xcomplex<f32>>
-    %69 = "stablehlo.slice"(%68) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
-    %70 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
+    %69 = "stablehlo.slice"(%68) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
+    %70 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
     %71 = stablehlo.real %69 : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xf32>
     %72 = stablehlo.real %70 : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xf32>
     %73 = stablehlo.compare  EQ, %71, %72,  FLOAT : (tensor<3x9xf32>, tensor<3x9xf32>) -> tensor<3x9xi1>
@@ -100,7 +100,7 @@ module @jit_testcase {
     %77 = stablehlo.compare  LT, %75, %76,  FLOAT : (tensor<3x9xf32>, tensor<3x9xf32>) -> tensor<3x9xi1>
     %78 = stablehlo.select %73, %77, %74 : tensor<3x9xi1>, tensor<3x9xi1>
     %79 = stablehlo.select %78, %69, %70 : tensor<3x9xi1>, tensor<3x9xcomplex<f32>>
-    %80 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %80 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %81 = stablehlo.concatenate %80, %79, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<3x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
     %82 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %83 = stablehlo.pad %81, %82, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<8x9xcomplex<f32>>

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf16>
   }
   func.func private @cummin(%arg0: tensor<8x9xf16>) -> tensor<8x9xf16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
     %2 = stablehlo.minimum %0, %1 : tensor<4x9xf16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
     %5 = stablehlo.minimum %3, %4 : tensor<2x9xf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
     %8 = stablehlo.minimum %6, %7 : tensor<1x9xf16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf16>) -> tensor<0x9xf16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<0x9xf16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf16>) -> tensor<0x9xf16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<0x9xf16>
     %11 = stablehlo.minimum %9, %10 : tensor<0x9xf16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf16>, tensor<0x9xf16>) -> tensor<1x9xf16>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf16>, tensor<f16>) -> tensor<2x9xf16>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf16>, tensor<f16>) -> tensor<2x9xf16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
     %21 = stablehlo.minimum %19, %20 : tensor<1x9xf16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf16>, tensor<1x9xf16>) -> tensor<2x9xf16>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf16>, tensor<f16>) -> tensor<4x9xf16>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf16>, tensor<f16>) -> tensor<4x9xf16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<3x9xf16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<3x9xf16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf16>) -> tensor<3x9xf16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<3x9xf16>
     %31 = stablehlo.minimum %29, %30 : tensor<3x9xf16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<1x9xf16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf16>) -> tensor<1x9xf16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf16>, tensor<3x9xf16>) -> tensor<4x9xf16>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf16>, tensor<f16>) -> tensor<8x9xf16>

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_float16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_float16_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf16>
   }
   func.func private @cummin(%arg0: tensor<8x9xf16>) -> tensor<8x9xf16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
     %2 = stablehlo.minimum %0, %1 : tensor<4x9xf16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
     %5 = stablehlo.minimum %3, %4 : tensor<2x9xf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
     %8 = stablehlo.minimum %6, %7 : tensor<1x9xf16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf16>) -> tensor<0x9xf16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<0x9xf16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf16>) -> tensor<0x9xf16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<0x9xf16>
     %11 = stablehlo.minimum %9, %10 : tensor<0x9xf16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf16>, tensor<0x9xf16>) -> tensor<1x9xf16>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf16>, tensor<f16>) -> tensor<2x9xf16>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf16>, tensor<f16>) -> tensor<2x9xf16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
     %21 = stablehlo.minimum %19, %20 : tensor<1x9xf16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf16>, tensor<1x9xf16>) -> tensor<2x9xf16>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf16>, tensor<f16>) -> tensor<4x9xf16>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf16>, tensor<f16>) -> tensor<4x9xf16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<3x9xf16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<3x9xf16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf16>) -> tensor<3x9xf16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<3x9xf16>
     %31 = stablehlo.minimum %29, %30 : tensor<3x9xf16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<1x9xf16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf16>) -> tensor<1x9xf16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf16>, tensor<3x9xf16>) -> tensor<4x9xf16>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf16>, tensor<f16>) -> tensor<8x9xf16>

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cummin(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %2 = stablehlo.minimum %0, %1 : tensor<4x9xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %5 = stablehlo.minimum %3, %4 : tensor<2x9xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %8 = stablehlo.minimum %6, %7 : tensor<1x9xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %11 = stablehlo.minimum %9, %10 : tensor<0x9xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %21 = stablehlo.minimum %19, %20 : tensor<1x9xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %31 = stablehlo.minimum %29, %30 : tensor<3x9xf32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cummin(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %2 = stablehlo.minimum %0, %1 : tensor<4x9xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %5 = stablehlo.minimum %3, %4 : tensor<2x9xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %8 = stablehlo.minimum %6, %7 : tensor<1x9xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %11 = stablehlo.minimum %9, %10 : tensor<0x9xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %21 = stablehlo.minimum %19, %20 : tensor<1x9xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %31 = stablehlo.minimum %29, %30 : tensor<3x9xf32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_int16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_int16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi16>
   }
   func.func private @cummin(%arg0: tensor<8x9xi16>) -> tensor<8x9xi16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
     %2 = stablehlo.minimum %0, %1 : tensor<4x9xi16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
     %5 = stablehlo.minimum %3, %4 : tensor<2x9xi16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
     %8 = stablehlo.minimum %6, %7 : tensor<1x9xi16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi16>) -> tensor<0x9xi16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<0x9xi16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi16>) -> tensor<0x9xi16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<0x9xi16>
     %11 = stablehlo.minimum %9, %10 : tensor<0x9xi16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi16>, tensor<0x9xi16>) -> tensor<1x9xi16>
     %14 = stablehlo.constant dense<0> : tensor<i16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi16>, tensor<i16>) -> tensor<2x9xi16>
     %16 = stablehlo.constant dense<0> : tensor<i16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi16>, tensor<i16>) -> tensor<2x9xi16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
     %21 = stablehlo.minimum %19, %20 : tensor<1x9xi16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi16>, tensor<1x9xi16>) -> tensor<2x9xi16>
     %24 = stablehlo.constant dense<0> : tensor<i16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi16>, tensor<i16>) -> tensor<4x9xi16>
     %26 = stablehlo.constant dense<0> : tensor<i16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi16>, tensor<i16>) -> tensor<4x9xi16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<3x9xi16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<3x9xi16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi16>) -> tensor<3x9xi16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<3x9xi16>
     %31 = stablehlo.minimum %29, %30 : tensor<3x9xi16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<1x9xi16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi16>) -> tensor<1x9xi16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi16>, tensor<3x9xi16>) -> tensor<4x9xi16>
     %34 = stablehlo.constant dense<0> : tensor<i16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi16>, tensor<i16>) -> tensor<8x9xi16>

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_int16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_int16_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi16>
   }
   func.func private @cummin(%arg0: tensor<8x9xi16>) -> tensor<8x9xi16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
     %2 = stablehlo.minimum %0, %1 : tensor<4x9xi16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
     %5 = stablehlo.minimum %3, %4 : tensor<2x9xi16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
     %8 = stablehlo.minimum %6, %7 : tensor<1x9xi16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi16>) -> tensor<0x9xi16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<0x9xi16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi16>) -> tensor<0x9xi16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<0x9xi16>
     %11 = stablehlo.minimum %9, %10 : tensor<0x9xi16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi16>, tensor<0x9xi16>) -> tensor<1x9xi16>
     %14 = stablehlo.constant dense<0> : tensor<i16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi16>, tensor<i16>) -> tensor<2x9xi16>
     %16 = stablehlo.constant dense<0> : tensor<i16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi16>, tensor<i16>) -> tensor<2x9xi16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
     %21 = stablehlo.minimum %19, %20 : tensor<1x9xi16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi16>, tensor<1x9xi16>) -> tensor<2x9xi16>
     %24 = stablehlo.constant dense<0> : tensor<i16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi16>, tensor<i16>) -> tensor<4x9xi16>
     %26 = stablehlo.constant dense<0> : tensor<i16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi16>, tensor<i16>) -> tensor<4x9xi16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<3x9xi16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<3x9xi16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi16>) -> tensor<3x9xi16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<3x9xi16>
     %31 = stablehlo.minimum %29, %30 : tensor<3x9xi16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<1x9xi16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi16>) -> tensor<1x9xi16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi16>, tensor<3x9xi16>) -> tensor<4x9xi16>
     %34 = stablehlo.constant dense<0> : tensor<i16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi16>, tensor<i16>) -> tensor<8x9xi16>

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_int32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_int32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi32>
   }
   func.func private @cummin(%arg0: tensor<8x9xi32>) -> tensor<8x9xi32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
     %2 = stablehlo.minimum %0, %1 : tensor<4x9xi32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
     %5 = stablehlo.minimum %3, %4 : tensor<2x9xi32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
     %8 = stablehlo.minimum %6, %7 : tensor<1x9xi32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi32>) -> tensor<0x9xi32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<0x9xi32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi32>) -> tensor<0x9xi32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<0x9xi32>
     %11 = stablehlo.minimum %9, %10 : tensor<0x9xi32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi32>, tensor<0x9xi32>) -> tensor<1x9xi32>
     %14 = stablehlo.constant dense<0> : tensor<i32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi32>, tensor<i32>) -> tensor<2x9xi32>
     %16 = stablehlo.constant dense<0> : tensor<i32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi32>, tensor<i32>) -> tensor<2x9xi32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
     %21 = stablehlo.minimum %19, %20 : tensor<1x9xi32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi32>, tensor<1x9xi32>) -> tensor<2x9xi32>
     %24 = stablehlo.constant dense<0> : tensor<i32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi32>, tensor<i32>) -> tensor<4x9xi32>
     %26 = stablehlo.constant dense<0> : tensor<i32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi32>, tensor<i32>) -> tensor<4x9xi32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<3x9xi32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<3x9xi32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi32>) -> tensor<3x9xi32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<3x9xi32>
     %31 = stablehlo.minimum %29, %30 : tensor<3x9xi32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<1x9xi32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi32>) -> tensor<1x9xi32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi32>, tensor<3x9xi32>) -> tensor<4x9xi32>
     %34 = stablehlo.constant dense<0> : tensor<i32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi32>, tensor<i32>) -> tensor<8x9xi32>

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_int32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_int32_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi32>
   }
   func.func private @cummin(%arg0: tensor<8x9xi32>) -> tensor<8x9xi32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
     %2 = stablehlo.minimum %0, %1 : tensor<4x9xi32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
     %5 = stablehlo.minimum %3, %4 : tensor<2x9xi32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
     %8 = stablehlo.minimum %6, %7 : tensor<1x9xi32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi32>) -> tensor<0x9xi32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<0x9xi32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi32>) -> tensor<0x9xi32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<0x9xi32>
     %11 = stablehlo.minimum %9, %10 : tensor<0x9xi32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi32>, tensor<0x9xi32>) -> tensor<1x9xi32>
     %14 = stablehlo.constant dense<0> : tensor<i32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi32>, tensor<i32>) -> tensor<2x9xi32>
     %16 = stablehlo.constant dense<0> : tensor<i32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi32>, tensor<i32>) -> tensor<2x9xi32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
     %21 = stablehlo.minimum %19, %20 : tensor<1x9xi32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi32>, tensor<1x9xi32>) -> tensor<2x9xi32>
     %24 = stablehlo.constant dense<0> : tensor<i32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi32>, tensor<i32>) -> tensor<4x9xi32>
     %26 = stablehlo.constant dense<0> : tensor<i32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi32>, tensor<i32>) -> tensor<4x9xi32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<3x9xi32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<3x9xi32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi32>) -> tensor<3x9xi32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<3x9xi32>
     %31 = stablehlo.minimum %29, %30 : tensor<3x9xi32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<1x9xi32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi32>) -> tensor<1x9xi32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi32>, tensor<3x9xi32>) -> tensor<4x9xi32>
     %34 = stablehlo.constant dense<0> : tensor<i32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi32>, tensor<i32>) -> tensor<8x9xi32>

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_int8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_int8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi8>
   }
   func.func private @cummin(%arg0: tensor<8x9xi8>) -> tensor<8x9xi8> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
     %2 = stablehlo.minimum %0, %1 : tensor<4x9xi8>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
     %5 = stablehlo.minimum %3, %4 : tensor<2x9xi8>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
     %8 = stablehlo.minimum %6, %7 : tensor<1x9xi8>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi8>) -> tensor<0x9xi8>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<0x9xi8>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi8>) -> tensor<0x9xi8>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<0x9xi8>
     %11 = stablehlo.minimum %9, %10 : tensor<0x9xi8>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi8>, tensor<0x9xi8>) -> tensor<1x9xi8>
     %14 = stablehlo.constant dense<0> : tensor<i8>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi8>, tensor<i8>) -> tensor<2x9xi8>
     %16 = stablehlo.constant dense<0> : tensor<i8>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi8>, tensor<i8>) -> tensor<2x9xi8>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi8>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
     %21 = stablehlo.minimum %19, %20 : tensor<1x9xi8>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi8>, tensor<1x9xi8>) -> tensor<2x9xi8>
     %24 = stablehlo.constant dense<0> : tensor<i8>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi8>, tensor<i8>) -> tensor<4x9xi8>
     %26 = stablehlo.constant dense<0> : tensor<i8>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi8>, tensor<i8>) -> tensor<4x9xi8>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi8>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<3x9xi8>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<3x9xi8>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi8>) -> tensor<3x9xi8>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<3x9xi8>
     %31 = stablehlo.minimum %29, %30 : tensor<3x9xi8>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<1x9xi8>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi8>) -> tensor<1x9xi8>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi8>, tensor<3x9xi8>) -> tensor<4x9xi8>
     %34 = stablehlo.constant dense<0> : tensor<i8>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi8>, tensor<i8>) -> tensor<8x9xi8>

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_int8_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_int8_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi8>
   }
   func.func private @cummin(%arg0: tensor<8x9xi8>) -> tensor<8x9xi8> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
     %2 = stablehlo.minimum %0, %1 : tensor<4x9xi8>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
     %5 = stablehlo.minimum %3, %4 : tensor<2x9xi8>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
     %8 = stablehlo.minimum %6, %7 : tensor<1x9xi8>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi8>) -> tensor<0x9xi8>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<0x9xi8>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi8>) -> tensor<0x9xi8>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<0x9xi8>
     %11 = stablehlo.minimum %9, %10 : tensor<0x9xi8>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi8>, tensor<0x9xi8>) -> tensor<1x9xi8>
     %14 = stablehlo.constant dense<0> : tensor<i8>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi8>, tensor<i8>) -> tensor<2x9xi8>
     %16 = stablehlo.constant dense<0> : tensor<i8>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi8>, tensor<i8>) -> tensor<2x9xi8>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi8>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
     %21 = stablehlo.minimum %19, %20 : tensor<1x9xi8>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi8>, tensor<1x9xi8>) -> tensor<2x9xi8>
     %24 = stablehlo.constant dense<0> : tensor<i8>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi8>, tensor<i8>) -> tensor<4x9xi8>
     %26 = stablehlo.constant dense<0> : tensor<i8>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi8>, tensor<i8>) -> tensor<4x9xi8>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi8>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<3x9xi8>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<3x9xi8>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi8>) -> tensor<3x9xi8>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<3x9xi8>
     %31 = stablehlo.minimum %29, %30 : tensor<3x9xi8>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<1x9xi8>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi8>) -> tensor<1x9xi8>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi8>, tensor<3x9xi8>) -> tensor<4x9xi8>
     %34 = stablehlo.constant dense<0> : tensor<i8>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi8>, tensor<i8>) -> tensor<8x9xi8>

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_uint16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_uint16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui16>
   }
   func.func private @cummin(%arg0: tensor<8x9xui16>) -> tensor<8x9xui16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
     %2 = stablehlo.minimum %0, %1 : tensor<4x9xui16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
     %5 = stablehlo.minimum %3, %4 : tensor<2x9xui16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
     %8 = stablehlo.minimum %6, %7 : tensor<1x9xui16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui16>) -> tensor<0x9xui16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<0x9xui16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui16>) -> tensor<0x9xui16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<0x9xui16>
     %11 = stablehlo.minimum %9, %10 : tensor<0x9xui16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui16>, tensor<0x9xui16>) -> tensor<1x9xui16>
     %14 = stablehlo.constant dense<0> : tensor<ui16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui16>, tensor<ui16>) -> tensor<2x9xui16>
     %16 = stablehlo.constant dense<0> : tensor<ui16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui16>, tensor<ui16>) -> tensor<2x9xui16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
     %21 = stablehlo.minimum %19, %20 : tensor<1x9xui16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui16>, tensor<1x9xui16>) -> tensor<2x9xui16>
     %24 = stablehlo.constant dense<0> : tensor<ui16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui16>, tensor<ui16>) -> tensor<4x9xui16>
     %26 = stablehlo.constant dense<0> : tensor<ui16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui16>, tensor<ui16>) -> tensor<4x9xui16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<3x9xui16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<3x9xui16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui16>) -> tensor<3x9xui16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<3x9xui16>
     %31 = stablehlo.minimum %29, %30 : tensor<3x9xui16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<1x9xui16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui16>) -> tensor<1x9xui16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui16>, tensor<3x9xui16>) -> tensor<4x9xui16>
     %34 = stablehlo.constant dense<0> : tensor<ui16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui16>, tensor<ui16>) -> tensor<8x9xui16>

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_uint16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_uint16_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui16>
   }
   func.func private @cummin(%arg0: tensor<8x9xui16>) -> tensor<8x9xui16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
     %2 = stablehlo.minimum %0, %1 : tensor<4x9xui16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
     %5 = stablehlo.minimum %3, %4 : tensor<2x9xui16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
     %8 = stablehlo.minimum %6, %7 : tensor<1x9xui16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui16>) -> tensor<0x9xui16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<0x9xui16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui16>) -> tensor<0x9xui16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<0x9xui16>
     %11 = stablehlo.minimum %9, %10 : tensor<0x9xui16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui16>, tensor<0x9xui16>) -> tensor<1x9xui16>
     %14 = stablehlo.constant dense<0> : tensor<ui16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui16>, tensor<ui16>) -> tensor<2x9xui16>
     %16 = stablehlo.constant dense<0> : tensor<ui16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui16>, tensor<ui16>) -> tensor<2x9xui16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
     %21 = stablehlo.minimum %19, %20 : tensor<1x9xui16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui16>, tensor<1x9xui16>) -> tensor<2x9xui16>
     %24 = stablehlo.constant dense<0> : tensor<ui16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui16>, tensor<ui16>) -> tensor<4x9xui16>
     %26 = stablehlo.constant dense<0> : tensor<ui16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui16>, tensor<ui16>) -> tensor<4x9xui16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<3x9xui16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<3x9xui16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui16>) -> tensor<3x9xui16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<3x9xui16>
     %31 = stablehlo.minimum %29, %30 : tensor<3x9xui16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<1x9xui16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui16>) -> tensor<1x9xui16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui16>, tensor<3x9xui16>) -> tensor<4x9xui16>
     %34 = stablehlo.constant dense<0> : tensor<ui16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui16>, tensor<ui16>) -> tensor<8x9xui16>

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_uint32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_uint32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui32>
   }
   func.func private @cummin(%arg0: tensor<8x9xui32>) -> tensor<8x9xui32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
     %2 = stablehlo.minimum %0, %1 : tensor<4x9xui32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
     %5 = stablehlo.minimum %3, %4 : tensor<2x9xui32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
     %8 = stablehlo.minimum %6, %7 : tensor<1x9xui32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui32>) -> tensor<0x9xui32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<0x9xui32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui32>) -> tensor<0x9xui32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<0x9xui32>
     %11 = stablehlo.minimum %9, %10 : tensor<0x9xui32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui32>, tensor<0x9xui32>) -> tensor<1x9xui32>
     %14 = stablehlo.constant dense<0> : tensor<ui32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui32>, tensor<ui32>) -> tensor<2x9xui32>
     %16 = stablehlo.constant dense<0> : tensor<ui32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui32>, tensor<ui32>) -> tensor<2x9xui32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
     %21 = stablehlo.minimum %19, %20 : tensor<1x9xui32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui32>, tensor<1x9xui32>) -> tensor<2x9xui32>
     %24 = stablehlo.constant dense<0> : tensor<ui32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui32>, tensor<ui32>) -> tensor<4x9xui32>
     %26 = stablehlo.constant dense<0> : tensor<ui32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui32>, tensor<ui32>) -> tensor<4x9xui32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<3x9xui32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<3x9xui32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui32>) -> tensor<3x9xui32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<3x9xui32>
     %31 = stablehlo.minimum %29, %30 : tensor<3x9xui32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<1x9xui32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui32>) -> tensor<1x9xui32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui32>, tensor<3x9xui32>) -> tensor<4x9xui32>
     %34 = stablehlo.constant dense<0> : tensor<ui32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui32>, tensor<ui32>) -> tensor<8x9xui32>

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_uint32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_uint32_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui32>
   }
   func.func private @cummin(%arg0: tensor<8x9xui32>) -> tensor<8x9xui32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
     %2 = stablehlo.minimum %0, %1 : tensor<4x9xui32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
     %5 = stablehlo.minimum %3, %4 : tensor<2x9xui32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
     %8 = stablehlo.minimum %6, %7 : tensor<1x9xui32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui32>) -> tensor<0x9xui32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<0x9xui32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui32>) -> tensor<0x9xui32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<0x9xui32>
     %11 = stablehlo.minimum %9, %10 : tensor<0x9xui32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui32>, tensor<0x9xui32>) -> tensor<1x9xui32>
     %14 = stablehlo.constant dense<0> : tensor<ui32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui32>, tensor<ui32>) -> tensor<2x9xui32>
     %16 = stablehlo.constant dense<0> : tensor<ui32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui32>, tensor<ui32>) -> tensor<2x9xui32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
     %21 = stablehlo.minimum %19, %20 : tensor<1x9xui32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui32>, tensor<1x9xui32>) -> tensor<2x9xui32>
     %24 = stablehlo.constant dense<0> : tensor<ui32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui32>, tensor<ui32>) -> tensor<4x9xui32>
     %26 = stablehlo.constant dense<0> : tensor<ui32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui32>, tensor<ui32>) -> tensor<4x9xui32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<3x9xui32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<3x9xui32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui32>) -> tensor<3x9xui32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<3x9xui32>
     %31 = stablehlo.minimum %29, %30 : tensor<3x9xui32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<1x9xui32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui32>) -> tensor<1x9xui32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui32>, tensor<3x9xui32>) -> tensor<4x9xui32>
     %34 = stablehlo.constant dense<0> : tensor<ui32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui32>, tensor<ui32>) -> tensor<8x9xui32>

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_uint8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_uint8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui8>
   }
   func.func private @cummin(%arg0: tensor<8x9xui8>) -> tensor<8x9xui8> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
     %2 = stablehlo.minimum %0, %1 : tensor<4x9xui8>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
     %5 = stablehlo.minimum %3, %4 : tensor<2x9xui8>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
     %8 = stablehlo.minimum %6, %7 : tensor<1x9xui8>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui8>) -> tensor<0x9xui8>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<0x9xui8>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui8>) -> tensor<0x9xui8>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<0x9xui8>
     %11 = stablehlo.minimum %9, %10 : tensor<0x9xui8>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui8>, tensor<0x9xui8>) -> tensor<1x9xui8>
     %14 = stablehlo.constant dense<0> : tensor<ui8>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui8>, tensor<ui8>) -> tensor<2x9xui8>
     %16 = stablehlo.constant dense<0> : tensor<ui8>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui8>, tensor<ui8>) -> tensor<2x9xui8>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui8>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
     %21 = stablehlo.minimum %19, %20 : tensor<1x9xui8>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui8>, tensor<1x9xui8>) -> tensor<2x9xui8>
     %24 = stablehlo.constant dense<0> : tensor<ui8>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui8>, tensor<ui8>) -> tensor<4x9xui8>
     %26 = stablehlo.constant dense<0> : tensor<ui8>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui8>, tensor<ui8>) -> tensor<4x9xui8>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui8>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<3x9xui8>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<3x9xui8>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui8>) -> tensor<3x9xui8>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<3x9xui8>
     %31 = stablehlo.minimum %29, %30 : tensor<3x9xui8>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<1x9xui8>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui8>) -> tensor<1x9xui8>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui8>, tensor<3x9xui8>) -> tensor<4x9xui8>
     %34 = stablehlo.constant dense<0> : tensor<ui8>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui8>, tensor<ui8>) -> tensor<8x9xui8>

--- a/stablehlo/testdata/cummin_dtype_by_fun_shape_uint8_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cummin_dtype_by_fun_shape_uint8_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui8>
   }
   func.func private @cummin(%arg0: tensor<8x9xui8>) -> tensor<8x9xui8> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
     %2 = stablehlo.minimum %0, %1 : tensor<4x9xui8>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
     %5 = stablehlo.minimum %3, %4 : tensor<2x9xui8>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
     %8 = stablehlo.minimum %6, %7 : tensor<1x9xui8>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui8>) -> tensor<0x9xui8>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<0x9xui8>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui8>) -> tensor<0x9xui8>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<0x9xui8>
     %11 = stablehlo.minimum %9, %10 : tensor<0x9xui8>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui8>, tensor<0x9xui8>) -> tensor<1x9xui8>
     %14 = stablehlo.constant dense<0> : tensor<ui8>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui8>, tensor<ui8>) -> tensor<2x9xui8>
     %16 = stablehlo.constant dense<0> : tensor<ui8>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui8>, tensor<ui8>) -> tensor<2x9xui8>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui8>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
     %21 = stablehlo.minimum %19, %20 : tensor<1x9xui8>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui8>, tensor<1x9xui8>) -> tensor<2x9xui8>
     %24 = stablehlo.constant dense<0> : tensor<ui8>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui8>, tensor<ui8>) -> tensor<4x9xui8>
     %26 = stablehlo.constant dense<0> : tensor<ui8>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui8>, tensor<ui8>) -> tensor<4x9xui8>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui8>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<3x9xui8>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<3x9xui8>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui8>) -> tensor<3x9xui8>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<3x9xui8>
     %31 = stablehlo.minimum %29, %30 : tensor<3x9xui8>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<1x9xui8>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui8>) -> tensor<1x9xui8>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui8>, tensor<3x9xui8>) -> tensor<4x9xui8>
     %34 = stablehlo.constant dense<0> : tensor<ui8>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui8>, tensor<ui8>) -> tensor<8x9xui8>

--- a/stablehlo/testdata/cummin_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cummin_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
@@ -21,39 +21,39 @@ module @jit_testcase {
   }
   func.func private @cummin(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
     %0 = stablehlo.reverse %arg0, dims = [0] : tensor<8x9xf32>
-    %1 = "stablehlo.slice"(%0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %3 = stablehlo.minimum %1, %2 : tensor<4x9xf32>
-    %4 = "stablehlo.slice"(%3) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %5 = "stablehlo.slice"(%3) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%3) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %5 = "stablehlo.slice"(%3) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %6 = stablehlo.minimum %4, %5 : tensor<2x9xf32>
-    %7 = "stablehlo.slice"(%6) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %8 = "stablehlo.slice"(%6) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%6) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %8 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %9 = stablehlo.minimum %7, %8 : tensor<1x9xf32>
-    %10 = "stablehlo.slice"(%9) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%9) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %12 = stablehlo.minimum %10, %11 : tensor<0x9xf32>
-    %13 = "stablehlo.slice"(%6) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %13 = "stablehlo.slice"(%6) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.concatenate %13, %12, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %15 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %16 = stablehlo.pad %14, %15, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %17 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %18 = stablehlo.pad %9, %17, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %19 = stablehlo.add %16, %18 : tensor<2x9xf32>
-    %20 = "stablehlo.slice"(%19) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %21 = "stablehlo.slice"(%3) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%19) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %21 = "stablehlo.slice"(%3) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %22 = stablehlo.minimum %20, %21 : tensor<1x9xf32>
-    %23 = "stablehlo.slice"(%3) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %23 = "stablehlo.slice"(%3) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %24 = stablehlo.concatenate %23, %22, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %25 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %26 = stablehlo.pad %24, %25, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %27 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %28 = stablehlo.pad %19, %27, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %29 = stablehlo.add %26, %28 : tensor<4x9xf32>
-    %30 = "stablehlo.slice"(%29) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %31 = "stablehlo.slice"(%0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%29) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %31 = "stablehlo.slice"(%0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %32 = stablehlo.minimum %30, %31 : tensor<3x9xf32>
-    %33 = "stablehlo.slice"(%0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %33 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %34 = stablehlo.concatenate %33, %32, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %35 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %36 = stablehlo.pad %34, %35, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cummin_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cummin_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
@@ -21,39 +21,39 @@ module @jit_testcase {
   }
   func.func private @cummin(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
     %0 = stablehlo.reverse %arg0, dims = [0] : tensor<8x9xf32>
-    %1 = "stablehlo.slice"(%0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %3 = stablehlo.minimum %1, %2 : tensor<4x9xf32>
-    %4 = "stablehlo.slice"(%3) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %5 = "stablehlo.slice"(%3) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%3) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %5 = "stablehlo.slice"(%3) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %6 = stablehlo.minimum %4, %5 : tensor<2x9xf32>
-    %7 = "stablehlo.slice"(%6) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %8 = "stablehlo.slice"(%6) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%6) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %8 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %9 = stablehlo.minimum %7, %8 : tensor<1x9xf32>
-    %10 = "stablehlo.slice"(%9) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%9) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %12 = stablehlo.minimum %10, %11 : tensor<0x9xf32>
-    %13 = "stablehlo.slice"(%6) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %13 = "stablehlo.slice"(%6) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.concatenate %13, %12, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %15 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %16 = stablehlo.pad %14, %15, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %17 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %18 = stablehlo.pad %9, %17, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %19 = stablehlo.add %16, %18 : tensor<2x9xf32>
-    %20 = "stablehlo.slice"(%19) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %21 = "stablehlo.slice"(%3) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%19) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %21 = "stablehlo.slice"(%3) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %22 = stablehlo.minimum %20, %21 : tensor<1x9xf32>
-    %23 = "stablehlo.slice"(%3) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %23 = "stablehlo.slice"(%3) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %24 = stablehlo.concatenate %23, %22, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %25 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %26 = stablehlo.pad %24, %25, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %27 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %28 = stablehlo.pad %19, %27, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %29 = stablehlo.add %26, %28 : tensor<4x9xf32>
-    %30 = "stablehlo.slice"(%29) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %31 = "stablehlo.slice"(%0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%29) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %31 = "stablehlo.slice"(%0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %32 = stablehlo.minimum %30, %31 : tensor<3x9xf32>
-    %33 = "stablehlo.slice"(%0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %33 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %34 = stablehlo.concatenate %33, %32, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %35 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %36 = stablehlo.pad %34, %35, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumprod_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cumprod(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xf32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumprod_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
@@ -20,38 +20,38 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cumprod(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<8> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 8>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
     %2 = stablehlo.multiply %0, %1 : tensor<8x4xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 3]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 4]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 3>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 4>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
     %5 = stablehlo.multiply %3, %4 : tensor<8x2xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 2]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 2>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
     %8 = stablehlo.multiply %6, %7 : tensor<8x1xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[8, 0]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x1xf32>) -> tensor<8x0xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 2]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x0xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 8, 0>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x1xf32>) -> tensor<8x0xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 2>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x0xf32>
     %11 = stablehlo.multiply %9, %10 : tensor<8x0xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 1 : (tensor<8x1xf32>, tensor<8x0xf32>) -> tensor<8x1xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [0, 1], interior = [0, 1] : (tensor<8x1xf32>, tensor<f32>) -> tensor<8x2xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [0, 1], high = [0, 0], interior = [0, 1] : (tensor<8x1xf32>, tensor<f32>) -> tensor<8x2xf32>
     %18 = stablehlo.add %15, %17 : tensor<8x2xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 4]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 4>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
     %21 = stablehlo.multiply %19, %20 : tensor<8x1xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 1 : (tensor<8x1xf32>, tensor<8x1xf32>) -> tensor<8x2xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [0, 1], interior = [0, 1] : (tensor<8x2xf32>, tensor<f32>) -> tensor<8x4xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [0, 1], high = [0, 0], interior = [0, 1] : (tensor<8x2xf32>, tensor<f32>) -> tensor<8x4xf32>
     %28 = stablehlo.add %25, %27 : tensor<8x4xf32>
-    %29 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %29 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
     %30 = stablehlo.multiply %28, %29 : tensor<8x4xf32>
-    %31 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x1xf32>
+    %31 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<8x1xf32>
     %32 = stablehlo.concatenate %31, %30, dim = 1 : (tensor<8x1xf32>, tensor<8x4xf32>) -> tensor<8x5xf32>
     %33 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %34 = stablehlo.pad %32, %33, low = [0, 0], high = [0, 0], interior = [0, 1] : (tensor<8x5xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumprod_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cumprod(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xf32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumprod_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
@@ -20,38 +20,38 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cumprod(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<8> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 8>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
     %2 = stablehlo.multiply %0, %1 : tensor<8x4xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 3]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 4]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 3>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 4>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
     %5 = stablehlo.multiply %3, %4 : tensor<8x2xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 2]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 2>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
     %8 = stablehlo.multiply %6, %7 : tensor<8x1xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[8, 0]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x1xf32>) -> tensor<8x0xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 2]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x0xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 8, 0>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x1xf32>) -> tensor<8x0xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 2>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x0xf32>
     %11 = stablehlo.multiply %9, %10 : tensor<8x0xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 1 : (tensor<8x1xf32>, tensor<8x0xf32>) -> tensor<8x1xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [0, 1], interior = [0, 1] : (tensor<8x1xf32>, tensor<f32>) -> tensor<8x2xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [0, 1], high = [0, 0], interior = [0, 1] : (tensor<8x1xf32>, tensor<f32>) -> tensor<8x2xf32>
     %18 = stablehlo.add %15, %17 : tensor<8x2xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 4]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 4>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
     %21 = stablehlo.multiply %19, %20 : tensor<8x1xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 1 : (tensor<8x1xf32>, tensor<8x1xf32>) -> tensor<8x2xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [0, 1], interior = [0, 1] : (tensor<8x2xf32>, tensor<f32>) -> tensor<8x4xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [0, 1], high = [0, 0], interior = [0, 1] : (tensor<8x2xf32>, tensor<f32>) -> tensor<8x4xf32>
     %28 = stablehlo.add %25, %27 : tensor<8x4xf32>
-    %29 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %29 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
     %30 = stablehlo.multiply %28, %29 : tensor<8x4xf32>
-    %31 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x1xf32>
+    %31 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<8x1xf32>
     %32 = stablehlo.concatenate %31, %30, dim = 1 : (tensor<8x1xf32>, tensor<8x4xf32>) -> tensor<8x5xf32>
     %33 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %34 = stablehlo.pad %32, %33, low = [0, 0], high = [0, 0], interior = [0, 1] : (tensor<8x5xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_bfloat16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_bfloat16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xbf16>
   }
   func.func private @cumprod(%arg0: tensor<8x9xbf16>) -> tensor<8x9xbf16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xbf16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xbf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xbf16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xbf16>) -> tensor<0x9xbf16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<0x9xbf16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xbf16>) -> tensor<0x9xbf16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<0x9xbf16>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xbf16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xbf16>, tensor<0x9xbf16>) -> tensor<1x9xbf16>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xbf16>, tensor<bf16>) -> tensor<2x9xbf16>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xbf16>, tensor<bf16>) -> tensor<2x9xbf16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xbf16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xbf16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xbf16>, tensor<1x9xbf16>) -> tensor<2x9xbf16>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xbf16>, tensor<bf16>) -> tensor<4x9xbf16>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xbf16>, tensor<bf16>) -> tensor<4x9xbf16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xbf16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<3x9xbf16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<3x9xbf16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xbf16>) -> tensor<3x9xbf16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<3x9xbf16>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xbf16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<1x9xbf16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xbf16>) -> tensor<1x9xbf16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xbf16>, tensor<3x9xbf16>) -> tensor<4x9xbf16>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xbf16>, tensor<bf16>) -> tensor<8x9xbf16>

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_bfloat16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_bfloat16_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xbf16>
   }
   func.func private @cumprod(%arg0: tensor<8x9xbf16>) -> tensor<8x9xbf16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xbf16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xbf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xbf16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xbf16>) -> tensor<0x9xbf16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<0x9xbf16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xbf16>) -> tensor<0x9xbf16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<0x9xbf16>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xbf16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xbf16>, tensor<0x9xbf16>) -> tensor<1x9xbf16>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xbf16>, tensor<bf16>) -> tensor<2x9xbf16>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xbf16>, tensor<bf16>) -> tensor<2x9xbf16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xbf16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xbf16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xbf16>, tensor<1x9xbf16>) -> tensor<2x9xbf16>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xbf16>, tensor<bf16>) -> tensor<4x9xbf16>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xbf16>, tensor<bf16>) -> tensor<4x9xbf16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xbf16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<3x9xbf16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<3x9xbf16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xbf16>) -> tensor<3x9xbf16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<3x9xbf16>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xbf16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<1x9xbf16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xbf16>) -> tensor<1x9xbf16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xbf16>, tensor<3x9xbf16>) -> tensor<4x9xbf16>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xbf16>, tensor<bf16>) -> tensor<8x9xbf16>

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_complex64_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_complex64_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xcomplex<f32>>
   }
   func.func private @cumprod(%arg0: tensor<8x9xcomplex<f32>>) -> tensor<8x9xcomplex<f32>> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xcomplex<f32>>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xcomplex<f32>>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xcomplex<f32>>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xcomplex<f32>>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<0x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %14 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<2x9xcomplex<f32>>
     %16 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<2x9xcomplex<f32>>
     %18 = stablehlo.add %15, %17 : tensor<2x9xcomplex<f32>>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xcomplex<f32>>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<1x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
     %24 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<4x9xcomplex<f32>>
     %26 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<4x9xcomplex<f32>>
     %28 = stablehlo.add %25, %27 : tensor<4x9xcomplex<f32>>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xcomplex<f32>>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<3x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
     %34 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<8x9xcomplex<f32>>

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_complex64_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_complex64_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xcomplex<f32>>
   }
   func.func private @cumprod(%arg0: tensor<8x9xcomplex<f32>>) -> tensor<8x9xcomplex<f32>> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xcomplex<f32>>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xcomplex<f32>>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xcomplex<f32>>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xcomplex<f32>>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<0x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %14 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<2x9xcomplex<f32>>
     %16 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<2x9xcomplex<f32>>
     %18 = stablehlo.add %15, %17 : tensor<2x9xcomplex<f32>>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xcomplex<f32>>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<1x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
     %24 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<4x9xcomplex<f32>>
     %26 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<4x9xcomplex<f32>>
     %28 = stablehlo.add %25, %27 : tensor<4x9xcomplex<f32>>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xcomplex<f32>>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<3x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
     %34 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<8x9xcomplex<f32>>

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf16>
   }
   func.func private @cumprod(%arg0: tensor<8x9xf16>) -> tensor<8x9xf16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xf16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xf16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf16>) -> tensor<0x9xf16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<0x9xf16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf16>) -> tensor<0x9xf16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<0x9xf16>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xf16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf16>, tensor<0x9xf16>) -> tensor<1x9xf16>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf16>, tensor<f16>) -> tensor<2x9xf16>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf16>, tensor<f16>) -> tensor<2x9xf16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xf16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf16>, tensor<1x9xf16>) -> tensor<2x9xf16>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf16>, tensor<f16>) -> tensor<4x9xf16>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf16>, tensor<f16>) -> tensor<4x9xf16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<3x9xf16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<3x9xf16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf16>) -> tensor<3x9xf16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<3x9xf16>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xf16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<1x9xf16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf16>) -> tensor<1x9xf16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf16>, tensor<3x9xf16>) -> tensor<4x9xf16>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf16>, tensor<f16>) -> tensor<8x9xf16>

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_float16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_float16_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf16>
   }
   func.func private @cumprod(%arg0: tensor<8x9xf16>) -> tensor<8x9xf16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xf16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xf16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf16>) -> tensor<0x9xf16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<0x9xf16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf16>) -> tensor<0x9xf16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<0x9xf16>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xf16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf16>, tensor<0x9xf16>) -> tensor<1x9xf16>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf16>, tensor<f16>) -> tensor<2x9xf16>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf16>, tensor<f16>) -> tensor<2x9xf16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xf16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf16>, tensor<1x9xf16>) -> tensor<2x9xf16>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf16>, tensor<f16>) -> tensor<4x9xf16>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf16>, tensor<f16>) -> tensor<4x9xf16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<3x9xf16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<3x9xf16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf16>) -> tensor<3x9xf16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<3x9xf16>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xf16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<1x9xf16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf16>) -> tensor<1x9xf16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf16>, tensor<3x9xf16>) -> tensor<4x9xf16>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf16>, tensor<f16>) -> tensor<8x9xf16>

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cumprod(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xf32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cumprod(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xf32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_int16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_int16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi16>
   }
   func.func private @cumprod(%arg0: tensor<8x9xi16>) -> tensor<8x9xi16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xi16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xi16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xi16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi16>) -> tensor<0x9xi16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<0x9xi16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi16>) -> tensor<0x9xi16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<0x9xi16>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xi16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi16>, tensor<0x9xi16>) -> tensor<1x9xi16>
     %14 = stablehlo.constant dense<0> : tensor<i16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi16>, tensor<i16>) -> tensor<2x9xi16>
     %16 = stablehlo.constant dense<0> : tensor<i16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi16>, tensor<i16>) -> tensor<2x9xi16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xi16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi16>, tensor<1x9xi16>) -> tensor<2x9xi16>
     %24 = stablehlo.constant dense<0> : tensor<i16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi16>, tensor<i16>) -> tensor<4x9xi16>
     %26 = stablehlo.constant dense<0> : tensor<i16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi16>, tensor<i16>) -> tensor<4x9xi16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<3x9xi16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<3x9xi16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi16>) -> tensor<3x9xi16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<3x9xi16>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xi16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<1x9xi16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi16>) -> tensor<1x9xi16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi16>, tensor<3x9xi16>) -> tensor<4x9xi16>
     %34 = stablehlo.constant dense<0> : tensor<i16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi16>, tensor<i16>) -> tensor<8x9xi16>

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_int16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_int16_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi16>
   }
   func.func private @cumprod(%arg0: tensor<8x9xi16>) -> tensor<8x9xi16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xi16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xi16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xi16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi16>) -> tensor<0x9xi16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<0x9xi16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi16>) -> tensor<0x9xi16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<0x9xi16>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xi16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi16>, tensor<0x9xi16>) -> tensor<1x9xi16>
     %14 = stablehlo.constant dense<0> : tensor<i16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi16>, tensor<i16>) -> tensor<2x9xi16>
     %16 = stablehlo.constant dense<0> : tensor<i16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi16>, tensor<i16>) -> tensor<2x9xi16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xi16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi16>, tensor<1x9xi16>) -> tensor<2x9xi16>
     %24 = stablehlo.constant dense<0> : tensor<i16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi16>, tensor<i16>) -> tensor<4x9xi16>
     %26 = stablehlo.constant dense<0> : tensor<i16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi16>, tensor<i16>) -> tensor<4x9xi16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<3x9xi16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<3x9xi16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi16>) -> tensor<3x9xi16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<3x9xi16>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xi16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<1x9xi16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi16>) -> tensor<1x9xi16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi16>, tensor<3x9xi16>) -> tensor<4x9xi16>
     %34 = stablehlo.constant dense<0> : tensor<i16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi16>, tensor<i16>) -> tensor<8x9xi16>

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_int32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_int32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi32>
   }
   func.func private @cumprod(%arg0: tensor<8x9xi32>) -> tensor<8x9xi32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xi32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xi32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xi32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi32>) -> tensor<0x9xi32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<0x9xi32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi32>) -> tensor<0x9xi32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<0x9xi32>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xi32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi32>, tensor<0x9xi32>) -> tensor<1x9xi32>
     %14 = stablehlo.constant dense<0> : tensor<i32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi32>, tensor<i32>) -> tensor<2x9xi32>
     %16 = stablehlo.constant dense<0> : tensor<i32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi32>, tensor<i32>) -> tensor<2x9xi32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xi32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi32>, tensor<1x9xi32>) -> tensor<2x9xi32>
     %24 = stablehlo.constant dense<0> : tensor<i32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi32>, tensor<i32>) -> tensor<4x9xi32>
     %26 = stablehlo.constant dense<0> : tensor<i32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi32>, tensor<i32>) -> tensor<4x9xi32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<3x9xi32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<3x9xi32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi32>) -> tensor<3x9xi32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<3x9xi32>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xi32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<1x9xi32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi32>) -> tensor<1x9xi32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi32>, tensor<3x9xi32>) -> tensor<4x9xi32>
     %34 = stablehlo.constant dense<0> : tensor<i32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi32>, tensor<i32>) -> tensor<8x9xi32>

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_int32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_int32_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi32>
   }
   func.func private @cumprod(%arg0: tensor<8x9xi32>) -> tensor<8x9xi32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xi32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xi32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xi32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi32>) -> tensor<0x9xi32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<0x9xi32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi32>) -> tensor<0x9xi32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<0x9xi32>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xi32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi32>, tensor<0x9xi32>) -> tensor<1x9xi32>
     %14 = stablehlo.constant dense<0> : tensor<i32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi32>, tensor<i32>) -> tensor<2x9xi32>
     %16 = stablehlo.constant dense<0> : tensor<i32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi32>, tensor<i32>) -> tensor<2x9xi32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xi32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi32>, tensor<1x9xi32>) -> tensor<2x9xi32>
     %24 = stablehlo.constant dense<0> : tensor<i32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi32>, tensor<i32>) -> tensor<4x9xi32>
     %26 = stablehlo.constant dense<0> : tensor<i32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi32>, tensor<i32>) -> tensor<4x9xi32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<3x9xi32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<3x9xi32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi32>) -> tensor<3x9xi32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<3x9xi32>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xi32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<1x9xi32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi32>) -> tensor<1x9xi32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi32>, tensor<3x9xi32>) -> tensor<4x9xi32>
     %34 = stablehlo.constant dense<0> : tensor<i32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi32>, tensor<i32>) -> tensor<8x9xi32>

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_int8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_int8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi8>
   }
   func.func private @cumprod(%arg0: tensor<8x9xi8>) -> tensor<8x9xi8> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xi8>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xi8>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xi8>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi8>) -> tensor<0x9xi8>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<0x9xi8>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi8>) -> tensor<0x9xi8>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<0x9xi8>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xi8>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi8>, tensor<0x9xi8>) -> tensor<1x9xi8>
     %14 = stablehlo.constant dense<0> : tensor<i8>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi8>, tensor<i8>) -> tensor<2x9xi8>
     %16 = stablehlo.constant dense<0> : tensor<i8>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi8>, tensor<i8>) -> tensor<2x9xi8>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi8>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xi8>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi8>, tensor<1x9xi8>) -> tensor<2x9xi8>
     %24 = stablehlo.constant dense<0> : tensor<i8>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi8>, tensor<i8>) -> tensor<4x9xi8>
     %26 = stablehlo.constant dense<0> : tensor<i8>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi8>, tensor<i8>) -> tensor<4x9xi8>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi8>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<3x9xi8>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<3x9xi8>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi8>) -> tensor<3x9xi8>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<3x9xi8>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xi8>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<1x9xi8>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi8>) -> tensor<1x9xi8>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi8>, tensor<3x9xi8>) -> tensor<4x9xi8>
     %34 = stablehlo.constant dense<0> : tensor<i8>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi8>, tensor<i8>) -> tensor<8x9xi8>

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_int8_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_int8_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi8>
   }
   func.func private @cumprod(%arg0: tensor<8x9xi8>) -> tensor<8x9xi8> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xi8>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xi8>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xi8>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi8>) -> tensor<0x9xi8>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<0x9xi8>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi8>) -> tensor<0x9xi8>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<0x9xi8>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xi8>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi8>, tensor<0x9xi8>) -> tensor<1x9xi8>
     %14 = stablehlo.constant dense<0> : tensor<i8>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi8>, tensor<i8>) -> tensor<2x9xi8>
     %16 = stablehlo.constant dense<0> : tensor<i8>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi8>, tensor<i8>) -> tensor<2x9xi8>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi8>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xi8>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi8>, tensor<1x9xi8>) -> tensor<2x9xi8>
     %24 = stablehlo.constant dense<0> : tensor<i8>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi8>, tensor<i8>) -> tensor<4x9xi8>
     %26 = stablehlo.constant dense<0> : tensor<i8>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi8>, tensor<i8>) -> tensor<4x9xi8>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi8>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<3x9xi8>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<3x9xi8>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi8>) -> tensor<3x9xi8>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<3x9xi8>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xi8>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<1x9xi8>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi8>) -> tensor<1x9xi8>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi8>, tensor<3x9xi8>) -> tensor<4x9xi8>
     %34 = stablehlo.constant dense<0> : tensor<i8>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi8>, tensor<i8>) -> tensor<8x9xi8>

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui16>
   }
   func.func private @cumprod(%arg0: tensor<8x9xui16>) -> tensor<8x9xui16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xui16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xui16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xui16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui16>) -> tensor<0x9xui16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<0x9xui16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui16>) -> tensor<0x9xui16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<0x9xui16>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xui16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui16>, tensor<0x9xui16>) -> tensor<1x9xui16>
     %14 = stablehlo.constant dense<0> : tensor<ui16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui16>, tensor<ui16>) -> tensor<2x9xui16>
     %16 = stablehlo.constant dense<0> : tensor<ui16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui16>, tensor<ui16>) -> tensor<2x9xui16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xui16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui16>, tensor<1x9xui16>) -> tensor<2x9xui16>
     %24 = stablehlo.constant dense<0> : tensor<ui16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui16>, tensor<ui16>) -> tensor<4x9xui16>
     %26 = stablehlo.constant dense<0> : tensor<ui16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui16>, tensor<ui16>) -> tensor<4x9xui16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<3x9xui16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<3x9xui16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui16>) -> tensor<3x9xui16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<3x9xui16>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xui16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<1x9xui16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui16>) -> tensor<1x9xui16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui16>, tensor<3x9xui16>) -> tensor<4x9xui16>
     %34 = stablehlo.constant dense<0> : tensor<ui16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui16>, tensor<ui16>) -> tensor<8x9xui16>

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint16_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui16>
   }
   func.func private @cumprod(%arg0: tensor<8x9xui16>) -> tensor<8x9xui16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xui16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xui16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xui16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui16>) -> tensor<0x9xui16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<0x9xui16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui16>) -> tensor<0x9xui16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<0x9xui16>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xui16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui16>, tensor<0x9xui16>) -> tensor<1x9xui16>
     %14 = stablehlo.constant dense<0> : tensor<ui16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui16>, tensor<ui16>) -> tensor<2x9xui16>
     %16 = stablehlo.constant dense<0> : tensor<ui16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui16>, tensor<ui16>) -> tensor<2x9xui16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xui16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui16>, tensor<1x9xui16>) -> tensor<2x9xui16>
     %24 = stablehlo.constant dense<0> : tensor<ui16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui16>, tensor<ui16>) -> tensor<4x9xui16>
     %26 = stablehlo.constant dense<0> : tensor<ui16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui16>, tensor<ui16>) -> tensor<4x9xui16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<3x9xui16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<3x9xui16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui16>) -> tensor<3x9xui16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<3x9xui16>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xui16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<1x9xui16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui16>) -> tensor<1x9xui16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui16>, tensor<3x9xui16>) -> tensor<4x9xui16>
     %34 = stablehlo.constant dense<0> : tensor<ui16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui16>, tensor<ui16>) -> tensor<8x9xui16>

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui32>
   }
   func.func private @cumprod(%arg0: tensor<8x9xui32>) -> tensor<8x9xui32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xui32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xui32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xui32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui32>) -> tensor<0x9xui32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<0x9xui32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui32>) -> tensor<0x9xui32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<0x9xui32>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xui32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui32>, tensor<0x9xui32>) -> tensor<1x9xui32>
     %14 = stablehlo.constant dense<0> : tensor<ui32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui32>, tensor<ui32>) -> tensor<2x9xui32>
     %16 = stablehlo.constant dense<0> : tensor<ui32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui32>, tensor<ui32>) -> tensor<2x9xui32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xui32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui32>, tensor<1x9xui32>) -> tensor<2x9xui32>
     %24 = stablehlo.constant dense<0> : tensor<ui32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui32>, tensor<ui32>) -> tensor<4x9xui32>
     %26 = stablehlo.constant dense<0> : tensor<ui32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui32>, tensor<ui32>) -> tensor<4x9xui32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<3x9xui32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<3x9xui32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui32>) -> tensor<3x9xui32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<3x9xui32>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xui32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<1x9xui32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui32>) -> tensor<1x9xui32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui32>, tensor<3x9xui32>) -> tensor<4x9xui32>
     %34 = stablehlo.constant dense<0> : tensor<ui32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui32>, tensor<ui32>) -> tensor<8x9xui32>

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint32_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui32>
   }
   func.func private @cumprod(%arg0: tensor<8x9xui32>) -> tensor<8x9xui32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xui32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xui32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xui32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui32>) -> tensor<0x9xui32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<0x9xui32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui32>) -> tensor<0x9xui32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<0x9xui32>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xui32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui32>, tensor<0x9xui32>) -> tensor<1x9xui32>
     %14 = stablehlo.constant dense<0> : tensor<ui32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui32>, tensor<ui32>) -> tensor<2x9xui32>
     %16 = stablehlo.constant dense<0> : tensor<ui32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui32>, tensor<ui32>) -> tensor<2x9xui32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xui32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui32>, tensor<1x9xui32>) -> tensor<2x9xui32>
     %24 = stablehlo.constant dense<0> : tensor<ui32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui32>, tensor<ui32>) -> tensor<4x9xui32>
     %26 = stablehlo.constant dense<0> : tensor<ui32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui32>, tensor<ui32>) -> tensor<4x9xui32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<3x9xui32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<3x9xui32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui32>) -> tensor<3x9xui32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<3x9xui32>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xui32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<1x9xui32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui32>) -> tensor<1x9xui32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui32>, tensor<3x9xui32>) -> tensor<4x9xui32>
     %34 = stablehlo.constant dense<0> : tensor<ui32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui32>, tensor<ui32>) -> tensor<8x9xui32>

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui8>
   }
   func.func private @cumprod(%arg0: tensor<8x9xui8>) -> tensor<8x9xui8> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xui8>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xui8>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xui8>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui8>) -> tensor<0x9xui8>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<0x9xui8>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui8>) -> tensor<0x9xui8>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<0x9xui8>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xui8>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui8>, tensor<0x9xui8>) -> tensor<1x9xui8>
     %14 = stablehlo.constant dense<0> : tensor<ui8>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui8>, tensor<ui8>) -> tensor<2x9xui8>
     %16 = stablehlo.constant dense<0> : tensor<ui8>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui8>, tensor<ui8>) -> tensor<2x9xui8>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui8>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xui8>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui8>, tensor<1x9xui8>) -> tensor<2x9xui8>
     %24 = stablehlo.constant dense<0> : tensor<ui8>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui8>, tensor<ui8>) -> tensor<4x9xui8>
     %26 = stablehlo.constant dense<0> : tensor<ui8>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui8>, tensor<ui8>) -> tensor<4x9xui8>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui8>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<3x9xui8>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<3x9xui8>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui8>) -> tensor<3x9xui8>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<3x9xui8>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xui8>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<1x9xui8>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui8>) -> tensor<1x9xui8>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui8>, tensor<3x9xui8>) -> tensor<4x9xui8>
     %34 = stablehlo.constant dense<0> : tensor<ui8>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui8>, tensor<ui8>) -> tensor<8x9xui8>

--- a/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint8_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumprod_dtype_by_fun_shape_uint8_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui8>
   }
   func.func private @cumprod(%arg0: tensor<8x9xui8>) -> tensor<8x9xui8> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
     %2 = stablehlo.multiply %0, %1 : tensor<4x9xui8>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
     %5 = stablehlo.multiply %3, %4 : tensor<2x9xui8>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
     %8 = stablehlo.multiply %6, %7 : tensor<1x9xui8>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui8>) -> tensor<0x9xui8>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<0x9xui8>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui8>) -> tensor<0x9xui8>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<0x9xui8>
     %11 = stablehlo.multiply %9, %10 : tensor<0x9xui8>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui8>, tensor<0x9xui8>) -> tensor<1x9xui8>
     %14 = stablehlo.constant dense<0> : tensor<ui8>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui8>, tensor<ui8>) -> tensor<2x9xui8>
     %16 = stablehlo.constant dense<0> : tensor<ui8>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui8>, tensor<ui8>) -> tensor<2x9xui8>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui8>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
     %21 = stablehlo.multiply %19, %20 : tensor<1x9xui8>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui8>, tensor<1x9xui8>) -> tensor<2x9xui8>
     %24 = stablehlo.constant dense<0> : tensor<ui8>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui8>, tensor<ui8>) -> tensor<4x9xui8>
     %26 = stablehlo.constant dense<0> : tensor<ui8>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui8>, tensor<ui8>) -> tensor<4x9xui8>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui8>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<3x9xui8>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<3x9xui8>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui8>) -> tensor<3x9xui8>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<3x9xui8>
     %31 = stablehlo.multiply %29, %30 : tensor<3x9xui8>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<1x9xui8>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui8>) -> tensor<1x9xui8>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui8>, tensor<3x9xui8>) -> tensor<4x9xui8>
     %34 = stablehlo.constant dense<0> : tensor<ui8>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui8>, tensor<ui8>) -> tensor<8x9xui8>

--- a/stablehlo/testdata/cumprod_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cumprod_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
@@ -21,39 +21,39 @@ module @jit_testcase {
   }
   func.func private @cumprod(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
     %0 = stablehlo.reverse %arg0, dims = [0] : tensor<8x9xf32>
-    %1 = "stablehlo.slice"(%0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %3 = stablehlo.multiply %1, %2 : tensor<4x9xf32>
-    %4 = "stablehlo.slice"(%3) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %5 = "stablehlo.slice"(%3) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%3) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %5 = "stablehlo.slice"(%3) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %6 = stablehlo.multiply %4, %5 : tensor<2x9xf32>
-    %7 = "stablehlo.slice"(%6) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %8 = "stablehlo.slice"(%6) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%6) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %8 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %9 = stablehlo.multiply %7, %8 : tensor<1x9xf32>
-    %10 = "stablehlo.slice"(%9) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%9) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %12 = stablehlo.multiply %10, %11 : tensor<0x9xf32>
-    %13 = "stablehlo.slice"(%6) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %13 = "stablehlo.slice"(%6) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.concatenate %13, %12, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %15 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %16 = stablehlo.pad %14, %15, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %17 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %18 = stablehlo.pad %9, %17, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %19 = stablehlo.add %16, %18 : tensor<2x9xf32>
-    %20 = "stablehlo.slice"(%19) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %21 = "stablehlo.slice"(%3) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%19) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %21 = "stablehlo.slice"(%3) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %22 = stablehlo.multiply %20, %21 : tensor<1x9xf32>
-    %23 = "stablehlo.slice"(%3) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %23 = "stablehlo.slice"(%3) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %24 = stablehlo.concatenate %23, %22, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %25 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %26 = stablehlo.pad %24, %25, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %27 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %28 = stablehlo.pad %19, %27, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %29 = stablehlo.add %26, %28 : tensor<4x9xf32>
-    %30 = "stablehlo.slice"(%29) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %31 = "stablehlo.slice"(%0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%29) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %31 = "stablehlo.slice"(%0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %32 = stablehlo.multiply %30, %31 : tensor<3x9xf32>
-    %33 = "stablehlo.slice"(%0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %33 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %34 = stablehlo.concatenate %33, %32, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %35 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %36 = stablehlo.pad %34, %35, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumprod_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cumprod_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
@@ -21,39 +21,39 @@ module @jit_testcase {
   }
   func.func private @cumprod(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
     %0 = stablehlo.reverse %arg0, dims = [0] : tensor<8x9xf32>
-    %1 = "stablehlo.slice"(%0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %3 = stablehlo.multiply %1, %2 : tensor<4x9xf32>
-    %4 = "stablehlo.slice"(%3) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %5 = "stablehlo.slice"(%3) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%3) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %5 = "stablehlo.slice"(%3) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %6 = stablehlo.multiply %4, %5 : tensor<2x9xf32>
-    %7 = "stablehlo.slice"(%6) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %8 = "stablehlo.slice"(%6) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%6) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %8 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %9 = stablehlo.multiply %7, %8 : tensor<1x9xf32>
-    %10 = "stablehlo.slice"(%9) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%9) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %12 = stablehlo.multiply %10, %11 : tensor<0x9xf32>
-    %13 = "stablehlo.slice"(%6) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %13 = "stablehlo.slice"(%6) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.concatenate %13, %12, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %15 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %16 = stablehlo.pad %14, %15, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %17 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %18 = stablehlo.pad %9, %17, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %19 = stablehlo.add %16, %18 : tensor<2x9xf32>
-    %20 = "stablehlo.slice"(%19) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %21 = "stablehlo.slice"(%3) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%19) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %21 = "stablehlo.slice"(%3) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %22 = stablehlo.multiply %20, %21 : tensor<1x9xf32>
-    %23 = "stablehlo.slice"(%3) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %23 = "stablehlo.slice"(%3) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %24 = stablehlo.concatenate %23, %22, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %25 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %26 = stablehlo.pad %24, %25, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %27 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %28 = stablehlo.pad %19, %27, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %29 = stablehlo.add %26, %28 : tensor<4x9xf32>
-    %30 = "stablehlo.slice"(%29) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %31 = "stablehlo.slice"(%0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%29) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %31 = "stablehlo.slice"(%0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %32 = stablehlo.multiply %30, %31 : tensor<3x9xf32>
-    %33 = "stablehlo.slice"(%0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %33 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %34 = stablehlo.concatenate %33, %32, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %35 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %36 = stablehlo.pad %34, %35, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumsum_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cumsum(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %2 = stablehlo.add %0, %1 : tensor<4x9xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %5 = stablehlo.add %3, %4 : tensor<2x9xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %8 = stablehlo.add %6, %7 : tensor<1x9xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %11 = stablehlo.add %9, %10 : tensor<0x9xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %21 = stablehlo.add %19, %20 : tensor<1x9xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %31 = stablehlo.add %29, %30 : tensor<3x9xf32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumsum_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_axis_by_fun_shape_float32_8_9__associative_scan_reductions_axis_1_reverse_False.mlir
@@ -20,38 +20,38 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cumsum(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<8> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 8>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
     %2 = stablehlo.add %0, %1 : tensor<8x4xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 3]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 4]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 3>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 4>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
     %5 = stablehlo.add %3, %4 : tensor<8x2xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 2]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 2>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
     %8 = stablehlo.add %6, %7 : tensor<8x1xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[8, 0]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x1xf32>) -> tensor<8x0xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 2]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x0xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 8, 0>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x1xf32>) -> tensor<8x0xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 2>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x0xf32>
     %11 = stablehlo.add %9, %10 : tensor<8x0xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 1 : (tensor<8x1xf32>, tensor<8x0xf32>) -> tensor<8x1xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [0, 1], interior = [0, 1] : (tensor<8x1xf32>, tensor<f32>) -> tensor<8x2xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [0, 1], high = [0, 0], interior = [0, 1] : (tensor<8x1xf32>, tensor<f32>) -> tensor<8x2xf32>
     %18 = stablehlo.add %15, %17 : tensor<8x2xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 4]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 4>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
     %21 = stablehlo.add %19, %20 : tensor<8x1xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 1 : (tensor<8x1xf32>, tensor<8x1xf32>) -> tensor<8x2xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [0, 1], interior = [0, 1] : (tensor<8x2xf32>, tensor<f32>) -> tensor<8x4xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [0, 1], high = [0, 0], interior = [0, 1] : (tensor<8x2xf32>, tensor<f32>) -> tensor<8x4xf32>
     %28 = stablehlo.add %25, %27 : tensor<8x4xf32>
-    %29 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %29 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
     %30 = stablehlo.add %28, %29 : tensor<8x4xf32>
-    %31 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x1xf32>
+    %31 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<8x1xf32>
     %32 = stablehlo.concatenate %31, %30, dim = 1 : (tensor<8x1xf32>, tensor<8x4xf32>) -> tensor<8x5xf32>
     %33 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %34 = stablehlo.pad %32, %33, low = [0, 0], high = [0, 0], interior = [0, 1] : (tensor<8x5xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumsum_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_axis_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cumsum(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %2 = stablehlo.add %0, %1 : tensor<4x9xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %5 = stablehlo.add %3, %4 : tensor<2x9xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %8 = stablehlo.add %6, %7 : tensor<1x9xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %11 = stablehlo.add %9, %10 : tensor<0x9xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %21 = stablehlo.add %19, %20 : tensor<1x9xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %31 = stablehlo.add %29, %30 : tensor<3x9xf32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumsum_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_axis_by_fun_shape_float32_8_9__axis_1_reverse_False.mlir
@@ -20,38 +20,38 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cumsum(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<8> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 8>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
     %2 = stablehlo.add %0, %1 : tensor<8x4xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 3]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 4]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 3>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 4>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x2xf32>
     %5 = stablehlo.add %3, %4 : tensor<8x2xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 2]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 2>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
     %8 = stablehlo.add %6, %7 : tensor<8x1xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[8, 0]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x1xf32>) -> tensor<8x0xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 2]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x0xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 8, 0>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x1xf32>) -> tensor<8x0xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 2>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x2xf32>) -> tensor<8x0xf32>
     %11 = stablehlo.add %9, %10 : tensor<8x0xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 1 : (tensor<8x1xf32>, tensor<8x0xf32>) -> tensor<8x1xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [0, 1], interior = [0, 1] : (tensor<8x1xf32>, tensor<f32>) -> tensor<8x2xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [0, 1], high = [0, 0], interior = [0, 1] : (tensor<8x1xf32>, tensor<f32>) -> tensor<8x2xf32>
     %18 = stablehlo.add %15, %17 : tensor<8x2xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 4]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x2xf32>) -> tensor<8x1xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 4>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
     %21 = stablehlo.add %19, %20 : tensor<8x1xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x4xf32>) -> tensor<8x1xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 1 : (tensor<8x1xf32>, tensor<8x1xf32>) -> tensor<8x2xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [0, 1], interior = [0, 1] : (tensor<8x2xf32>, tensor<f32>) -> tensor<8x4xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [0, 1], high = [0, 0], interior = [0, 1] : (tensor<8x2xf32>, tensor<f32>) -> tensor<8x4xf32>
     %28 = stablehlo.add %25, %27 : tensor<8x4xf32>
-    %29 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[0, 2]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
+    %29 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 0, 2>, strides = array<i64: 1, 2>} : (tensor<8x9xf32>) -> tensor<8x4xf32>
     %30 = stablehlo.add %28, %29 : tensor<8x4xf32>
-    %31 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<8x1xf32>
+    %31 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<8x1xf32>
     %32 = stablehlo.concatenate %31, %30, dim = 1 : (tensor<8x1xf32>, tensor<8x4xf32>) -> tensor<8x5xf32>
     %33 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %34 = stablehlo.pad %32, %33, low = [0, 0], high = [0, 0], interior = [0, 1] : (tensor<8x5xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_bfloat16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_bfloat16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xbf16>
   }
   func.func private @cumsum(%arg0: tensor<8x9xbf16>) -> tensor<8x9xbf16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
     %2 = stablehlo.add %0, %1 : tensor<4x9xbf16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
     %5 = stablehlo.add %3, %4 : tensor<2x9xbf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
     %8 = stablehlo.add %6, %7 : tensor<1x9xbf16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xbf16>) -> tensor<0x9xbf16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<0x9xbf16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xbf16>) -> tensor<0x9xbf16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<0x9xbf16>
     %11 = stablehlo.add %9, %10 : tensor<0x9xbf16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xbf16>, tensor<0x9xbf16>) -> tensor<1x9xbf16>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xbf16>, tensor<bf16>) -> tensor<2x9xbf16>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xbf16>, tensor<bf16>) -> tensor<2x9xbf16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xbf16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
     %21 = stablehlo.add %19, %20 : tensor<1x9xbf16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xbf16>, tensor<1x9xbf16>) -> tensor<2x9xbf16>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xbf16>, tensor<bf16>) -> tensor<4x9xbf16>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xbf16>, tensor<bf16>) -> tensor<4x9xbf16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xbf16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<3x9xbf16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<3x9xbf16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xbf16>) -> tensor<3x9xbf16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<3x9xbf16>
     %31 = stablehlo.add %29, %30 : tensor<3x9xbf16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<1x9xbf16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xbf16>) -> tensor<1x9xbf16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xbf16>, tensor<3x9xbf16>) -> tensor<4x9xbf16>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xbf16>, tensor<bf16>) -> tensor<8x9xbf16>

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_bfloat16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_bfloat16_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xbf16>
   }
   func.func private @cumsum(%arg0: tensor<8x9xbf16>) -> tensor<8x9xbf16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<4x9xbf16>
     %2 = stablehlo.add %0, %1 : tensor<4x9xbf16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<2x9xbf16>
     %5 = stablehlo.add %3, %4 : tensor<2x9xbf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
     %8 = stablehlo.add %6, %7 : tensor<1x9xbf16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xbf16>) -> tensor<0x9xbf16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<0x9xbf16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xbf16>) -> tensor<0x9xbf16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xbf16>) -> tensor<0x9xbf16>
     %11 = stablehlo.add %9, %10 : tensor<0x9xbf16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xbf16>, tensor<0x9xbf16>) -> tensor<1x9xbf16>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xbf16>, tensor<bf16>) -> tensor<2x9xbf16>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xbf16>, tensor<bf16>) -> tensor<2x9xbf16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xbf16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xbf16>) -> tensor<1x9xbf16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
     %21 = stablehlo.add %19, %20 : tensor<1x9xbf16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xbf16>) -> tensor<1x9xbf16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xbf16>, tensor<1x9xbf16>) -> tensor<2x9xbf16>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xbf16>, tensor<bf16>) -> tensor<4x9xbf16>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xbf16>, tensor<bf16>) -> tensor<4x9xbf16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xbf16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xbf16>) -> tensor<3x9xbf16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<3x9xbf16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xbf16>) -> tensor<3x9xbf16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xbf16>) -> tensor<3x9xbf16>
     %31 = stablehlo.add %29, %30 : tensor<3x9xbf16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xbf16>) -> tensor<1x9xbf16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xbf16>) -> tensor<1x9xbf16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xbf16>, tensor<3x9xbf16>) -> tensor<4x9xbf16>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<bf16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xbf16>, tensor<bf16>) -> tensor<8x9xbf16>

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_complex64_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_complex64_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xcomplex<f32>>
   }
   func.func private @cumsum(%arg0: tensor<8x9xcomplex<f32>>) -> tensor<8x9xcomplex<f32>> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
     %2 = stablehlo.add %0, %1 : tensor<4x9xcomplex<f32>>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
     %5 = stablehlo.add %3, %4 : tensor<2x9xcomplex<f32>>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %8 = stablehlo.add %6, %7 : tensor<1x9xcomplex<f32>>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
     %11 = stablehlo.add %9, %10 : tensor<0x9xcomplex<f32>>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<0x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %14 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<2x9xcomplex<f32>>
     %16 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<2x9xcomplex<f32>>
     %18 = stablehlo.add %15, %17 : tensor<2x9xcomplex<f32>>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %21 = stablehlo.add %19, %20 : tensor<1x9xcomplex<f32>>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<1x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
     %24 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<4x9xcomplex<f32>>
     %26 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<4x9xcomplex<f32>>
     %28 = stablehlo.add %25, %27 : tensor<4x9xcomplex<f32>>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
     %31 = stablehlo.add %29, %30 : tensor<3x9xcomplex<f32>>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<3x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
     %34 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<8x9xcomplex<f32>>

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_complex64_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_complex64_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xcomplex<f32>>
   }
   func.func private @cumsum(%arg0: tensor<8x9xcomplex<f32>>) -> tensor<8x9xcomplex<f32>> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
     %2 = stablehlo.add %0, %1 : tensor<4x9xcomplex<f32>>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
     %5 = stablehlo.add %3, %4 : tensor<2x9xcomplex<f32>>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %8 = stablehlo.add %6, %7 : tensor<1x9xcomplex<f32>>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<0x9xcomplex<f32>>
     %11 = stablehlo.add %9, %10 : tensor<0x9xcomplex<f32>>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<0x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %14 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<2x9xcomplex<f32>>
     %16 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<2x9xcomplex<f32>>
     %18 = stablehlo.add %15, %17 : tensor<2x9xcomplex<f32>>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %21 = stablehlo.add %19, %20 : tensor<1x9xcomplex<f32>>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<1x9xcomplex<f32>>) -> tensor<2x9xcomplex<f32>>
     %24 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<4x9xcomplex<f32>>
     %26 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<4x9xcomplex<f32>>
     %28 = stablehlo.add %25, %27 : tensor<4x9xcomplex<f32>>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
     %31 = stablehlo.add %29, %30 : tensor<3x9xcomplex<f32>>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xcomplex<f32>>) -> tensor<1x9xcomplex<f32>>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xcomplex<f32>>, tensor<3x9xcomplex<f32>>) -> tensor<4x9xcomplex<f32>>
     %34 = stablehlo.constant dense<(0.000000e+00,0.000000e+00)> : tensor<complex<f32>>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xcomplex<f32>>, tensor<complex<f32>>) -> tensor<8x9xcomplex<f32>>

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_float16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf16>
   }
   func.func private @cumsum(%arg0: tensor<8x9xf16>) -> tensor<8x9xf16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
     %2 = stablehlo.add %0, %1 : tensor<4x9xf16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
     %5 = stablehlo.add %3, %4 : tensor<2x9xf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
     %8 = stablehlo.add %6, %7 : tensor<1x9xf16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf16>) -> tensor<0x9xf16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<0x9xf16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf16>) -> tensor<0x9xf16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<0x9xf16>
     %11 = stablehlo.add %9, %10 : tensor<0x9xf16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf16>, tensor<0x9xf16>) -> tensor<1x9xf16>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf16>, tensor<f16>) -> tensor<2x9xf16>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf16>, tensor<f16>) -> tensor<2x9xf16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
     %21 = stablehlo.add %19, %20 : tensor<1x9xf16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf16>, tensor<1x9xf16>) -> tensor<2x9xf16>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf16>, tensor<f16>) -> tensor<4x9xf16>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf16>, tensor<f16>) -> tensor<4x9xf16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<3x9xf16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<3x9xf16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf16>) -> tensor<3x9xf16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<3x9xf16>
     %31 = stablehlo.add %29, %30 : tensor<3x9xf16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<1x9xf16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf16>) -> tensor<1x9xf16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf16>, tensor<3x9xf16>) -> tensor<4x9xf16>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf16>, tensor<f16>) -> tensor<8x9xf16>

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_float16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_float16_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf16>
   }
   func.func private @cumsum(%arg0: tensor<8x9xf16>) -> tensor<8x9xf16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<4x9xf16>
     %2 = stablehlo.add %0, %1 : tensor<4x9xf16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<2x9xf16>
     %5 = stablehlo.add %3, %4 : tensor<2x9xf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
     %8 = stablehlo.add %6, %7 : tensor<1x9xf16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf16>) -> tensor<0x9xf16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<0x9xf16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf16>) -> tensor<0x9xf16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf16>) -> tensor<0x9xf16>
     %11 = stablehlo.add %9, %10 : tensor<0x9xf16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf16>, tensor<0x9xf16>) -> tensor<1x9xf16>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf16>, tensor<f16>) -> tensor<2x9xf16>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf16>, tensor<f16>) -> tensor<2x9xf16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf16>) -> tensor<1x9xf16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
     %21 = stablehlo.add %19, %20 : tensor<1x9xf16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf16>) -> tensor<1x9xf16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf16>, tensor<1x9xf16>) -> tensor<2x9xf16>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf16>, tensor<f16>) -> tensor<4x9xf16>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf16>, tensor<f16>) -> tensor<4x9xf16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf16>) -> tensor<3x9xf16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<3x9xf16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf16>) -> tensor<3x9xf16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf16>) -> tensor<3x9xf16>
     %31 = stablehlo.add %29, %30 : tensor<3x9xf16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf16>) -> tensor<1x9xf16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf16>) -> tensor<1x9xf16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf16>, tensor<3x9xf16>) -> tensor<4x9xf16>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf16>, tensor<f16>) -> tensor<8x9xf16>

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cumsum(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %2 = stablehlo.add %0, %1 : tensor<4x9xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %5 = stablehlo.add %3, %4 : tensor<2x9xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %8 = stablehlo.add %6, %7 : tensor<1x9xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %11 = stablehlo.add %9, %10 : tensor<0x9xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %21 = stablehlo.add %19, %20 : tensor<1x9xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %31 = stablehlo.add %29, %30 : tensor<3x9xf32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_float32_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xf32>
   }
   func.func private @cumsum(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %2 = stablehlo.add %0, %1 : tensor<4x9xf32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %5 = stablehlo.add %3, %4 : tensor<2x9xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %8 = stablehlo.add %6, %7 : tensor<1x9xf32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %11 = stablehlo.add %9, %10 : tensor<0x9xf32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %16 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xf32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %21 = stablehlo.add %19, %20 : tensor<1x9xf32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %24 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %26 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xf32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %31 = stablehlo.add %29, %30 : tensor<3x9xf32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %34 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_int16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_int16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi16>
   }
   func.func private @cumsum(%arg0: tensor<8x9xi16>) -> tensor<8x9xi16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
     %2 = stablehlo.add %0, %1 : tensor<4x9xi16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
     %5 = stablehlo.add %3, %4 : tensor<2x9xi16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
     %8 = stablehlo.add %6, %7 : tensor<1x9xi16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi16>) -> tensor<0x9xi16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<0x9xi16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi16>) -> tensor<0x9xi16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<0x9xi16>
     %11 = stablehlo.add %9, %10 : tensor<0x9xi16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi16>, tensor<0x9xi16>) -> tensor<1x9xi16>
     %14 = stablehlo.constant dense<0> : tensor<i16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi16>, tensor<i16>) -> tensor<2x9xi16>
     %16 = stablehlo.constant dense<0> : tensor<i16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi16>, tensor<i16>) -> tensor<2x9xi16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
     %21 = stablehlo.add %19, %20 : tensor<1x9xi16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi16>, tensor<1x9xi16>) -> tensor<2x9xi16>
     %24 = stablehlo.constant dense<0> : tensor<i16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi16>, tensor<i16>) -> tensor<4x9xi16>
     %26 = stablehlo.constant dense<0> : tensor<i16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi16>, tensor<i16>) -> tensor<4x9xi16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<3x9xi16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<3x9xi16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi16>) -> tensor<3x9xi16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<3x9xi16>
     %31 = stablehlo.add %29, %30 : tensor<3x9xi16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<1x9xi16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi16>) -> tensor<1x9xi16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi16>, tensor<3x9xi16>) -> tensor<4x9xi16>
     %34 = stablehlo.constant dense<0> : tensor<i16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi16>, tensor<i16>) -> tensor<8x9xi16>

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_int16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_int16_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi16>
   }
   func.func private @cumsum(%arg0: tensor<8x9xi16>) -> tensor<8x9xi16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<4x9xi16>
     %2 = stablehlo.add %0, %1 : tensor<4x9xi16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<2x9xi16>
     %5 = stablehlo.add %3, %4 : tensor<2x9xi16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
     %8 = stablehlo.add %6, %7 : tensor<1x9xi16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi16>) -> tensor<0x9xi16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<0x9xi16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi16>) -> tensor<0x9xi16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi16>) -> tensor<0x9xi16>
     %11 = stablehlo.add %9, %10 : tensor<0x9xi16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi16>, tensor<0x9xi16>) -> tensor<1x9xi16>
     %14 = stablehlo.constant dense<0> : tensor<i16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi16>, tensor<i16>) -> tensor<2x9xi16>
     %16 = stablehlo.constant dense<0> : tensor<i16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi16>, tensor<i16>) -> tensor<2x9xi16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi16>) -> tensor<1x9xi16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
     %21 = stablehlo.add %19, %20 : tensor<1x9xi16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi16>) -> tensor<1x9xi16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi16>, tensor<1x9xi16>) -> tensor<2x9xi16>
     %24 = stablehlo.constant dense<0> : tensor<i16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi16>, tensor<i16>) -> tensor<4x9xi16>
     %26 = stablehlo.constant dense<0> : tensor<i16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi16>, tensor<i16>) -> tensor<4x9xi16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi16>) -> tensor<3x9xi16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<3x9xi16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi16>) -> tensor<3x9xi16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi16>) -> tensor<3x9xi16>
     %31 = stablehlo.add %29, %30 : tensor<3x9xi16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi16>) -> tensor<1x9xi16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi16>) -> tensor<1x9xi16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi16>, tensor<3x9xi16>) -> tensor<4x9xi16>
     %34 = stablehlo.constant dense<0> : tensor<i16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi16>, tensor<i16>) -> tensor<8x9xi16>

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_int32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_int32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi32>
   }
   func.func private @cumsum(%arg0: tensor<8x9xi32>) -> tensor<8x9xi32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
     %2 = stablehlo.add %0, %1 : tensor<4x9xi32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
     %5 = stablehlo.add %3, %4 : tensor<2x9xi32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
     %8 = stablehlo.add %6, %7 : tensor<1x9xi32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi32>) -> tensor<0x9xi32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<0x9xi32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi32>) -> tensor<0x9xi32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<0x9xi32>
     %11 = stablehlo.add %9, %10 : tensor<0x9xi32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi32>, tensor<0x9xi32>) -> tensor<1x9xi32>
     %14 = stablehlo.constant dense<0> : tensor<i32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi32>, tensor<i32>) -> tensor<2x9xi32>
     %16 = stablehlo.constant dense<0> : tensor<i32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi32>, tensor<i32>) -> tensor<2x9xi32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
     %21 = stablehlo.add %19, %20 : tensor<1x9xi32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi32>, tensor<1x9xi32>) -> tensor<2x9xi32>
     %24 = stablehlo.constant dense<0> : tensor<i32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi32>, tensor<i32>) -> tensor<4x9xi32>
     %26 = stablehlo.constant dense<0> : tensor<i32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi32>, tensor<i32>) -> tensor<4x9xi32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<3x9xi32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<3x9xi32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi32>) -> tensor<3x9xi32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<3x9xi32>
     %31 = stablehlo.add %29, %30 : tensor<3x9xi32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<1x9xi32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi32>) -> tensor<1x9xi32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi32>, tensor<3x9xi32>) -> tensor<4x9xi32>
     %34 = stablehlo.constant dense<0> : tensor<i32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi32>, tensor<i32>) -> tensor<8x9xi32>

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_int32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_int32_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi32>
   }
   func.func private @cumsum(%arg0: tensor<8x9xi32>) -> tensor<8x9xi32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<4x9xi32>
     %2 = stablehlo.add %0, %1 : tensor<4x9xi32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<2x9xi32>
     %5 = stablehlo.add %3, %4 : tensor<2x9xi32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
     %8 = stablehlo.add %6, %7 : tensor<1x9xi32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi32>) -> tensor<0x9xi32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<0x9xi32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi32>) -> tensor<0x9xi32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi32>) -> tensor<0x9xi32>
     %11 = stablehlo.add %9, %10 : tensor<0x9xi32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi32>, tensor<0x9xi32>) -> tensor<1x9xi32>
     %14 = stablehlo.constant dense<0> : tensor<i32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi32>, tensor<i32>) -> tensor<2x9xi32>
     %16 = stablehlo.constant dense<0> : tensor<i32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi32>, tensor<i32>) -> tensor<2x9xi32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi32>) -> tensor<1x9xi32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
     %21 = stablehlo.add %19, %20 : tensor<1x9xi32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi32>) -> tensor<1x9xi32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi32>, tensor<1x9xi32>) -> tensor<2x9xi32>
     %24 = stablehlo.constant dense<0> : tensor<i32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi32>, tensor<i32>) -> tensor<4x9xi32>
     %26 = stablehlo.constant dense<0> : tensor<i32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi32>, tensor<i32>) -> tensor<4x9xi32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi32>) -> tensor<3x9xi32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<3x9xi32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi32>) -> tensor<3x9xi32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi32>) -> tensor<3x9xi32>
     %31 = stablehlo.add %29, %30 : tensor<3x9xi32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi32>) -> tensor<1x9xi32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi32>) -> tensor<1x9xi32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi32>, tensor<3x9xi32>) -> tensor<4x9xi32>
     %34 = stablehlo.constant dense<0> : tensor<i32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi32>, tensor<i32>) -> tensor<8x9xi32>

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_int8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_int8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi8>
   }
   func.func private @cumsum(%arg0: tensor<8x9xi8>) -> tensor<8x9xi8> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
     %2 = stablehlo.add %0, %1 : tensor<4x9xi8>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
     %5 = stablehlo.add %3, %4 : tensor<2x9xi8>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
     %8 = stablehlo.add %6, %7 : tensor<1x9xi8>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi8>) -> tensor<0x9xi8>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<0x9xi8>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi8>) -> tensor<0x9xi8>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<0x9xi8>
     %11 = stablehlo.add %9, %10 : tensor<0x9xi8>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi8>, tensor<0x9xi8>) -> tensor<1x9xi8>
     %14 = stablehlo.constant dense<0> : tensor<i8>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi8>, tensor<i8>) -> tensor<2x9xi8>
     %16 = stablehlo.constant dense<0> : tensor<i8>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi8>, tensor<i8>) -> tensor<2x9xi8>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi8>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
     %21 = stablehlo.add %19, %20 : tensor<1x9xi8>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi8>, tensor<1x9xi8>) -> tensor<2x9xi8>
     %24 = stablehlo.constant dense<0> : tensor<i8>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi8>, tensor<i8>) -> tensor<4x9xi8>
     %26 = stablehlo.constant dense<0> : tensor<i8>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi8>, tensor<i8>) -> tensor<4x9xi8>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi8>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<3x9xi8>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<3x9xi8>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi8>) -> tensor<3x9xi8>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<3x9xi8>
     %31 = stablehlo.add %29, %30 : tensor<3x9xi8>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<1x9xi8>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi8>) -> tensor<1x9xi8>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi8>, tensor<3x9xi8>) -> tensor<4x9xi8>
     %34 = stablehlo.constant dense<0> : tensor<i8>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi8>, tensor<i8>) -> tensor<8x9xi8>

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_int8_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_int8_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xi8>
   }
   func.func private @cumsum(%arg0: tensor<8x9xi8>) -> tensor<8x9xi8> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<4x9xi8>
     %2 = stablehlo.add %0, %1 : tensor<4x9xi8>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<2x9xi8>
     %5 = stablehlo.add %3, %4 : tensor<2x9xi8>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
     %8 = stablehlo.add %6, %7 : tensor<1x9xi8>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xi8>) -> tensor<0x9xi8>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<0x9xi8>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xi8>) -> tensor<0x9xi8>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xi8>) -> tensor<0x9xi8>
     %11 = stablehlo.add %9, %10 : tensor<0x9xi8>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xi8>, tensor<0x9xi8>) -> tensor<1x9xi8>
     %14 = stablehlo.constant dense<0> : tensor<i8>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xi8>, tensor<i8>) -> tensor<2x9xi8>
     %16 = stablehlo.constant dense<0> : tensor<i8>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xi8>, tensor<i8>) -> tensor<2x9xi8>
     %18 = stablehlo.add %15, %17 : tensor<2x9xi8>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xi8>) -> tensor<1x9xi8>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
     %21 = stablehlo.add %19, %20 : tensor<1x9xi8>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi8>) -> tensor<1x9xi8>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xi8>, tensor<1x9xi8>) -> tensor<2x9xi8>
     %24 = stablehlo.constant dense<0> : tensor<i8>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xi8>, tensor<i8>) -> tensor<4x9xi8>
     %26 = stablehlo.constant dense<0> : tensor<i8>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xi8>, tensor<i8>) -> tensor<4x9xi8>
     %28 = stablehlo.add %25, %27 : tensor<4x9xi8>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xi8>) -> tensor<3x9xi8>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<3x9xi8>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xi8>) -> tensor<3x9xi8>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xi8>) -> tensor<3x9xi8>
     %31 = stablehlo.add %29, %30 : tensor<3x9xi8>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xi8>) -> tensor<1x9xi8>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xi8>) -> tensor<1x9xi8>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xi8>, tensor<3x9xi8>) -> tensor<4x9xi8>
     %34 = stablehlo.constant dense<0> : tensor<i8>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xi8>, tensor<i8>) -> tensor<8x9xi8>

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint16_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui16>
   }
   func.func private @cumsum(%arg0: tensor<8x9xui16>) -> tensor<8x9xui16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
     %2 = stablehlo.add %0, %1 : tensor<4x9xui16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
     %5 = stablehlo.add %3, %4 : tensor<2x9xui16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
     %8 = stablehlo.add %6, %7 : tensor<1x9xui16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui16>) -> tensor<0x9xui16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<0x9xui16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui16>) -> tensor<0x9xui16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<0x9xui16>
     %11 = stablehlo.add %9, %10 : tensor<0x9xui16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui16>, tensor<0x9xui16>) -> tensor<1x9xui16>
     %14 = stablehlo.constant dense<0> : tensor<ui16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui16>, tensor<ui16>) -> tensor<2x9xui16>
     %16 = stablehlo.constant dense<0> : tensor<ui16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui16>, tensor<ui16>) -> tensor<2x9xui16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
     %21 = stablehlo.add %19, %20 : tensor<1x9xui16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui16>, tensor<1x9xui16>) -> tensor<2x9xui16>
     %24 = stablehlo.constant dense<0> : tensor<ui16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui16>, tensor<ui16>) -> tensor<4x9xui16>
     %26 = stablehlo.constant dense<0> : tensor<ui16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui16>, tensor<ui16>) -> tensor<4x9xui16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<3x9xui16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<3x9xui16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui16>) -> tensor<3x9xui16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<3x9xui16>
     %31 = stablehlo.add %29, %30 : tensor<3x9xui16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<1x9xui16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui16>) -> tensor<1x9xui16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui16>, tensor<3x9xui16>) -> tensor<4x9xui16>
     %34 = stablehlo.constant dense<0> : tensor<ui16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui16>, tensor<ui16>) -> tensor<8x9xui16>

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint16_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint16_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui16>
   }
   func.func private @cumsum(%arg0: tensor<8x9xui16>) -> tensor<8x9xui16> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<4x9xui16>
     %2 = stablehlo.add %0, %1 : tensor<4x9xui16>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<2x9xui16>
     %5 = stablehlo.add %3, %4 : tensor<2x9xui16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
     %8 = stablehlo.add %6, %7 : tensor<1x9xui16>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui16>) -> tensor<0x9xui16>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<0x9xui16>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui16>) -> tensor<0x9xui16>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui16>) -> tensor<0x9xui16>
     %11 = stablehlo.add %9, %10 : tensor<0x9xui16>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui16>, tensor<0x9xui16>) -> tensor<1x9xui16>
     %14 = stablehlo.constant dense<0> : tensor<ui16>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui16>, tensor<ui16>) -> tensor<2x9xui16>
     %16 = stablehlo.constant dense<0> : tensor<ui16>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui16>, tensor<ui16>) -> tensor<2x9xui16>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui16>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui16>) -> tensor<1x9xui16>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
     %21 = stablehlo.add %19, %20 : tensor<1x9xui16>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui16>) -> tensor<1x9xui16>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui16>, tensor<1x9xui16>) -> tensor<2x9xui16>
     %24 = stablehlo.constant dense<0> : tensor<ui16>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui16>, tensor<ui16>) -> tensor<4x9xui16>
     %26 = stablehlo.constant dense<0> : tensor<ui16>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui16>, tensor<ui16>) -> tensor<4x9xui16>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui16>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui16>) -> tensor<3x9xui16>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<3x9xui16>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui16>) -> tensor<3x9xui16>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui16>) -> tensor<3x9xui16>
     %31 = stablehlo.add %29, %30 : tensor<3x9xui16>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui16>) -> tensor<1x9xui16>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui16>) -> tensor<1x9xui16>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui16>, tensor<3x9xui16>) -> tensor<4x9xui16>
     %34 = stablehlo.constant dense<0> : tensor<ui16>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui16>, tensor<ui16>) -> tensor<8x9xui16>

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint32_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui32>
   }
   func.func private @cumsum(%arg0: tensor<8x9xui32>) -> tensor<8x9xui32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
     %2 = stablehlo.add %0, %1 : tensor<4x9xui32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
     %5 = stablehlo.add %3, %4 : tensor<2x9xui32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
     %8 = stablehlo.add %6, %7 : tensor<1x9xui32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui32>) -> tensor<0x9xui32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<0x9xui32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui32>) -> tensor<0x9xui32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<0x9xui32>
     %11 = stablehlo.add %9, %10 : tensor<0x9xui32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui32>, tensor<0x9xui32>) -> tensor<1x9xui32>
     %14 = stablehlo.constant dense<0> : tensor<ui32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui32>, tensor<ui32>) -> tensor<2x9xui32>
     %16 = stablehlo.constant dense<0> : tensor<ui32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui32>, tensor<ui32>) -> tensor<2x9xui32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
     %21 = stablehlo.add %19, %20 : tensor<1x9xui32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui32>, tensor<1x9xui32>) -> tensor<2x9xui32>
     %24 = stablehlo.constant dense<0> : tensor<ui32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui32>, tensor<ui32>) -> tensor<4x9xui32>
     %26 = stablehlo.constant dense<0> : tensor<ui32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui32>, tensor<ui32>) -> tensor<4x9xui32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<3x9xui32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<3x9xui32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui32>) -> tensor<3x9xui32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<3x9xui32>
     %31 = stablehlo.add %29, %30 : tensor<3x9xui32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<1x9xui32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui32>) -> tensor<1x9xui32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui32>, tensor<3x9xui32>) -> tensor<4x9xui32>
     %34 = stablehlo.constant dense<0> : tensor<ui32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui32>, tensor<ui32>) -> tensor<8x9xui32>

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint32_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint32_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui32>
   }
   func.func private @cumsum(%arg0: tensor<8x9xui32>) -> tensor<8x9xui32> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<4x9xui32>
     %2 = stablehlo.add %0, %1 : tensor<4x9xui32>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<2x9xui32>
     %5 = stablehlo.add %3, %4 : tensor<2x9xui32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
     %8 = stablehlo.add %6, %7 : tensor<1x9xui32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui32>) -> tensor<0x9xui32>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<0x9xui32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui32>) -> tensor<0x9xui32>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui32>) -> tensor<0x9xui32>
     %11 = stablehlo.add %9, %10 : tensor<0x9xui32>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui32>, tensor<0x9xui32>) -> tensor<1x9xui32>
     %14 = stablehlo.constant dense<0> : tensor<ui32>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui32>, tensor<ui32>) -> tensor<2x9xui32>
     %16 = stablehlo.constant dense<0> : tensor<ui32>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui32>, tensor<ui32>) -> tensor<2x9xui32>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui32>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui32>) -> tensor<1x9xui32>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
     %21 = stablehlo.add %19, %20 : tensor<1x9xui32>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui32>) -> tensor<1x9xui32>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui32>, tensor<1x9xui32>) -> tensor<2x9xui32>
     %24 = stablehlo.constant dense<0> : tensor<ui32>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui32>, tensor<ui32>) -> tensor<4x9xui32>
     %26 = stablehlo.constant dense<0> : tensor<ui32>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui32>, tensor<ui32>) -> tensor<4x9xui32>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui32>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui32>) -> tensor<3x9xui32>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<3x9xui32>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui32>) -> tensor<3x9xui32>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui32>) -> tensor<3x9xui32>
     %31 = stablehlo.add %29, %30 : tensor<3x9xui32>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui32>) -> tensor<1x9xui32>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui32>) -> tensor<1x9xui32>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui32>, tensor<3x9xui32>) -> tensor<4x9xui32>
     %34 = stablehlo.constant dense<0> : tensor<ui32>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui32>, tensor<ui32>) -> tensor<8x9xui32>

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint8_8_9__associative_scan_reductions_axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui8>
   }
   func.func private @cumsum(%arg0: tensor<8x9xui8>) -> tensor<8x9xui8> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
     %2 = stablehlo.add %0, %1 : tensor<4x9xui8>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
     %5 = stablehlo.add %3, %4 : tensor<2x9xui8>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
     %8 = stablehlo.add %6, %7 : tensor<1x9xui8>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui8>) -> tensor<0x9xui8>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<0x9xui8>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui8>) -> tensor<0x9xui8>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<0x9xui8>
     %11 = stablehlo.add %9, %10 : tensor<0x9xui8>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui8>, tensor<0x9xui8>) -> tensor<1x9xui8>
     %14 = stablehlo.constant dense<0> : tensor<ui8>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui8>, tensor<ui8>) -> tensor<2x9xui8>
     %16 = stablehlo.constant dense<0> : tensor<ui8>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui8>, tensor<ui8>) -> tensor<2x9xui8>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui8>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
     %21 = stablehlo.add %19, %20 : tensor<1x9xui8>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui8>, tensor<1x9xui8>) -> tensor<2x9xui8>
     %24 = stablehlo.constant dense<0> : tensor<ui8>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui8>, tensor<ui8>) -> tensor<4x9xui8>
     %26 = stablehlo.constant dense<0> : tensor<ui8>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui8>, tensor<ui8>) -> tensor<4x9xui8>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui8>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<3x9xui8>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<3x9xui8>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui8>) -> tensor<3x9xui8>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<3x9xui8>
     %31 = stablehlo.add %29, %30 : tensor<3x9xui8>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<1x9xui8>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui8>) -> tensor<1x9xui8>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui8>, tensor<3x9xui8>) -> tensor<4x9xui8>
     %34 = stablehlo.constant dense<0> : tensor<ui8>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui8>, tensor<ui8>) -> tensor<8x9xui8>

--- a/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint8_8_9__axis_0_reverse_False.mlir
+++ b/stablehlo/testdata/cumsum_dtype_by_fun_shape_uint8_8_9__axis_0_reverse_False.mlir
@@ -20,39 +20,39 @@ module @jit_testcase {
     return %0 : tensor<8x9xui8>
   }
   func.func private @cumsum(%arg0: tensor<8x9xui8>) -> tensor<8x9xui8> {
-    %0 = "stablehlo.slice"(%arg0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
+    %0 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<4x9xui8>
     %2 = stablehlo.add %0, %1 : tensor<4x9xui8>
-    %3 = "stablehlo.slice"(%2) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
-    %4 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
+    %3 = "stablehlo.slice"(%2) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
+    %4 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<2x9xui8>
     %5 = stablehlo.add %3, %4 : tensor<2x9xui8>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
-    %7 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %7 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
     %8 = stablehlo.add %6, %7 : tensor<1x9xui8>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xui8>) -> tensor<0x9xui8>
-    %10 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<0x9xui8>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xui8>) -> tensor<0x9xui8>
+    %10 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xui8>) -> tensor<0x9xui8>
     %11 = stablehlo.add %9, %10 : tensor<0x9xui8>
-    %12 = "stablehlo.slice"(%5) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %12 = "stablehlo.slice"(%5) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
     %13 = stablehlo.concatenate %12, %11, dim = 0 : (tensor<1x9xui8>, tensor<0x9xui8>) -> tensor<1x9xui8>
     %14 = stablehlo.constant dense<0> : tensor<ui8>
     %15 = stablehlo.pad %13, %14, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xui8>, tensor<ui8>) -> tensor<2x9xui8>
     %16 = stablehlo.constant dense<0> : tensor<ui8>
     %17 = stablehlo.pad %8, %16, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xui8>, tensor<ui8>) -> tensor<2x9xui8>
     %18 = stablehlo.add %15, %17 : tensor<2x9xui8>
-    %19 = "stablehlo.slice"(%18) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
-    %20 = "stablehlo.slice"(%2) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
+    %19 = "stablehlo.slice"(%18) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xui8>) -> tensor<1x9xui8>
+    %20 = "stablehlo.slice"(%2) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
     %21 = stablehlo.add %19, %20 : tensor<1x9xui8>
-    %22 = "stablehlo.slice"(%2) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
+    %22 = "stablehlo.slice"(%2) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui8>) -> tensor<1x9xui8>
     %23 = stablehlo.concatenate %22, %21, dim = 0 : (tensor<1x9xui8>, tensor<1x9xui8>) -> tensor<2x9xui8>
     %24 = stablehlo.constant dense<0> : tensor<ui8>
     %25 = stablehlo.pad %23, %24, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xui8>, tensor<ui8>) -> tensor<4x9xui8>
     %26 = stablehlo.constant dense<0> : tensor<ui8>
     %27 = stablehlo.pad %18, %26, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xui8>, tensor<ui8>) -> tensor<4x9xui8>
     %28 = stablehlo.add %25, %27 : tensor<4x9xui8>
-    %29 = "stablehlo.slice"(%28) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xui8>) -> tensor<3x9xui8>
-    %30 = "stablehlo.slice"(%arg0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<3x9xui8>
+    %29 = "stablehlo.slice"(%28) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xui8>) -> tensor<3x9xui8>
+    %30 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xui8>) -> tensor<3x9xui8>
     %31 = stablehlo.add %29, %30 : tensor<3x9xui8>
-    %32 = "stablehlo.slice"(%arg0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xui8>) -> tensor<1x9xui8>
+    %32 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xui8>) -> tensor<1x9xui8>
     %33 = stablehlo.concatenate %32, %31, dim = 0 : (tensor<1x9xui8>, tensor<3x9xui8>) -> tensor<4x9xui8>
     %34 = stablehlo.constant dense<0> : tensor<ui8>
     %35 = stablehlo.pad %33, %34, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xui8>, tensor<ui8>) -> tensor<8x9xui8>

--- a/stablehlo/testdata/cumsum_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cumsum_reverse_shape_float32_8_9__associative_scan_reductions_axis_0_reverse_True.mlir
@@ -21,39 +21,39 @@ module @jit_testcase {
   }
   func.func private @cumsum(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
     %0 = stablehlo.reverse %arg0, dims = [0] : tensor<8x9xf32>
-    %1 = "stablehlo.slice"(%0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %3 = stablehlo.add %1, %2 : tensor<4x9xf32>
-    %4 = "stablehlo.slice"(%3) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %5 = "stablehlo.slice"(%3) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%3) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %5 = "stablehlo.slice"(%3) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %6 = stablehlo.add %4, %5 : tensor<2x9xf32>
-    %7 = "stablehlo.slice"(%6) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %8 = "stablehlo.slice"(%6) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%6) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %8 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %9 = stablehlo.add %7, %8 : tensor<1x9xf32>
-    %10 = "stablehlo.slice"(%9) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%9) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %12 = stablehlo.add %10, %11 : tensor<0x9xf32>
-    %13 = "stablehlo.slice"(%6) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %13 = "stablehlo.slice"(%6) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.concatenate %13, %12, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %15 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %16 = stablehlo.pad %14, %15, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %17 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %18 = stablehlo.pad %9, %17, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %19 = stablehlo.add %16, %18 : tensor<2x9xf32>
-    %20 = "stablehlo.slice"(%19) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %21 = "stablehlo.slice"(%3) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%19) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %21 = "stablehlo.slice"(%3) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %22 = stablehlo.add %20, %21 : tensor<1x9xf32>
-    %23 = "stablehlo.slice"(%3) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %23 = "stablehlo.slice"(%3) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %24 = stablehlo.concatenate %23, %22, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %25 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %26 = stablehlo.pad %24, %25, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %27 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %28 = stablehlo.pad %19, %27, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %29 = stablehlo.add %26, %28 : tensor<4x9xf32>
-    %30 = "stablehlo.slice"(%29) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %31 = "stablehlo.slice"(%0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%29) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %31 = "stablehlo.slice"(%0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %32 = stablehlo.add %30, %31 : tensor<3x9xf32>
-    %33 = "stablehlo.slice"(%0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %33 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %34 = stablehlo.concatenate %33, %32, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %35 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %36 = stablehlo.pad %34, %35, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/cumsum_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
+++ b/stablehlo/testdata/cumsum_reverse_shape_float32_8_9__axis_0_reverse_True.mlir
@@ -21,39 +21,39 @@ module @jit_testcase {
   }
   func.func private @cumsum(%arg0: tensor<8x9xf32>) -> tensor<8x9xf32> {
     %0 = stablehlo.reverse %arg0, dims = [0] : tensor<8x9xf32>
-    %1 = "stablehlo.slice"(%0) {limit_indices = dense<[7, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %1 = "stablehlo.slice"(%0) {limit_indices = array<i64: 7, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<4x9xf32>
     %3 = stablehlo.add %1, %2 : tensor<4x9xf32>
-    %4 = "stablehlo.slice"(%3) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
-    %5 = "stablehlo.slice"(%3) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %4 = "stablehlo.slice"(%3) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
+    %5 = "stablehlo.slice"(%3) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<2x9xf32>
     %6 = stablehlo.add %4, %5 : tensor<2x9xf32>
-    %7 = "stablehlo.slice"(%6) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %8 = "stablehlo.slice"(%6) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %7 = "stablehlo.slice"(%6) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %8 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 1, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %9 = stablehlo.add %7, %8 : tensor<1x9xf32>
-    %10 = "stablehlo.slice"(%9) {limit_indices = dense<[0, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<[2, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
+    %10 = "stablehlo.slice"(%9) {limit_indices = array<i64: 0, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x9xf32>) -> tensor<0x9xf32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<2x9xf32>) -> tensor<0x9xf32>
     %12 = stablehlo.add %10, %11 : tensor<0x9xf32>
-    %13 = "stablehlo.slice"(%6) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %13 = "stablehlo.slice"(%6) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
     %14 = stablehlo.concatenate %13, %12, dim = 0 : (tensor<1x9xf32>, tensor<0x9xf32>) -> tensor<1x9xf32>
     %15 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %16 = stablehlo.pad %14, %15, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %17 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %18 = stablehlo.pad %9, %17, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<1x9xf32>, tensor<f32>) -> tensor<2x9xf32>
     %19 = stablehlo.add %16, %18 : tensor<2x9xf32>
-    %20 = "stablehlo.slice"(%19) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
-    %21 = "stablehlo.slice"(%3) {limit_indices = dense<[4, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %20 = "stablehlo.slice"(%19) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x9xf32>) -> tensor<1x9xf32>
+    %21 = "stablehlo.slice"(%3) {limit_indices = array<i64: 4, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %22 = stablehlo.add %20, %21 : tensor<1x9xf32>
-    %23 = "stablehlo.slice"(%3) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
+    %23 = "stablehlo.slice"(%3) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<1x9xf32>
     %24 = stablehlo.concatenate %23, %22, dim = 0 : (tensor<1x9xf32>, tensor<1x9xf32>) -> tensor<2x9xf32>
     %25 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %26 = stablehlo.pad %24, %25, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %27 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %28 = stablehlo.pad %19, %27, low = [1, 0], high = [0, 0], interior = [1, 0] : (tensor<2x9xf32>, tensor<f32>) -> tensor<4x9xf32>
     %29 = stablehlo.add %26, %28 : tensor<4x9xf32>
-    %30 = "stablehlo.slice"(%29) {limit_indices = dense<[3, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
-    %31 = "stablehlo.slice"(%0) {limit_indices = dense<[8, 9]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
+    %30 = "stablehlo.slice"(%29) {limit_indices = array<i64: 3, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<4x9xf32>) -> tensor<3x9xf32>
+    %31 = "stablehlo.slice"(%0) {limit_indices = array<i64: 8, 9>, start_indices = array<i64: 2, 0>, strides = array<i64: 2, 1>} : (tensor<8x9xf32>) -> tensor<3x9xf32>
     %32 = stablehlo.add %30, %31 : tensor<3x9xf32>
-    %33 = "stablehlo.slice"(%0) {limit_indices = dense<[1, 9]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
+    %33 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1, 9>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<8x9xf32>) -> tensor<1x9xf32>
     %34 = stablehlo.concatenate %33, %32, dim = 0 : (tensor<1x9xf32>, tensor<3x9xf32>) -> tensor<4x9xf32>
     %35 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %36 = stablehlo.pad %34, %35, low = [0, 0], high = [1, 0], interior = [1, 0] : (tensor<4x9xf32>, tensor<f32>) -> tensor<8x9xf32>

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_bfloat16_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_bfloat16_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<3xbf16>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<1xbf16>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_bool_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_bool_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<3xi1>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<1xi1>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_complex64_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_complex64_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<3xcomplex<f32>>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<1xcomplex<f32>>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_float16_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_float16_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<3xf16>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<1xf16>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_float32_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_float32_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<3xf32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<1xf32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_int16_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_int16_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<3xi16>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<1xi16>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_int32_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_int32_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<3xi32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<1xi32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_int8_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_int8_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<3xi8>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<1xi8>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_uint16_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_uint16_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<3xui16>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<1xui16>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_uint32_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_uint32_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<3xui32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<1xui32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_dtypes_a_uint8_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_dtypes_a_uint8_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<3xui8>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<1xui8>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_idx_array_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/dynamic_slice_idx_array_enable_xla_True_dynamic.mlir
@@ -4,9 +4,9 @@
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}, %arg2: tensor<2xi32> {mhlo.sharding = ""}) -> tensor<?x2xf32> {
-    %0 = "stablehlo.slice"(%arg2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<1xi32>
+    %0 = "stablehlo.slice"(%arg2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xi32>) -> tensor<1xi32>
     %1 = stablehlo.reshape %0 : (tensor<1xi32>) -> tensor<i32>
-    %2 = "stablehlo.slice"(%arg2) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%arg2) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.convert %arg0 : (tensor<i64>) -> tensor<i32>
     %5 = stablehlo.constant dense<0> : tensor<i32>

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_3__start_indices__1___limit_indices__2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_3__start_indices__1___limit_indices__2___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<3xf32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<1xf32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_3__start_indices__array_1__dtype_uint32____limit_indices__array_2__dt566174576596150437.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_3__start_indices__array_1__dtype_uint32____limit_indices__array_2__dt566174576596150437.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<3xf32>, tensor<1xui32>)
     %1 = call @expected() : () -> tensor<1xf32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xui32>) -> tensor<1xui32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xui32>) -> tensor<1xui32>
     %3 = stablehlo.reshape %2 : (tensor<1xui32>) -> tensor<ui32>
     %4 = stablehlo.constant dense<0> : tensor<ui32>
     %5 = stablehlo.compare  LT, %3, %4,  UNSIGNED : (tensor<ui32>, tensor<ui32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_3__start_indices__array_1__dtype_uint8____limit_indices__array_2__dtype_uint8____enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_3__start_indices__array_1__dtype_uint8____limit_indices__array_2__dtype_uint8____enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<3xf32>, tensor<1xui8>)
     %1 = call @expected() : () -> tensor<1xf32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xui8>) -> tensor<1xui8>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xui8>) -> tensor<1xui8>
     %3 = stablehlo.reshape %2 : (tensor<1xui8>) -> tensor<ui8>
     %4 = stablehlo.constant dense<0> : tensor<ui8>
     %5 = stablehlo.compare  LT, %3, %4,  UNSIGNED : (tensor<ui8>, tensor<ui8>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__2__1__enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__2__1__enablexla_True.mlir
@@ -7,9 +7,9 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<5x3xf32>, tensor<2xi32>)
     %1 = call @expected() : () -> tensor<1x0xf32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
-    %4 = "stablehlo.slice"(%0#1) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<1xi32>
+    %4 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xi32>) -> tensor<1xi32>
     %5 = stablehlo.reshape %4 : (tensor<1xi32>) -> tensor<i32>
     %6 = stablehlo.constant dense<0> : tensor<i32>
     %7 = stablehlo.compare  LT, %3, %6,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__3__2__enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__3__2__enablexla_True.mlir
@@ -7,9 +7,9 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<5x3xf32>, tensor<2xi32>)
     %1 = call @expected() : () -> tensor<2x1xf32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
-    %4 = "stablehlo.slice"(%0#1) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<1xi32>
+    %4 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xi32>) -> tensor<1xi32>
     %5 = stablehlo.reshape %4 : (tensor<1xi32>) -> tensor<i32>
     %6 = stablehlo.constant dense<0> : tensor<i32>
     %7 = stablehlo.compare  LT, %3, %6,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-100___limit_indices__-99___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-100___limit_indices__-99___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<5xf32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<1xf32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-10___limit_indices__-9___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-10___limit_indices__-9___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<5xf32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<1xf32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-1___limit_indices__0___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-1___limit_indices__0___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<5xf32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<1xf32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-1___limit_indices__1___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-1___limit_indices__1___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<5xf32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<2xf32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-4___limit_indices__-2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-4___limit_indices__-2___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<5xf32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<2xf32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-5___limit_indices__-2___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-5___limit_indices__-2___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<5xf32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<3xf32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-6___limit_indices__-5___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__-6___limit_indices__-5___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<5xf32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<1xf32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__10___limit_indices__11___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__10___limit_indices__11___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<5xf32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<1xf32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__1___limit_indices__5___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__1___limit_indices__5___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<5xf32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<4xf32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__3___limit_indices__6___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__3___limit_indices__6___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<5xf32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<3xf32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__5___limit_indices__6___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_5__start_indices__5___limit_indices__6___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<5xf32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<1xf32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_7_5_3__start_indices__4__0__1__limit_indices__7__1__3__enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_7_5_3__start_indices__4__0__1__limit_indices__7__1__3__enablexla_True.mlir
@@ -7,11 +7,11 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<7x5x3xf32>, tensor<3xi32>)
     %1 = call @expected() : () -> tensor<3x1x2xf32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
-    %4 = "stablehlo.slice"(%0#1) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xi32>) -> tensor<1xi32>
+    %4 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xi32>) -> tensor<1xi32>
     %5 = stablehlo.reshape %4 : (tensor<1xi32>) -> tensor<i32>
-    %6 = "stablehlo.slice"(%0#1) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xi32>) -> tensor<1xi32>
+    %6 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<3xi32>) -> tensor<1xi32>
     %7 = stablehlo.reshape %6 : (tensor<1xi32>) -> tensor<i32>
     %8 = stablehlo.constant dense<0> : tensor<i32>
     %9 = stablehlo.compare  LT, %3, %8,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_7__start_indices__4___limit_indices__7___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_7__start_indices__4___limit_indices__7___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<7xf32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<3xf32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_slice_shapes_a_float32_8__start_indices__1___limit_indices__6___enablexla_True.mlir
+++ b/stablehlo/testdata/dynamic_slice_shapes_a_float32_8__start_indices__1___limit_indices__6___enablexla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:2 = call @inputs() : () -> (tensor<8xf32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<5xf32>
-    %2 = "stablehlo.slice"(%0#1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_bfloat16_3__update_bfloat16_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_bfloat16_3__update_bfloat16_1__start_indices__1___enable_xla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:3 = call @inputs() : () -> (tensor<3xbf16>, tensor<1xbf16>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<3xbf16>
-    %2 = "stablehlo.slice"(%0#2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_bool_3__update_bool_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_bool_3__update_bool_1__start_indices__1___enable_xla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:3 = call @inputs() : () -> (tensor<3xi1>, tensor<1xi1>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<3xi1>
-    %2 = "stablehlo.slice"(%0#2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_complex64_3__update_complex64_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_complex64_3__update_complex64_1__start_indices__1___enable_xla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:3 = call @inputs() : () -> (tensor<3xcomplex<f32>>, tensor<1xcomplex<f32>>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<3xcomplex<f32>>
-    %2 = "stablehlo.slice"(%0#2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_float16_3__update_float16_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_float16_3__update_float16_1__start_indices__1___enable_xla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:3 = call @inputs() : () -> (tensor<3xf16>, tensor<1xf16>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<3xf16>
-    %2 = "stablehlo.slice"(%0#2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_float32_3__update_float32_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_float32_3__update_float32_1__start_indices__1___enable_xla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:3 = call @inputs() : () -> (tensor<3xf32>, tensor<1xf32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<3xf32>
-    %2 = "stablehlo.slice"(%0#2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_int16_3__update_int16_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_int16_3__update_int16_1__start_indices__1___enable_xla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:3 = call @inputs() : () -> (tensor<3xi16>, tensor<1xi16>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<3xi16>
-    %2 = "stablehlo.slice"(%0#2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_int32_3__update_int32_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_int32_3__update_int32_1__start_indices__1___enable_xla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:3 = call @inputs() : () -> (tensor<3xi32>, tensor<1xi32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<3xi32>
-    %2 = "stablehlo.slice"(%0#2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_int8_3__update_int8_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_int8_3__update_int8_1__start_indices__1___enable_xla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:3 = call @inputs() : () -> (tensor<3xi8>, tensor<1xi8>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<3xi8>
-    %2 = "stablehlo.slice"(%0#2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_uint16_3__update_uint16_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_uint16_3__update_uint16_1__start_indices__1___enable_xla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:3 = call @inputs() : () -> (tensor<3xui16>, tensor<1xui16>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<3xui16>
-    %2 = "stablehlo.slice"(%0#2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_uint32_3__update_uint32_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_uint32_3__update_uint32_1__start_indices__1___enable_xla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:3 = call @inputs() : () -> (tensor<3xui32>, tensor<1xui32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<3xui32>
-    %2 = "stablehlo.slice"(%0#2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_update_slice_dtypes_operand_uint8_3__update_uint8_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_dtypes_operand_uint8_3__update_uint8_1__start_indices__1___enable_xla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:3 = call @inputs() : () -> (tensor<3xui8>, tensor<1xui8>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<3xui8>
-    %2 = "stablehlo.slice"(%0#2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_update_slice_idx_array_enable_xla_True_dynamic.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_idx_array_enable_xla_True_dynamic.mlir
@@ -4,9 +4,9 @@
 
 module @jit_fun_flat_jax {
   func.func public @main(%arg0: tensor<i64>, %arg1: tensor<?x4xf32> {mhlo.sharding = ""}, %arg2: tensor<2xi32> {mhlo.sharding = ""}) -> tensor<?x4xf32> {
-    %0 = "stablehlo.slice"(%arg2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<1xi32>
+    %0 = "stablehlo.slice"(%arg2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xi32>) -> tensor<1xi32>
     %1 = stablehlo.reshape %0 : (tensor<1xi32>) -> tensor<i32>
-    %2 = "stablehlo.slice"(%arg2) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%arg2) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.convert %arg0 : (tensor<i64>) -> tensor<i32>
     %5 = stablehlo.constant dense<0> : tensor<i32>

--- a/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__-1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__-1___enable_xla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:3 = call @inputs() : () -> (tensor<3xf32>, tensor<1xf32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<3xf32>
-    %2 = "stablehlo.slice"(%0#2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__10___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__10___enable_xla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:3 = call @inputs() : () -> (tensor<3xf32>, tensor<1xf32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<3xf32>
-    %2 = "stablehlo.slice"(%0#2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__1___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__1___enable_xla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:3 = call @inputs() : () -> (tensor<3xf32>, tensor<1xf32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<3xf32>
-    %2 = "stablehlo.slice"(%0#2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__array_1__dtype_uint32____enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__array_1__dtype_uint32____enable_xla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:3 = call @inputs() : () -> (tensor<3xf32>, tensor<1xf32>, tensor<1xui32>)
     %1 = call @expected() : () -> tensor<3xf32>
-    %2 = "stablehlo.slice"(%0#2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xui32>) -> tensor<1xui32>
+    %2 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xui32>) -> tensor<1xui32>
     %3 = stablehlo.reshape %2 : (tensor<1xui32>) -> tensor<ui32>
     %4 = stablehlo.constant dense<0> : tensor<ui32>
     %5 = stablehlo.compare  LT, %3, %4,  UNSIGNED : (tensor<ui32>, tensor<ui32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__array_1__dtype_uint8____enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_1__start_indices__array_1__dtype_uint8____enable_xla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:3 = call @inputs() : () -> (tensor<3xf32>, tensor<1xf32>, tensor<1xui8>)
     %1 = call @expected() : () -> tensor<3xf32>
-    %2 = "stablehlo.slice"(%0#2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xui8>) -> tensor<1xui8>
+    %2 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xui8>) -> tensor<1xui8>
     %3 = stablehlo.reshape %2 : (tensor<1xui8>) -> tensor<ui8>
     %4 = stablehlo.constant dense<0> : tensor<ui8>
     %5 = stablehlo.compare  LT, %3, %4,  UNSIGNED : (tensor<ui8>, tensor<ui8>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_2__start_indices__10___enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_3__update_float32_2__start_indices__10___enable_xla_True.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:3 = call @inputs() : () -> (tensor<3xf32>, tensor<2xf32>, tensor<1xi32>)
     %1 = call @expected() : () -> tensor<3xf32>
-    %2 = "stablehlo.slice"(%0#2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
     %4 = stablehlo.constant dense<0> : tensor<i32>
     %5 = stablehlo.compare  LT, %3, %4,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_5_3__update_float32_3_1__start_indices__1__1__enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_5_3__update_float32_3_1__start_indices__1__1__enable_xla_True.mlir
@@ -7,9 +7,9 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:3 = call @inputs() : () -> (tensor<5x3xf32>, tensor<3x1xf32>, tensor<2xi32>)
     %1 = call @expected() : () -> tensor<5x3xf32>
-    %2 = "stablehlo.slice"(%0#2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
-    %4 = "stablehlo.slice"(%0#2) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<1xi32>
+    %4 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xi32>) -> tensor<1xi32>
     %5 = stablehlo.reshape %4 : (tensor<1xi32>) -> tensor<i32>
     %6 = stablehlo.constant dense<0> : tensor<i32>
     %7 = stablehlo.compare  LT, %3, %6,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_7_5_3__update_float32_2_0_1__start_indices__4__1__0__enable_xla_True.mlir
+++ b/stablehlo/testdata/dynamic_update_slice_shapes_operand_float32_7_5_3__update_float32_2_0_1__start_indices__4__1__0__enable_xla_True.mlir
@@ -7,11 +7,11 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0:3 = call @inputs() : () -> (tensor<7x5x3xf32>, tensor<2x0x1xf32>, tensor<3xi32>)
     %1 = call @expected() : () -> tensor<7x5x3xf32>
-    %2 = "stablehlo.slice"(%0#2) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xi32>) -> tensor<1xi32>
     %3 = stablehlo.reshape %2 : (tensor<1xi32>) -> tensor<i32>
-    %4 = "stablehlo.slice"(%0#2) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xi32>) -> tensor<1xi32>
+    %4 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xi32>) -> tensor<1xi32>
     %5 = stablehlo.reshape %4 : (tensor<1xi32>) -> tensor<i32>
-    %6 = "stablehlo.slice"(%0#2) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xi32>) -> tensor<1xi32>
+    %6 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<3xi32>) -> tensor<1xi32>
     %7 = stablehlo.reshape %6 : (tensor<1xi32>) -> tensor<i32>
     %8 = stablehlo.constant dense<0> : tensor<i32>
     %9 = stablehlo.compare  LT, %3, %8,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>

--- a/stablehlo/testdata/random_categorical_shape_bfloat16_5_4__axis_0.mlir
+++ b/stablehlo/testdata/random_categorical_shape_bfloat16_5_4__axis_0.mlir
@@ -12,12 +12,12 @@ module @jit_testcase {
     %4 = stablehlo.constant dense<1.000000e+00> : tensor<bf16>
     %5 = stablehlo.broadcast_in_dim %4, dims = [] : (tensor<bf16>) -> tensor<1x1xbf16>
     %6 = stablehlo.iota dim = 0 : tensor<10xui32>
-    %7 = "stablehlo.slice"(%0#0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %7 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %8 = stablehlo.reshape %7 : (tensor<1xui32>) -> tensor<ui32>
-    %9 = "stablehlo.slice"(%0#0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %9 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %10 = stablehlo.reshape %9 : (tensor<1xui32>) -> tensor<ui32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<5> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<10xui32>) -> tensor<5xui32>
-    %12 = "stablehlo.slice"(%6) {limit_indices = dense<10> : tensor<1xi64>, start_indices = dense<5> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<10xui32>) -> tensor<5xui32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 5>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<10xui32>) -> tensor<5xui32>
+    %12 = "stablehlo.slice"(%6) {limit_indices = array<i64: 10>, start_indices = array<i64: 5>, strides = array<i64: 1>} : (tensor<10xui32>) -> tensor<5xui32>
     %13 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %14 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %15 = stablehlo.xor %8, %10 : tensor<ui32>
@@ -37,7 +37,7 @@ module @jit_testcase {
     } do {
       %65 = stablehlo.constant dense<1> : tensor<i32>
       %66 = stablehlo.add %iterArg_0, %65 : tensor<i32>
-      %67 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %67 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %68 = stablehlo.reshape %67 : (tensor<1xui32>) -> tensor<ui32>
       %69 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<5xui32>
       %70 = stablehlo.broadcast_in_dim %68, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -48,7 +48,7 @@ module @jit_testcase {
       %75 = stablehlo.shift_right_logical %iterArg_2, %74 : tensor<5xui32>
       %76 = stablehlo.or %71, %75 : tensor<5xui32>
       %77 = stablehlo.xor %69, %76 : tensor<5xui32>
-      %78 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %78 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %79 = stablehlo.reshape %78 : (tensor<1xui32>) -> tensor<ui32>
       %80 = stablehlo.add %69, %77 : tensor<5xui32>
       %81 = stablehlo.broadcast_in_dim %79, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -59,7 +59,7 @@ module @jit_testcase {
       %86 = stablehlo.shift_right_logical %77, %85 : tensor<5xui32>
       %87 = stablehlo.or %82, %86 : tensor<5xui32>
       %88 = stablehlo.xor %80, %87 : tensor<5xui32>
-      %89 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %89 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %90 = stablehlo.reshape %89 : (tensor<1xui32>) -> tensor<ui32>
       %91 = stablehlo.add %80, %88 : tensor<5xui32>
       %92 = stablehlo.broadcast_in_dim %90, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -70,7 +70,7 @@ module @jit_testcase {
       %97 = stablehlo.shift_right_logical %88, %96 : tensor<5xui32>
       %98 = stablehlo.or %93, %97 : tensor<5xui32>
       %99 = stablehlo.xor %91, %98 : tensor<5xui32>
-      %100 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %100 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %101 = stablehlo.reshape %100 : (tensor<1xui32>) -> tensor<ui32>
       %102 = stablehlo.add %91, %99 : tensor<5xui32>
       %103 = stablehlo.broadcast_in_dim %101, dims = [] : (tensor<ui32>) -> tensor<5xui32>

--- a/stablehlo/testdata/random_categorical_shape_bfloat16_5_4__axis_1.mlir
+++ b/stablehlo/testdata/random_categorical_shape_bfloat16_5_4__axis_1.mlir
@@ -12,12 +12,12 @@ module @jit_testcase {
     %4 = stablehlo.constant dense<1.000000e+00> : tensor<bf16>
     %5 = stablehlo.broadcast_in_dim %4, dims = [] : (tensor<bf16>) -> tensor<1x1xbf16>
     %6 = stablehlo.iota dim = 0 : tensor<10xui32>
-    %7 = "stablehlo.slice"(%0#0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %7 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %8 = stablehlo.reshape %7 : (tensor<1xui32>) -> tensor<ui32>
-    %9 = "stablehlo.slice"(%0#0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %9 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %10 = stablehlo.reshape %9 : (tensor<1xui32>) -> tensor<ui32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<5> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<10xui32>) -> tensor<5xui32>
-    %12 = "stablehlo.slice"(%6) {limit_indices = dense<10> : tensor<1xi64>, start_indices = dense<5> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<10xui32>) -> tensor<5xui32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 5>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<10xui32>) -> tensor<5xui32>
+    %12 = "stablehlo.slice"(%6) {limit_indices = array<i64: 10>, start_indices = array<i64: 5>, strides = array<i64: 1>} : (tensor<10xui32>) -> tensor<5xui32>
     %13 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %14 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %15 = stablehlo.xor %8, %10 : tensor<ui32>
@@ -37,7 +37,7 @@ module @jit_testcase {
     } do {
       %65 = stablehlo.constant dense<1> : tensor<i32>
       %66 = stablehlo.add %iterArg_0, %65 : tensor<i32>
-      %67 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %67 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %68 = stablehlo.reshape %67 : (tensor<1xui32>) -> tensor<ui32>
       %69 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<5xui32>
       %70 = stablehlo.broadcast_in_dim %68, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -48,7 +48,7 @@ module @jit_testcase {
       %75 = stablehlo.shift_right_logical %iterArg_2, %74 : tensor<5xui32>
       %76 = stablehlo.or %71, %75 : tensor<5xui32>
       %77 = stablehlo.xor %69, %76 : tensor<5xui32>
-      %78 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %78 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %79 = stablehlo.reshape %78 : (tensor<1xui32>) -> tensor<ui32>
       %80 = stablehlo.add %69, %77 : tensor<5xui32>
       %81 = stablehlo.broadcast_in_dim %79, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -59,7 +59,7 @@ module @jit_testcase {
       %86 = stablehlo.shift_right_logical %77, %85 : tensor<5xui32>
       %87 = stablehlo.or %82, %86 : tensor<5xui32>
       %88 = stablehlo.xor %80, %87 : tensor<5xui32>
-      %89 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %89 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %90 = stablehlo.reshape %89 : (tensor<1xui32>) -> tensor<ui32>
       %91 = stablehlo.add %80, %88 : tensor<5xui32>
       %92 = stablehlo.broadcast_in_dim %90, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -70,7 +70,7 @@ module @jit_testcase {
       %97 = stablehlo.shift_right_logical %88, %96 : tensor<5xui32>
       %98 = stablehlo.or %93, %97 : tensor<5xui32>
       %99 = stablehlo.xor %91, %98 : tensor<5xui32>
-      %100 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %100 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %101 = stablehlo.reshape %100 : (tensor<1xui32>) -> tensor<ui32>
       %102 = stablehlo.add %91, %99 : tensor<5xui32>
       %103 = stablehlo.broadcast_in_dim %101, dims = [] : (tensor<ui32>) -> tensor<5xui32>

--- a/stablehlo/testdata/random_categorical_shape_bfloat16_8__axis_0.mlir
+++ b/stablehlo/testdata/random_categorical_shape_bfloat16_8__axis_0.mlir
@@ -12,12 +12,12 @@ module @jit_testcase {
     %4 = stablehlo.constant dense<1.000000e+00> : tensor<bf16>
     %5 = stablehlo.broadcast_in_dim %4, dims = [] : (tensor<bf16>) -> tensor<1xbf16>
     %6 = stablehlo.iota dim = 0 : tensor<4xui32>
-    %7 = "stablehlo.slice"(%0#0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %7 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %8 = stablehlo.reshape %7 : (tensor<1xui32>) -> tensor<ui32>
-    %9 = "stablehlo.slice"(%0#0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %9 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %10 = stablehlo.reshape %9 : (tensor<1xui32>) -> tensor<ui32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-    %12 = "stablehlo.slice"(%6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+    %12 = "stablehlo.slice"(%6) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
     %13 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %14 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %15 = stablehlo.xor %8, %10 : tensor<ui32>
@@ -37,7 +37,7 @@ module @jit_testcase {
     } do {
       %64 = stablehlo.constant dense<1> : tensor<i32>
       %65 = stablehlo.add %iterArg_0, %64 : tensor<i32>
-      %66 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %66 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %67 = stablehlo.reshape %66 : (tensor<1xui32>) -> tensor<ui32>
       %68 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<2xui32>
       %69 = stablehlo.broadcast_in_dim %67, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -48,7 +48,7 @@ module @jit_testcase {
       %74 = stablehlo.shift_right_logical %iterArg_2, %73 : tensor<2xui32>
       %75 = stablehlo.or %70, %74 : tensor<2xui32>
       %76 = stablehlo.xor %68, %75 : tensor<2xui32>
-      %77 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %77 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %78 = stablehlo.reshape %77 : (tensor<1xui32>) -> tensor<ui32>
       %79 = stablehlo.add %68, %76 : tensor<2xui32>
       %80 = stablehlo.broadcast_in_dim %78, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -59,7 +59,7 @@ module @jit_testcase {
       %85 = stablehlo.shift_right_logical %76, %84 : tensor<2xui32>
       %86 = stablehlo.or %81, %85 : tensor<2xui32>
       %87 = stablehlo.xor %79, %86 : tensor<2xui32>
-      %88 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %88 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %89 = stablehlo.reshape %88 : (tensor<1xui32>) -> tensor<ui32>
       %90 = stablehlo.add %79, %87 : tensor<2xui32>
       %91 = stablehlo.broadcast_in_dim %89, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -70,7 +70,7 @@ module @jit_testcase {
       %96 = stablehlo.shift_right_logical %87, %95 : tensor<2xui32>
       %97 = stablehlo.or %92, %96 : tensor<2xui32>
       %98 = stablehlo.xor %90, %97 : tensor<2xui32>
-      %99 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %99 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %100 = stablehlo.reshape %99 : (tensor<1xui32>) -> tensor<ui32>
       %101 = stablehlo.add %90, %98 : tensor<2xui32>
       %102 = stablehlo.broadcast_in_dim %100, dims = [] : (tensor<ui32>) -> tensor<2xui32>

--- a/stablehlo/testdata/random_categorical_shape_float16_5_4__axis_0.mlir
+++ b/stablehlo/testdata/random_categorical_shape_float16_5_4__axis_0.mlir
@@ -12,12 +12,12 @@ module @jit_testcase {
     %4 = stablehlo.constant dense<1.000000e+00> : tensor<f16>
     %5 = stablehlo.broadcast_in_dim %4, dims = [] : (tensor<f16>) -> tensor<1x1xf16>
     %6 = stablehlo.iota dim = 0 : tensor<10xui32>
-    %7 = "stablehlo.slice"(%0#0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %7 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %8 = stablehlo.reshape %7 : (tensor<1xui32>) -> tensor<ui32>
-    %9 = "stablehlo.slice"(%0#0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %9 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %10 = stablehlo.reshape %9 : (tensor<1xui32>) -> tensor<ui32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<5> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<10xui32>) -> tensor<5xui32>
-    %12 = "stablehlo.slice"(%6) {limit_indices = dense<10> : tensor<1xi64>, start_indices = dense<5> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<10xui32>) -> tensor<5xui32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 5>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<10xui32>) -> tensor<5xui32>
+    %12 = "stablehlo.slice"(%6) {limit_indices = array<i64: 10>, start_indices = array<i64: 5>, strides = array<i64: 1>} : (tensor<10xui32>) -> tensor<5xui32>
     %13 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %14 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %15 = stablehlo.xor %8, %10 : tensor<ui32>
@@ -37,7 +37,7 @@ module @jit_testcase {
     } do {
       %65 = stablehlo.constant dense<1> : tensor<i32>
       %66 = stablehlo.add %iterArg_0, %65 : tensor<i32>
-      %67 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %67 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %68 = stablehlo.reshape %67 : (tensor<1xui32>) -> tensor<ui32>
       %69 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<5xui32>
       %70 = stablehlo.broadcast_in_dim %68, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -48,7 +48,7 @@ module @jit_testcase {
       %75 = stablehlo.shift_right_logical %iterArg_2, %74 : tensor<5xui32>
       %76 = stablehlo.or %71, %75 : tensor<5xui32>
       %77 = stablehlo.xor %69, %76 : tensor<5xui32>
-      %78 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %78 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %79 = stablehlo.reshape %78 : (tensor<1xui32>) -> tensor<ui32>
       %80 = stablehlo.add %69, %77 : tensor<5xui32>
       %81 = stablehlo.broadcast_in_dim %79, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -59,7 +59,7 @@ module @jit_testcase {
       %86 = stablehlo.shift_right_logical %77, %85 : tensor<5xui32>
       %87 = stablehlo.or %82, %86 : tensor<5xui32>
       %88 = stablehlo.xor %80, %87 : tensor<5xui32>
-      %89 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %89 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %90 = stablehlo.reshape %89 : (tensor<1xui32>) -> tensor<ui32>
       %91 = stablehlo.add %80, %88 : tensor<5xui32>
       %92 = stablehlo.broadcast_in_dim %90, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -70,7 +70,7 @@ module @jit_testcase {
       %97 = stablehlo.shift_right_logical %88, %96 : tensor<5xui32>
       %98 = stablehlo.or %93, %97 : tensor<5xui32>
       %99 = stablehlo.xor %91, %98 : tensor<5xui32>
-      %100 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %100 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %101 = stablehlo.reshape %100 : (tensor<1xui32>) -> tensor<ui32>
       %102 = stablehlo.add %91, %99 : tensor<5xui32>
       %103 = stablehlo.broadcast_in_dim %101, dims = [] : (tensor<ui32>) -> tensor<5xui32>

--- a/stablehlo/testdata/random_categorical_shape_float16_5_4__axis_1.mlir
+++ b/stablehlo/testdata/random_categorical_shape_float16_5_4__axis_1.mlir
@@ -12,12 +12,12 @@ module @jit_testcase {
     %4 = stablehlo.constant dense<1.000000e+00> : tensor<f16>
     %5 = stablehlo.broadcast_in_dim %4, dims = [] : (tensor<f16>) -> tensor<1x1xf16>
     %6 = stablehlo.iota dim = 0 : tensor<10xui32>
-    %7 = "stablehlo.slice"(%0#0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %7 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %8 = stablehlo.reshape %7 : (tensor<1xui32>) -> tensor<ui32>
-    %9 = "stablehlo.slice"(%0#0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %9 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %10 = stablehlo.reshape %9 : (tensor<1xui32>) -> tensor<ui32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<5> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<10xui32>) -> tensor<5xui32>
-    %12 = "stablehlo.slice"(%6) {limit_indices = dense<10> : tensor<1xi64>, start_indices = dense<5> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<10xui32>) -> tensor<5xui32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 5>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<10xui32>) -> tensor<5xui32>
+    %12 = "stablehlo.slice"(%6) {limit_indices = array<i64: 10>, start_indices = array<i64: 5>, strides = array<i64: 1>} : (tensor<10xui32>) -> tensor<5xui32>
     %13 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %14 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %15 = stablehlo.xor %8, %10 : tensor<ui32>
@@ -37,7 +37,7 @@ module @jit_testcase {
     } do {
       %65 = stablehlo.constant dense<1> : tensor<i32>
       %66 = stablehlo.add %iterArg_0, %65 : tensor<i32>
-      %67 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %67 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %68 = stablehlo.reshape %67 : (tensor<1xui32>) -> tensor<ui32>
       %69 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<5xui32>
       %70 = stablehlo.broadcast_in_dim %68, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -48,7 +48,7 @@ module @jit_testcase {
       %75 = stablehlo.shift_right_logical %iterArg_2, %74 : tensor<5xui32>
       %76 = stablehlo.or %71, %75 : tensor<5xui32>
       %77 = stablehlo.xor %69, %76 : tensor<5xui32>
-      %78 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %78 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %79 = stablehlo.reshape %78 : (tensor<1xui32>) -> tensor<ui32>
       %80 = stablehlo.add %69, %77 : tensor<5xui32>
       %81 = stablehlo.broadcast_in_dim %79, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -59,7 +59,7 @@ module @jit_testcase {
       %86 = stablehlo.shift_right_logical %77, %85 : tensor<5xui32>
       %87 = stablehlo.or %82, %86 : tensor<5xui32>
       %88 = stablehlo.xor %80, %87 : tensor<5xui32>
-      %89 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %89 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %90 = stablehlo.reshape %89 : (tensor<1xui32>) -> tensor<ui32>
       %91 = stablehlo.add %80, %88 : tensor<5xui32>
       %92 = stablehlo.broadcast_in_dim %90, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -70,7 +70,7 @@ module @jit_testcase {
       %97 = stablehlo.shift_right_logical %88, %96 : tensor<5xui32>
       %98 = stablehlo.or %93, %97 : tensor<5xui32>
       %99 = stablehlo.xor %91, %98 : tensor<5xui32>
-      %100 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %100 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %101 = stablehlo.reshape %100 : (tensor<1xui32>) -> tensor<ui32>
       %102 = stablehlo.add %91, %99 : tensor<5xui32>
       %103 = stablehlo.broadcast_in_dim %101, dims = [] : (tensor<ui32>) -> tensor<5xui32>

--- a/stablehlo/testdata/random_categorical_shape_float16_8__axis_0.mlir
+++ b/stablehlo/testdata/random_categorical_shape_float16_8__axis_0.mlir
@@ -12,12 +12,12 @@ module @jit_testcase {
     %4 = stablehlo.constant dense<1.000000e+00> : tensor<f16>
     %5 = stablehlo.broadcast_in_dim %4, dims = [] : (tensor<f16>) -> tensor<1xf16>
     %6 = stablehlo.iota dim = 0 : tensor<4xui32>
-    %7 = "stablehlo.slice"(%0#0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %7 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %8 = stablehlo.reshape %7 : (tensor<1xui32>) -> tensor<ui32>
-    %9 = "stablehlo.slice"(%0#0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %9 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %10 = stablehlo.reshape %9 : (tensor<1xui32>) -> tensor<ui32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-    %12 = "stablehlo.slice"(%6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+    %12 = "stablehlo.slice"(%6) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
     %13 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %14 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %15 = stablehlo.xor %8, %10 : tensor<ui32>
@@ -37,7 +37,7 @@ module @jit_testcase {
     } do {
       %64 = stablehlo.constant dense<1> : tensor<i32>
       %65 = stablehlo.add %iterArg_0, %64 : tensor<i32>
-      %66 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %66 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %67 = stablehlo.reshape %66 : (tensor<1xui32>) -> tensor<ui32>
       %68 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<2xui32>
       %69 = stablehlo.broadcast_in_dim %67, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -48,7 +48,7 @@ module @jit_testcase {
       %74 = stablehlo.shift_right_logical %iterArg_2, %73 : tensor<2xui32>
       %75 = stablehlo.or %70, %74 : tensor<2xui32>
       %76 = stablehlo.xor %68, %75 : tensor<2xui32>
-      %77 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %77 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %78 = stablehlo.reshape %77 : (tensor<1xui32>) -> tensor<ui32>
       %79 = stablehlo.add %68, %76 : tensor<2xui32>
       %80 = stablehlo.broadcast_in_dim %78, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -59,7 +59,7 @@ module @jit_testcase {
       %85 = stablehlo.shift_right_logical %76, %84 : tensor<2xui32>
       %86 = stablehlo.or %81, %85 : tensor<2xui32>
       %87 = stablehlo.xor %79, %86 : tensor<2xui32>
-      %88 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %88 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %89 = stablehlo.reshape %88 : (tensor<1xui32>) -> tensor<ui32>
       %90 = stablehlo.add %79, %87 : tensor<2xui32>
       %91 = stablehlo.broadcast_in_dim %89, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -70,7 +70,7 @@ module @jit_testcase {
       %96 = stablehlo.shift_right_logical %87, %95 : tensor<2xui32>
       %97 = stablehlo.or %92, %96 : tensor<2xui32>
       %98 = stablehlo.xor %90, %97 : tensor<2xui32>
-      %99 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %99 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %100 = stablehlo.reshape %99 : (tensor<1xui32>) -> tensor<ui32>
       %101 = stablehlo.add %90, %98 : tensor<2xui32>
       %102 = stablehlo.broadcast_in_dim %100, dims = [] : (tensor<ui32>) -> tensor<2xui32>

--- a/stablehlo/testdata/random_categorical_shape_float32_5_4__axis_0.mlir
+++ b/stablehlo/testdata/random_categorical_shape_float32_5_4__axis_0.mlir
@@ -12,12 +12,12 @@ module @jit_testcase {
     %4 = stablehlo.constant dense<1.000000e+00> : tensor<f32>
     %5 = stablehlo.broadcast_in_dim %4, dims = [] : (tensor<f32>) -> tensor<1x1xf32>
     %6 = stablehlo.iota dim = 0 : tensor<20xui32>
-    %7 = "stablehlo.slice"(%0#0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %7 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %8 = stablehlo.reshape %7 : (tensor<1xui32>) -> tensor<ui32>
-    %9 = "stablehlo.slice"(%0#0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %9 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %10 = stablehlo.reshape %9 : (tensor<1xui32>) -> tensor<ui32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<10> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<20xui32>) -> tensor<10xui32>
-    %12 = "stablehlo.slice"(%6) {limit_indices = dense<20> : tensor<1xi64>, start_indices = dense<10> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<20xui32>) -> tensor<10xui32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 10>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<20xui32>) -> tensor<10xui32>
+    %12 = "stablehlo.slice"(%6) {limit_indices = array<i64: 20>, start_indices = array<i64: 10>, strides = array<i64: 1>} : (tensor<20xui32>) -> tensor<10xui32>
     %13 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %14 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %15 = stablehlo.xor %8, %10 : tensor<ui32>
@@ -37,7 +37,7 @@ module @jit_testcase {
     } do {
       %51 = stablehlo.constant dense<1> : tensor<i32>
       %52 = stablehlo.add %iterArg_0, %51 : tensor<i32>
-      %53 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %53 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %54 = stablehlo.reshape %53 : (tensor<1xui32>) -> tensor<ui32>
       %55 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<10xui32>
       %56 = stablehlo.broadcast_in_dim %54, dims = [] : (tensor<ui32>) -> tensor<10xui32>
@@ -48,7 +48,7 @@ module @jit_testcase {
       %61 = stablehlo.shift_right_logical %iterArg_2, %60 : tensor<10xui32>
       %62 = stablehlo.or %57, %61 : tensor<10xui32>
       %63 = stablehlo.xor %55, %62 : tensor<10xui32>
-      %64 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %64 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %65 = stablehlo.reshape %64 : (tensor<1xui32>) -> tensor<ui32>
       %66 = stablehlo.add %55, %63 : tensor<10xui32>
       %67 = stablehlo.broadcast_in_dim %65, dims = [] : (tensor<ui32>) -> tensor<10xui32>
@@ -59,7 +59,7 @@ module @jit_testcase {
       %72 = stablehlo.shift_right_logical %63, %71 : tensor<10xui32>
       %73 = stablehlo.or %68, %72 : tensor<10xui32>
       %74 = stablehlo.xor %66, %73 : tensor<10xui32>
-      %75 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %75 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %76 = stablehlo.reshape %75 : (tensor<1xui32>) -> tensor<ui32>
       %77 = stablehlo.add %66, %74 : tensor<10xui32>
       %78 = stablehlo.broadcast_in_dim %76, dims = [] : (tensor<ui32>) -> tensor<10xui32>
@@ -70,7 +70,7 @@ module @jit_testcase {
       %83 = stablehlo.shift_right_logical %74, %82 : tensor<10xui32>
       %84 = stablehlo.or %79, %83 : tensor<10xui32>
       %85 = stablehlo.xor %77, %84 : tensor<10xui32>
-      %86 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %86 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %87 = stablehlo.reshape %86 : (tensor<1xui32>) -> tensor<ui32>
       %88 = stablehlo.add %77, %85 : tensor<10xui32>
       %89 = stablehlo.broadcast_in_dim %87, dims = [] : (tensor<ui32>) -> tensor<10xui32>

--- a/stablehlo/testdata/random_categorical_shape_float32_5_4__axis_1.mlir
+++ b/stablehlo/testdata/random_categorical_shape_float32_5_4__axis_1.mlir
@@ -12,12 +12,12 @@ module @jit_testcase {
     %4 = stablehlo.constant dense<1.000000e+00> : tensor<f32>
     %5 = stablehlo.broadcast_in_dim %4, dims = [] : (tensor<f32>) -> tensor<1x1xf32>
     %6 = stablehlo.iota dim = 0 : tensor<20xui32>
-    %7 = "stablehlo.slice"(%0#0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %7 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %8 = stablehlo.reshape %7 : (tensor<1xui32>) -> tensor<ui32>
-    %9 = "stablehlo.slice"(%0#0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %9 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %10 = stablehlo.reshape %9 : (tensor<1xui32>) -> tensor<ui32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<10> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<20xui32>) -> tensor<10xui32>
-    %12 = "stablehlo.slice"(%6) {limit_indices = dense<20> : tensor<1xi64>, start_indices = dense<10> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<20xui32>) -> tensor<10xui32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 10>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<20xui32>) -> tensor<10xui32>
+    %12 = "stablehlo.slice"(%6) {limit_indices = array<i64: 20>, start_indices = array<i64: 10>, strides = array<i64: 1>} : (tensor<20xui32>) -> tensor<10xui32>
     %13 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %14 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %15 = stablehlo.xor %8, %10 : tensor<ui32>
@@ -37,7 +37,7 @@ module @jit_testcase {
     } do {
       %51 = stablehlo.constant dense<1> : tensor<i32>
       %52 = stablehlo.add %iterArg_0, %51 : tensor<i32>
-      %53 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %53 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %54 = stablehlo.reshape %53 : (tensor<1xui32>) -> tensor<ui32>
       %55 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<10xui32>
       %56 = stablehlo.broadcast_in_dim %54, dims = [] : (tensor<ui32>) -> tensor<10xui32>
@@ -48,7 +48,7 @@ module @jit_testcase {
       %61 = stablehlo.shift_right_logical %iterArg_2, %60 : tensor<10xui32>
       %62 = stablehlo.or %57, %61 : tensor<10xui32>
       %63 = stablehlo.xor %55, %62 : tensor<10xui32>
-      %64 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %64 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %65 = stablehlo.reshape %64 : (tensor<1xui32>) -> tensor<ui32>
       %66 = stablehlo.add %55, %63 : tensor<10xui32>
       %67 = stablehlo.broadcast_in_dim %65, dims = [] : (tensor<ui32>) -> tensor<10xui32>
@@ -59,7 +59,7 @@ module @jit_testcase {
       %72 = stablehlo.shift_right_logical %63, %71 : tensor<10xui32>
       %73 = stablehlo.or %68, %72 : tensor<10xui32>
       %74 = stablehlo.xor %66, %73 : tensor<10xui32>
-      %75 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %75 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %76 = stablehlo.reshape %75 : (tensor<1xui32>) -> tensor<ui32>
       %77 = stablehlo.add %66, %74 : tensor<10xui32>
       %78 = stablehlo.broadcast_in_dim %76, dims = [] : (tensor<ui32>) -> tensor<10xui32>
@@ -70,7 +70,7 @@ module @jit_testcase {
       %83 = stablehlo.shift_right_logical %74, %82 : tensor<10xui32>
       %84 = stablehlo.or %79, %83 : tensor<10xui32>
       %85 = stablehlo.xor %77, %84 : tensor<10xui32>
-      %86 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %86 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %87 = stablehlo.reshape %86 : (tensor<1xui32>) -> tensor<ui32>
       %88 = stablehlo.add %77, %85 : tensor<10xui32>
       %89 = stablehlo.broadcast_in_dim %87, dims = [] : (tensor<ui32>) -> tensor<10xui32>

--- a/stablehlo/testdata/random_categorical_shape_float32_8__axis_0.mlir
+++ b/stablehlo/testdata/random_categorical_shape_float32_8__axis_0.mlir
@@ -12,12 +12,12 @@ module @jit_testcase {
     %4 = stablehlo.constant dense<1.000000e+00> : tensor<f32>
     %5 = stablehlo.broadcast_in_dim %4, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %6 = stablehlo.iota dim = 0 : tensor<8xui32>
-    %7 = "stablehlo.slice"(%0#0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %7 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %8 = stablehlo.reshape %7 : (tensor<1xui32>) -> tensor<ui32>
-    %9 = "stablehlo.slice"(%0#0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %9 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %10 = stablehlo.reshape %9 : (tensor<1xui32>) -> tensor<ui32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<8xui32>) -> tensor<4xui32>
-    %12 = "stablehlo.slice"(%6) {limit_indices = dense<8> : tensor<1xi64>, start_indices = dense<4> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<8xui32>) -> tensor<4xui32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 4>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<8xui32>) -> tensor<4xui32>
+    %12 = "stablehlo.slice"(%6) {limit_indices = array<i64: 8>, start_indices = array<i64: 4>, strides = array<i64: 1>} : (tensor<8xui32>) -> tensor<4xui32>
     %13 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %14 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %15 = stablehlo.xor %8, %10 : tensor<ui32>
@@ -37,7 +37,7 @@ module @jit_testcase {
     } do {
       %50 = stablehlo.constant dense<1> : tensor<i32>
       %51 = stablehlo.add %iterArg_0, %50 : tensor<i32>
-      %52 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %52 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %53 = stablehlo.reshape %52 : (tensor<1xui32>) -> tensor<ui32>
       %54 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<4xui32>
       %55 = stablehlo.broadcast_in_dim %53, dims = [] : (tensor<ui32>) -> tensor<4xui32>
@@ -48,7 +48,7 @@ module @jit_testcase {
       %60 = stablehlo.shift_right_logical %iterArg_2, %59 : tensor<4xui32>
       %61 = stablehlo.or %56, %60 : tensor<4xui32>
       %62 = stablehlo.xor %54, %61 : tensor<4xui32>
-      %63 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %63 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %64 = stablehlo.reshape %63 : (tensor<1xui32>) -> tensor<ui32>
       %65 = stablehlo.add %54, %62 : tensor<4xui32>
       %66 = stablehlo.broadcast_in_dim %64, dims = [] : (tensor<ui32>) -> tensor<4xui32>
@@ -59,7 +59,7 @@ module @jit_testcase {
       %71 = stablehlo.shift_right_logical %62, %70 : tensor<4xui32>
       %72 = stablehlo.or %67, %71 : tensor<4xui32>
       %73 = stablehlo.xor %65, %72 : tensor<4xui32>
-      %74 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %74 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %75 = stablehlo.reshape %74 : (tensor<1xui32>) -> tensor<ui32>
       %76 = stablehlo.add %65, %73 : tensor<4xui32>
       %77 = stablehlo.broadcast_in_dim %75, dims = [] : (tensor<ui32>) -> tensor<4xui32>
@@ -70,7 +70,7 @@ module @jit_testcase {
       %82 = stablehlo.shift_right_logical %73, %81 : tensor<4xui32>
       %83 = stablehlo.or %78, %82 : tensor<4xui32>
       %84 = stablehlo.xor %76, %83 : tensor<4xui32>
-      %85 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %85 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %86 = stablehlo.reshape %85 : (tensor<1xui32>) -> tensor<ui32>
       %87 = stablehlo.add %76, %84 : tensor<4xui32>
       %88 = stablehlo.broadcast_in_dim %86, dims = [] : (tensor<ui32>) -> tensor<4xui32>

--- a/stablehlo/testdata/random_gamma_shape_float32.mlir
+++ b/stablehlo/testdata/random_gamma_shape_float32.mlir
@@ -23,12 +23,12 @@ module @jit_testcase {
   func.func private @gamma(%arg0: tensor<2xui32>, %arg1: tensor<f32>) -> tensor<f32> {
     %0 = stablehlo.reshape %arg0 : (tensor<2xui32>) -> tensor<1x2xui32>
     %1 = stablehlo.iota dim = 0 : tensor<2xui32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x2xui32>) -> tensor<1x1xui32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x2xui32>) -> tensor<1x1xui32>
     %3 = stablehlo.reshape %2 : (tensor<1x1xui32>) -> tensor<1xui32>
-    %4 = "stablehlo.slice"(%0) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x2xui32>) -> tensor<1x1xui32>
+    %4 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 1>} : (tensor<1x2xui32>) -> tensor<1x1xui32>
     %5 = stablehlo.reshape %4 : (tensor<1x1xui32>) -> tensor<1xui32>
-    %6 = "stablehlo.slice"(%1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-    %7 = "stablehlo.slice"(%1) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %6 = "stablehlo.slice"(%1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+    %7 = "stablehlo.slice"(%1) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %8 = stablehlo.broadcast_in_dim %6, dims = [1] : (tensor<1xui32>) -> tensor<1x1xui32>
     %9 = stablehlo.broadcast_in_dim %7, dims = [1] : (tensor<1xui32>) -> tensor<1x1xui32>
     %10 = stablehlo.broadcast_in_dim %3, dims = [0] : (tensor<1xui32>) -> tensor<1x1xui32>
@@ -51,7 +51,7 @@ module @jit_testcase {
     } do {
       %32 = stablehlo.constant dense<1> : tensor<i32>
       %33 = stablehlo.add %iterArg_0, %32 : tensor<i32>
-      %34 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %34 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %35 = stablehlo.reshape %34 : (tensor<1xui32>) -> tensor<ui32>
       %36 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<1x1xui32>
       %37 = stablehlo.broadcast_in_dim %35, dims = [] : (tensor<ui32>) -> tensor<1x1xui32>
@@ -62,7 +62,7 @@ module @jit_testcase {
       %42 = stablehlo.shift_right_logical %iterArg_2, %41 : tensor<1x1xui32>
       %43 = stablehlo.or %38, %42 : tensor<1x1xui32>
       %44 = stablehlo.xor %36, %43 : tensor<1x1xui32>
-      %45 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %45 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %46 = stablehlo.reshape %45 : (tensor<1xui32>) -> tensor<ui32>
       %47 = stablehlo.add %36, %44 : tensor<1x1xui32>
       %48 = stablehlo.broadcast_in_dim %46, dims = [] : (tensor<ui32>) -> tensor<1x1xui32>
@@ -73,7 +73,7 @@ module @jit_testcase {
       %53 = stablehlo.shift_right_logical %44, %52 : tensor<1x1xui32>
       %54 = stablehlo.or %49, %53 : tensor<1x1xui32>
       %55 = stablehlo.xor %47, %54 : tensor<1x1xui32>
-      %56 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %56 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %57 = stablehlo.reshape %56 : (tensor<1xui32>) -> tensor<ui32>
       %58 = stablehlo.add %47, %55 : tensor<1x1xui32>
       %59 = stablehlo.broadcast_in_dim %57, dims = [] : (tensor<ui32>) -> tensor<1x1xui32>
@@ -84,7 +84,7 @@ module @jit_testcase {
       %64 = stablehlo.shift_right_logical %55, %63 : tensor<1x1xui32>
       %65 = stablehlo.or %60, %64 : tensor<1x1xui32>
       %66 = stablehlo.xor %58, %65 : tensor<1x1xui32>
-      %67 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %67 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %68 = stablehlo.reshape %67 : (tensor<1xui32>) -> tensor<ui32>
       %69 = stablehlo.add %58, %66 : tensor<1x1xui32>
       %70 = stablehlo.broadcast_in_dim %68, dims = [] : (tensor<ui32>) -> tensor<1x1xui32>
@@ -147,12 +147,12 @@ module @jit_testcase {
       %57 = stablehlo.constant dense<0.333333343> : tensor<f32>
       %58 = stablehlo.divide %57, %56 : tensor<f32>
       %59 = stablehlo.iota dim = 0 : tensor<4xui32>
-      %60 = "stablehlo.slice"(%40) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+      %60 = "stablehlo.slice"(%40) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
       %61 = stablehlo.reshape %60 : (tensor<1xui32>) -> tensor<ui32>
-      %62 = "stablehlo.slice"(%40) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+      %62 = "stablehlo.slice"(%40) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
       %63 = stablehlo.reshape %62 : (tensor<1xui32>) -> tensor<ui32>
-      %64 = "stablehlo.slice"(%59) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-      %65 = "stablehlo.slice"(%59) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+      %64 = "stablehlo.slice"(%59) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+      %65 = "stablehlo.slice"(%59) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
       %66 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
       %67 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
       %68 = stablehlo.xor %61, %63 : tensor<ui32>
@@ -172,7 +172,7 @@ module @jit_testcase {
       } do {
         %151 = stablehlo.constant dense<1> : tensor<i32>
         %152 = stablehlo.add %iterArg_4, %151 : tensor<i32>
-        %153 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %153 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %154 = stablehlo.reshape %153 : (tensor<1xui32>) -> tensor<ui32>
         %155 = stablehlo.add %iterArg_5, %iterArg_6 : tensor<2xui32>
         %156 = stablehlo.broadcast_in_dim %154, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -183,7 +183,7 @@ module @jit_testcase {
         %161 = stablehlo.shift_right_logical %iterArg_6, %160 : tensor<2xui32>
         %162 = stablehlo.or %157, %161 : tensor<2xui32>
         %163 = stablehlo.xor %155, %162 : tensor<2xui32>
-        %164 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %164 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %165 = stablehlo.reshape %164 : (tensor<1xui32>) -> tensor<ui32>
         %166 = stablehlo.add %155, %163 : tensor<2xui32>
         %167 = stablehlo.broadcast_in_dim %165, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -194,7 +194,7 @@ module @jit_testcase {
         %172 = stablehlo.shift_right_logical %163, %171 : tensor<2xui32>
         %173 = stablehlo.or %168, %172 : tensor<2xui32>
         %174 = stablehlo.xor %166, %173 : tensor<2xui32>
-        %175 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %175 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %176 = stablehlo.reshape %175 : (tensor<1xui32>) -> tensor<ui32>
         %177 = stablehlo.add %166, %174 : tensor<2xui32>
         %178 = stablehlo.broadcast_in_dim %176, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -205,7 +205,7 @@ module @jit_testcase {
         %183 = stablehlo.shift_right_logical %174, %182 : tensor<2xui32>
         %184 = stablehlo.or %179, %183 : tensor<2xui32>
         %185 = stablehlo.xor %177, %184 : tensor<2xui32>
-        %186 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %186 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %187 = stablehlo.reshape %186 : (tensor<1xui32>) -> tensor<ui32>
         %188 = stablehlo.add %177, %185 : tensor<2xui32>
         %189 = stablehlo.broadcast_in_dim %187, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -231,19 +231,19 @@ module @jit_testcase {
       }
       %78 = stablehlo.concatenate %77#2, %77#3, dim = 0 : (tensor<2xui32>, tensor<2xui32>) -> tensor<4xui32>
       %79 = stablehlo.reshape %78 : (tensor<4xui32>) -> tensor<2x2xui32>
-      %80 = "stablehlo.slice"(%79) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+      %80 = "stablehlo.slice"(%79) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
       %81 = stablehlo.reshape %80 : (tensor<1x2xui32>) -> tensor<2xui32>
-      %82 = "stablehlo.slice"(%79) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+      %82 = "stablehlo.slice"(%79) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
       %83 = stablehlo.reshape %82 : (tensor<1x2xui32>) -> tensor<2xui32>
       %84 = stablehlo.constant dense<0> : tensor<1xui32>
       %85 = stablehlo.iota dim = 0 : tensor<1xui32>
-      %86 = "stablehlo.slice"(%83) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+      %86 = "stablehlo.slice"(%83) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
       %87 = stablehlo.reshape %86 : (tensor<1xui32>) -> tensor<ui32>
-      %88 = "stablehlo.slice"(%83) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+      %88 = "stablehlo.slice"(%83) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
       %89 = stablehlo.reshape %88 : (tensor<1xui32>) -> tensor<ui32>
       %90 = stablehlo.concatenate %85, %84, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-      %91 = "stablehlo.slice"(%90) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-      %92 = "stablehlo.slice"(%90) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+      %91 = "stablehlo.slice"(%90) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+      %92 = "stablehlo.slice"(%90) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
       %93 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
       %94 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
       %95 = stablehlo.xor %87, %89 : tensor<ui32>
@@ -263,7 +263,7 @@ module @jit_testcase {
       } do {
         %151 = stablehlo.constant dense<1> : tensor<i32>
         %152 = stablehlo.add %iterArg_4, %151 : tensor<i32>
-        %153 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %153 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %154 = stablehlo.reshape %153 : (tensor<1xui32>) -> tensor<ui32>
         %155 = stablehlo.add %iterArg_5, %iterArg_6 : tensor<1xui32>
         %156 = stablehlo.broadcast_in_dim %154, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -274,7 +274,7 @@ module @jit_testcase {
         %161 = stablehlo.shift_right_logical %iterArg_6, %160 : tensor<1xui32>
         %162 = stablehlo.or %157, %161 : tensor<1xui32>
         %163 = stablehlo.xor %155, %162 : tensor<1xui32>
-        %164 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %164 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %165 = stablehlo.reshape %164 : (tensor<1xui32>) -> tensor<ui32>
         %166 = stablehlo.add %155, %163 : tensor<1xui32>
         %167 = stablehlo.broadcast_in_dim %165, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -285,7 +285,7 @@ module @jit_testcase {
         %172 = stablehlo.shift_right_logical %163, %171 : tensor<1xui32>
         %173 = stablehlo.or %168, %172 : tensor<1xui32>
         %174 = stablehlo.xor %166, %173 : tensor<1xui32>
-        %175 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %175 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %176 = stablehlo.reshape %175 : (tensor<1xui32>) -> tensor<ui32>
         %177 = stablehlo.add %166, %174 : tensor<1xui32>
         %178 = stablehlo.broadcast_in_dim %176, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -296,7 +296,7 @@ module @jit_testcase {
         %183 = stablehlo.shift_right_logical %174, %182 : tensor<1xui32>
         %184 = stablehlo.or %179, %183 : tensor<1xui32>
         %185 = stablehlo.xor %177, %184 : tensor<1xui32>
-        %186 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %186 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %187 = stablehlo.reshape %186 : (tensor<1xui32>) -> tensor<ui32>
         %188 = stablehlo.add %177, %185 : tensor<1xui32>
         %189 = stablehlo.broadcast_in_dim %187, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -366,12 +366,12 @@ module @jit_testcase {
         stablehlo.return %167 : tensor<i1>
       } do {
         %151 = stablehlo.iota dim = 0 : tensor<6xui32>
-        %152 = "stablehlo.slice"(%iterArg_5) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+        %152 = "stablehlo.slice"(%iterArg_5) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
         %153 = stablehlo.reshape %152 : (tensor<1xui32>) -> tensor<ui32>
-        %154 = "stablehlo.slice"(%iterArg_5) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+        %154 = "stablehlo.slice"(%iterArg_5) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
         %155 = stablehlo.reshape %154 : (tensor<1xui32>) -> tensor<ui32>
-        %156 = "stablehlo.slice"(%151) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<6xui32>) -> tensor<3xui32>
-        %157 = "stablehlo.slice"(%151) {limit_indices = dense<6> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<6xui32>) -> tensor<3xui32>
+        %156 = "stablehlo.slice"(%151) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<6xui32>) -> tensor<3xui32>
+        %157 = "stablehlo.slice"(%151) {limit_indices = array<i64: 6>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<6xui32>) -> tensor<3xui32>
         %158 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
         %159 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
         %160 = stablehlo.xor %153, %155 : tensor<ui32>
@@ -391,7 +391,7 @@ module @jit_testcase {
         } do {
           %226 = stablehlo.constant dense<1> : tensor<i32>
           %227 = stablehlo.add %iterArg_10, %226 : tensor<i32>
-          %228 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %228 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %229 = stablehlo.reshape %228 : (tensor<1xui32>) -> tensor<ui32>
           %230 = stablehlo.add %iterArg_11, %iterArg_12 : tensor<3xui32>
           %231 = stablehlo.broadcast_in_dim %229, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -402,7 +402,7 @@ module @jit_testcase {
           %236 = stablehlo.shift_right_logical %iterArg_12, %235 : tensor<3xui32>
           %237 = stablehlo.or %232, %236 : tensor<3xui32>
           %238 = stablehlo.xor %230, %237 : tensor<3xui32>
-          %239 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %239 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %240 = stablehlo.reshape %239 : (tensor<1xui32>) -> tensor<ui32>
           %241 = stablehlo.add %230, %238 : tensor<3xui32>
           %242 = stablehlo.broadcast_in_dim %240, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -413,7 +413,7 @@ module @jit_testcase {
           %247 = stablehlo.shift_right_logical %238, %246 : tensor<3xui32>
           %248 = stablehlo.or %243, %247 : tensor<3xui32>
           %249 = stablehlo.xor %241, %248 : tensor<3xui32>
-          %250 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %250 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %251 = stablehlo.reshape %250 : (tensor<1xui32>) -> tensor<ui32>
           %252 = stablehlo.add %241, %249 : tensor<3xui32>
           %253 = stablehlo.broadcast_in_dim %251, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -424,7 +424,7 @@ module @jit_testcase {
           %258 = stablehlo.shift_right_logical %249, %257 : tensor<3xui32>
           %259 = stablehlo.or %254, %258 : tensor<3xui32>
           %260 = stablehlo.xor %252, %259 : tensor<3xui32>
-          %261 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %261 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %262 = stablehlo.reshape %261 : (tensor<1xui32>) -> tensor<ui32>
           %263 = stablehlo.add %252, %260 : tensor<3xui32>
           %264 = stablehlo.broadcast_in_dim %262, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -450,11 +450,11 @@ module @jit_testcase {
         }
         %170 = stablehlo.concatenate %169#2, %169#3, dim = 0 : (tensor<3xui32>, tensor<3xui32>) -> tensor<6xui32>
         %171 = stablehlo.reshape %170 : (tensor<6xui32>) -> tensor<3x2xui32>
-        %172 = "stablehlo.slice"(%171) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
+        %172 = "stablehlo.slice"(%171) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
         %173 = stablehlo.reshape %172 : (tensor<1x2xui32>) -> tensor<2xui32>
-        %174 = "stablehlo.slice"(%171) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
+        %174 = "stablehlo.slice"(%171) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
         %175 = stablehlo.reshape %174 : (tensor<1x2xui32>) -> tensor<2xui32>
-        %176 = "stablehlo.slice"(%171) {limit_indices = dense<[3, 2]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
+        %176 = "stablehlo.slice"(%171) {limit_indices = array<i64: 3, 2>, start_indices = array<i64: 2, 0>, strides = array<i64: 1, 1>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
         %177 = stablehlo.reshape %176 : (tensor<1x2xui32>) -> tensor<2xui32>
         %178 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
         %179 = stablehlo.constant dense<-1.000000e+00> : tensor<f32>
@@ -465,12 +465,12 @@ module @jit_testcase {
           stablehlo.return %227 : tensor<i1>
         } do {
           %226 = stablehlo.iota dim = 0 : tensor<4xui32>
-          %227 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+          %227 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
           %228 = stablehlo.reshape %227 : (tensor<1xui32>) -> tensor<ui32>
-          %229 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+          %229 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
           %230 = stablehlo.reshape %229 : (tensor<1xui32>) -> tensor<ui32>
-          %231 = "stablehlo.slice"(%226) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-          %232 = "stablehlo.slice"(%226) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+          %231 = "stablehlo.slice"(%226) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+          %232 = "stablehlo.slice"(%226) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
           %233 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
           %234 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
           %235 = stablehlo.xor %228, %230 : tensor<ui32>
@@ -490,7 +490,7 @@ module @jit_testcase {
           } do {
             %299 = stablehlo.constant dense<1> : tensor<i32>
             %300 = stablehlo.add %iterArg_14, %299 : tensor<i32>
-            %301 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %301 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %302 = stablehlo.reshape %301 : (tensor<1xui32>) -> tensor<ui32>
             %303 = stablehlo.add %iterArg_15, %iterArg_16 : tensor<2xui32>
             %304 = stablehlo.broadcast_in_dim %302, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -501,7 +501,7 @@ module @jit_testcase {
             %309 = stablehlo.shift_right_logical %iterArg_16, %308 : tensor<2xui32>
             %310 = stablehlo.or %305, %309 : tensor<2xui32>
             %311 = stablehlo.xor %303, %310 : tensor<2xui32>
-            %312 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %312 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %313 = stablehlo.reshape %312 : (tensor<1xui32>) -> tensor<ui32>
             %314 = stablehlo.add %303, %311 : tensor<2xui32>
             %315 = stablehlo.broadcast_in_dim %313, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -512,7 +512,7 @@ module @jit_testcase {
             %320 = stablehlo.shift_right_logical %311, %319 : tensor<2xui32>
             %321 = stablehlo.or %316, %320 : tensor<2xui32>
             %322 = stablehlo.xor %314, %321 : tensor<2xui32>
-            %323 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %323 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %324 = stablehlo.reshape %323 : (tensor<1xui32>) -> tensor<ui32>
             %325 = stablehlo.add %314, %322 : tensor<2xui32>
             %326 = stablehlo.broadcast_in_dim %324, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -523,7 +523,7 @@ module @jit_testcase {
             %331 = stablehlo.shift_right_logical %322, %330 : tensor<2xui32>
             %332 = stablehlo.or %327, %331 : tensor<2xui32>
             %333 = stablehlo.xor %325, %332 : tensor<2xui32>
-            %334 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %334 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %335 = stablehlo.reshape %334 : (tensor<1xui32>) -> tensor<ui32>
             %336 = stablehlo.add %325, %333 : tensor<2xui32>
             %337 = stablehlo.broadcast_in_dim %335, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -549,19 +549,19 @@ module @jit_testcase {
           }
           %245 = stablehlo.concatenate %244#2, %244#3, dim = 0 : (tensor<2xui32>, tensor<2xui32>) -> tensor<4xui32>
           %246 = stablehlo.reshape %245 : (tensor<4xui32>) -> tensor<2x2xui32>
-          %247 = "stablehlo.slice"(%246) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+          %247 = "stablehlo.slice"(%246) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
           %248 = stablehlo.reshape %247 : (tensor<1x2xui32>) -> tensor<2xui32>
-          %249 = "stablehlo.slice"(%246) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+          %249 = "stablehlo.slice"(%246) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
           %250 = stablehlo.reshape %249 : (tensor<1x2xui32>) -> tensor<2xui32>
           %251 = stablehlo.constant dense<0> : tensor<1xui32>
           %252 = stablehlo.iota dim = 0 : tensor<1xui32>
-          %253 = "stablehlo.slice"(%250) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+          %253 = "stablehlo.slice"(%250) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
           %254 = stablehlo.reshape %253 : (tensor<1xui32>) -> tensor<ui32>
-          %255 = "stablehlo.slice"(%250) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+          %255 = "stablehlo.slice"(%250) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
           %256 = stablehlo.reshape %255 : (tensor<1xui32>) -> tensor<ui32>
           %257 = stablehlo.concatenate %252, %251, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-          %258 = "stablehlo.slice"(%257) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-          %259 = "stablehlo.slice"(%257) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+          %258 = "stablehlo.slice"(%257) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+          %259 = "stablehlo.slice"(%257) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
           %260 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
           %261 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
           %262 = stablehlo.xor %254, %256 : tensor<ui32>
@@ -581,7 +581,7 @@ module @jit_testcase {
           } do {
             %299 = stablehlo.constant dense<1> : tensor<i32>
             %300 = stablehlo.add %iterArg_14, %299 : tensor<i32>
-            %301 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %301 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %302 = stablehlo.reshape %301 : (tensor<1xui32>) -> tensor<ui32>
             %303 = stablehlo.add %iterArg_15, %iterArg_16 : tensor<1xui32>
             %304 = stablehlo.broadcast_in_dim %302, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -592,7 +592,7 @@ module @jit_testcase {
             %309 = stablehlo.shift_right_logical %iterArg_16, %308 : tensor<1xui32>
             %310 = stablehlo.or %305, %309 : tensor<1xui32>
             %311 = stablehlo.xor %303, %310 : tensor<1xui32>
-            %312 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %312 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %313 = stablehlo.reshape %312 : (tensor<1xui32>) -> tensor<ui32>
             %314 = stablehlo.add %303, %311 : tensor<1xui32>
             %315 = stablehlo.broadcast_in_dim %313, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -603,7 +603,7 @@ module @jit_testcase {
             %320 = stablehlo.shift_right_logical %311, %319 : tensor<1xui32>
             %321 = stablehlo.or %316, %320 : tensor<1xui32>
             %322 = stablehlo.xor %314, %321 : tensor<1xui32>
-            %323 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %323 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %324 = stablehlo.reshape %323 : (tensor<1xui32>) -> tensor<ui32>
             %325 = stablehlo.add %314, %322 : tensor<1xui32>
             %326 = stablehlo.broadcast_in_dim %324, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -614,7 +614,7 @@ module @jit_testcase {
             %331 = stablehlo.shift_right_logical %322, %330 : tensor<1xui32>
             %332 = stablehlo.or %327, %331 : tensor<1xui32>
             %333 = stablehlo.xor %325, %332 : tensor<1xui32>
-            %334 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %334 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %335 = stablehlo.reshape %334 : (tensor<1xui32>) -> tensor<ui32>
             %336 = stablehlo.add %325, %333 : tensor<1xui32>
             %337 = stablehlo.broadcast_in_dim %335, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -672,13 +672,13 @@ module @jit_testcase {
         %183 = stablehlo.multiply %182, %180#3 : tensor<f32>
         %184 = stablehlo.constant dense<0> : tensor<1xui32>
         %185 = stablehlo.iota dim = 0 : tensor<1xui32>
-        %186 = "stablehlo.slice"(%177) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+        %186 = "stablehlo.slice"(%177) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
         %187 = stablehlo.reshape %186 : (tensor<1xui32>) -> tensor<ui32>
-        %188 = "stablehlo.slice"(%177) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+        %188 = "stablehlo.slice"(%177) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
         %189 = stablehlo.reshape %188 : (tensor<1xui32>) -> tensor<ui32>
         %190 = stablehlo.concatenate %185, %184, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-        %191 = "stablehlo.slice"(%190) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-        %192 = "stablehlo.slice"(%190) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+        %191 = "stablehlo.slice"(%190) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+        %192 = "stablehlo.slice"(%190) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
         %193 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
         %194 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
         %195 = stablehlo.xor %187, %189 : tensor<ui32>
@@ -698,7 +698,7 @@ module @jit_testcase {
         } do {
           %226 = stablehlo.constant dense<1> : tensor<i32>
           %227 = stablehlo.add %iterArg_10, %226 : tensor<i32>
-          %228 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %228 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %229 = stablehlo.reshape %228 : (tensor<1xui32>) -> tensor<ui32>
           %230 = stablehlo.add %iterArg_11, %iterArg_12 : tensor<1xui32>
           %231 = stablehlo.broadcast_in_dim %229, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -709,7 +709,7 @@ module @jit_testcase {
           %236 = stablehlo.shift_right_logical %iterArg_12, %235 : tensor<1xui32>
           %237 = stablehlo.or %232, %236 : tensor<1xui32>
           %238 = stablehlo.xor %230, %237 : tensor<1xui32>
-          %239 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %239 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %240 = stablehlo.reshape %239 : (tensor<1xui32>) -> tensor<ui32>
           %241 = stablehlo.add %230, %238 : tensor<1xui32>
           %242 = stablehlo.broadcast_in_dim %240, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -720,7 +720,7 @@ module @jit_testcase {
           %247 = stablehlo.shift_right_logical %238, %246 : tensor<1xui32>
           %248 = stablehlo.or %243, %247 : tensor<1xui32>
           %249 = stablehlo.xor %241, %248 : tensor<1xui32>
-          %250 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %250 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %251 = stablehlo.reshape %250 : (tensor<1xui32>) -> tensor<ui32>
           %252 = stablehlo.add %241, %249 : tensor<1xui32>
           %253 = stablehlo.broadcast_in_dim %251, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -731,7 +731,7 @@ module @jit_testcase {
           %258 = stablehlo.shift_right_logical %249, %257 : tensor<1xui32>
           %259 = stablehlo.or %254, %258 : tensor<1xui32>
           %260 = stablehlo.xor %252, %259 : tensor<1xui32>
-          %261 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %261 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %262 = stablehlo.reshape %261 : (tensor<1xui32>) -> tensor<ui32>
           %263 = stablehlo.add %252, %260 : tensor<1xui32>
           %264 = stablehlo.broadcast_in_dim %262, dims = [] : (tensor<ui32>) -> tensor<1xui32>

--- a/stablehlo/testdata/random_gamma_shape_float32_3.mlir
+++ b/stablehlo/testdata/random_gamma_shape_float32_3.mlir
@@ -23,12 +23,12 @@ module @jit_testcase {
   func.func private @gamma(%arg0: tensor<2xui32>, %arg1: tensor<3xf32>) -> tensor<3xf32> {
     %0 = stablehlo.reshape %arg0 : (tensor<2xui32>) -> tensor<1x2xui32>
     %1 = stablehlo.iota dim = 0 : tensor<6xui32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x2xui32>) -> tensor<1x1xui32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x2xui32>) -> tensor<1x1xui32>
     %3 = stablehlo.reshape %2 : (tensor<1x1xui32>) -> tensor<1xui32>
-    %4 = "stablehlo.slice"(%0) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x2xui32>) -> tensor<1x1xui32>
+    %4 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 1>} : (tensor<1x2xui32>) -> tensor<1x1xui32>
     %5 = stablehlo.reshape %4 : (tensor<1x1xui32>) -> tensor<1xui32>
-    %6 = "stablehlo.slice"(%1) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<6xui32>) -> tensor<3xui32>
-    %7 = "stablehlo.slice"(%1) {limit_indices = dense<6> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<6xui32>) -> tensor<3xui32>
+    %6 = "stablehlo.slice"(%1) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<6xui32>) -> tensor<3xui32>
+    %7 = "stablehlo.slice"(%1) {limit_indices = array<i64: 6>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<6xui32>) -> tensor<3xui32>
     %8 = stablehlo.broadcast_in_dim %6, dims = [1] : (tensor<3xui32>) -> tensor<1x3xui32>
     %9 = stablehlo.broadcast_in_dim %7, dims = [1] : (tensor<3xui32>) -> tensor<1x3xui32>
     %10 = stablehlo.broadcast_in_dim %3, dims = [0] : (tensor<1xui32>) -> tensor<1x1xui32>
@@ -53,7 +53,7 @@ module @jit_testcase {
     } do {
       %32 = stablehlo.constant dense<1> : tensor<i32>
       %33 = stablehlo.add %iterArg_0, %32 : tensor<i32>
-      %34 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %34 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %35 = stablehlo.reshape %34 : (tensor<1xui32>) -> tensor<ui32>
       %36 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<1x3xui32>
       %37 = stablehlo.broadcast_in_dim %35, dims = [] : (tensor<ui32>) -> tensor<1x3xui32>
@@ -64,7 +64,7 @@ module @jit_testcase {
       %42 = stablehlo.shift_right_logical %iterArg_2, %41 : tensor<1x3xui32>
       %43 = stablehlo.or %38, %42 : tensor<1x3xui32>
       %44 = stablehlo.xor %36, %43 : tensor<1x3xui32>
-      %45 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %45 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %46 = stablehlo.reshape %45 : (tensor<1xui32>) -> tensor<ui32>
       %47 = stablehlo.add %36, %44 : tensor<1x3xui32>
       %48 = stablehlo.broadcast_in_dim %46, dims = [] : (tensor<ui32>) -> tensor<1x3xui32>
@@ -75,7 +75,7 @@ module @jit_testcase {
       %53 = stablehlo.shift_right_logical %44, %52 : tensor<1x3xui32>
       %54 = stablehlo.or %49, %53 : tensor<1x3xui32>
       %55 = stablehlo.xor %47, %54 : tensor<1x3xui32>
-      %56 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %56 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %57 = stablehlo.reshape %56 : (tensor<1xui32>) -> tensor<ui32>
       %58 = stablehlo.add %47, %55 : tensor<1x3xui32>
       %59 = stablehlo.broadcast_in_dim %57, dims = [] : (tensor<ui32>) -> tensor<1x3xui32>
@@ -86,7 +86,7 @@ module @jit_testcase {
       %64 = stablehlo.shift_right_logical %55, %63 : tensor<1x3xui32>
       %65 = stablehlo.or %60, %64 : tensor<1x3xui32>
       %66 = stablehlo.xor %58, %65 : tensor<1x3xui32>
-      %67 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %67 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %68 = stablehlo.reshape %67 : (tensor<1xui32>) -> tensor<ui32>
       %69 = stablehlo.add %58, %66 : tensor<1x3xui32>
       %70 = stablehlo.broadcast_in_dim %68, dims = [] : (tensor<ui32>) -> tensor<1x3xui32>
@@ -150,12 +150,12 @@ module @jit_testcase {
       %57 = stablehlo.constant dense<0.333333343> : tensor<f32>
       %58 = stablehlo.divide %57, %56 : tensor<f32>
       %59 = stablehlo.iota dim = 0 : tensor<4xui32>
-      %60 = "stablehlo.slice"(%40) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+      %60 = "stablehlo.slice"(%40) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
       %61 = stablehlo.reshape %60 : (tensor<1xui32>) -> tensor<ui32>
-      %62 = "stablehlo.slice"(%40) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+      %62 = "stablehlo.slice"(%40) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
       %63 = stablehlo.reshape %62 : (tensor<1xui32>) -> tensor<ui32>
-      %64 = "stablehlo.slice"(%59) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-      %65 = "stablehlo.slice"(%59) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+      %64 = "stablehlo.slice"(%59) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+      %65 = "stablehlo.slice"(%59) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
       %66 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
       %67 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
       %68 = stablehlo.xor %61, %63 : tensor<ui32>
@@ -175,7 +175,7 @@ module @jit_testcase {
       } do {
         %151 = stablehlo.constant dense<1> : tensor<i32>
         %152 = stablehlo.add %iterArg_4, %151 : tensor<i32>
-        %153 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %153 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %154 = stablehlo.reshape %153 : (tensor<1xui32>) -> tensor<ui32>
         %155 = stablehlo.add %iterArg_5, %iterArg_6 : tensor<2xui32>
         %156 = stablehlo.broadcast_in_dim %154, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -186,7 +186,7 @@ module @jit_testcase {
         %161 = stablehlo.shift_right_logical %iterArg_6, %160 : tensor<2xui32>
         %162 = stablehlo.or %157, %161 : tensor<2xui32>
         %163 = stablehlo.xor %155, %162 : tensor<2xui32>
-        %164 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %164 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %165 = stablehlo.reshape %164 : (tensor<1xui32>) -> tensor<ui32>
         %166 = stablehlo.add %155, %163 : tensor<2xui32>
         %167 = stablehlo.broadcast_in_dim %165, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -197,7 +197,7 @@ module @jit_testcase {
         %172 = stablehlo.shift_right_logical %163, %171 : tensor<2xui32>
         %173 = stablehlo.or %168, %172 : tensor<2xui32>
         %174 = stablehlo.xor %166, %173 : tensor<2xui32>
-        %175 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %175 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %176 = stablehlo.reshape %175 : (tensor<1xui32>) -> tensor<ui32>
         %177 = stablehlo.add %166, %174 : tensor<2xui32>
         %178 = stablehlo.broadcast_in_dim %176, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -208,7 +208,7 @@ module @jit_testcase {
         %183 = stablehlo.shift_right_logical %174, %182 : tensor<2xui32>
         %184 = stablehlo.or %179, %183 : tensor<2xui32>
         %185 = stablehlo.xor %177, %184 : tensor<2xui32>
-        %186 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %186 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %187 = stablehlo.reshape %186 : (tensor<1xui32>) -> tensor<ui32>
         %188 = stablehlo.add %177, %185 : tensor<2xui32>
         %189 = stablehlo.broadcast_in_dim %187, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -234,19 +234,19 @@ module @jit_testcase {
       }
       %78 = stablehlo.concatenate %77#2, %77#3, dim = 0 : (tensor<2xui32>, tensor<2xui32>) -> tensor<4xui32>
       %79 = stablehlo.reshape %78 : (tensor<4xui32>) -> tensor<2x2xui32>
-      %80 = "stablehlo.slice"(%79) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+      %80 = "stablehlo.slice"(%79) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
       %81 = stablehlo.reshape %80 : (tensor<1x2xui32>) -> tensor<2xui32>
-      %82 = "stablehlo.slice"(%79) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+      %82 = "stablehlo.slice"(%79) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
       %83 = stablehlo.reshape %82 : (tensor<1x2xui32>) -> tensor<2xui32>
       %84 = stablehlo.constant dense<0> : tensor<1xui32>
       %85 = stablehlo.iota dim = 0 : tensor<1xui32>
-      %86 = "stablehlo.slice"(%83) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+      %86 = "stablehlo.slice"(%83) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
       %87 = stablehlo.reshape %86 : (tensor<1xui32>) -> tensor<ui32>
-      %88 = "stablehlo.slice"(%83) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+      %88 = "stablehlo.slice"(%83) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
       %89 = stablehlo.reshape %88 : (tensor<1xui32>) -> tensor<ui32>
       %90 = stablehlo.concatenate %85, %84, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-      %91 = "stablehlo.slice"(%90) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-      %92 = "stablehlo.slice"(%90) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+      %91 = "stablehlo.slice"(%90) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+      %92 = "stablehlo.slice"(%90) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
       %93 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
       %94 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
       %95 = stablehlo.xor %87, %89 : tensor<ui32>
@@ -266,7 +266,7 @@ module @jit_testcase {
       } do {
         %151 = stablehlo.constant dense<1> : tensor<i32>
         %152 = stablehlo.add %iterArg_4, %151 : tensor<i32>
-        %153 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %153 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %154 = stablehlo.reshape %153 : (tensor<1xui32>) -> tensor<ui32>
         %155 = stablehlo.add %iterArg_5, %iterArg_6 : tensor<1xui32>
         %156 = stablehlo.broadcast_in_dim %154, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -277,7 +277,7 @@ module @jit_testcase {
         %161 = stablehlo.shift_right_logical %iterArg_6, %160 : tensor<1xui32>
         %162 = stablehlo.or %157, %161 : tensor<1xui32>
         %163 = stablehlo.xor %155, %162 : tensor<1xui32>
-        %164 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %164 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %165 = stablehlo.reshape %164 : (tensor<1xui32>) -> tensor<ui32>
         %166 = stablehlo.add %155, %163 : tensor<1xui32>
         %167 = stablehlo.broadcast_in_dim %165, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -288,7 +288,7 @@ module @jit_testcase {
         %172 = stablehlo.shift_right_logical %163, %171 : tensor<1xui32>
         %173 = stablehlo.or %168, %172 : tensor<1xui32>
         %174 = stablehlo.xor %166, %173 : tensor<1xui32>
-        %175 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %175 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %176 = stablehlo.reshape %175 : (tensor<1xui32>) -> tensor<ui32>
         %177 = stablehlo.add %166, %174 : tensor<1xui32>
         %178 = stablehlo.broadcast_in_dim %176, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -299,7 +299,7 @@ module @jit_testcase {
         %183 = stablehlo.shift_right_logical %174, %182 : tensor<1xui32>
         %184 = stablehlo.or %179, %183 : tensor<1xui32>
         %185 = stablehlo.xor %177, %184 : tensor<1xui32>
-        %186 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %186 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %187 = stablehlo.reshape %186 : (tensor<1xui32>) -> tensor<ui32>
         %188 = stablehlo.add %177, %185 : tensor<1xui32>
         %189 = stablehlo.broadcast_in_dim %187, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -369,12 +369,12 @@ module @jit_testcase {
         stablehlo.return %167 : tensor<i1>
       } do {
         %151 = stablehlo.iota dim = 0 : tensor<6xui32>
-        %152 = "stablehlo.slice"(%iterArg_5) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+        %152 = "stablehlo.slice"(%iterArg_5) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
         %153 = stablehlo.reshape %152 : (tensor<1xui32>) -> tensor<ui32>
-        %154 = "stablehlo.slice"(%iterArg_5) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+        %154 = "stablehlo.slice"(%iterArg_5) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
         %155 = stablehlo.reshape %154 : (tensor<1xui32>) -> tensor<ui32>
-        %156 = "stablehlo.slice"(%151) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<6xui32>) -> tensor<3xui32>
-        %157 = "stablehlo.slice"(%151) {limit_indices = dense<6> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<6xui32>) -> tensor<3xui32>
+        %156 = "stablehlo.slice"(%151) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<6xui32>) -> tensor<3xui32>
+        %157 = "stablehlo.slice"(%151) {limit_indices = array<i64: 6>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<6xui32>) -> tensor<3xui32>
         %158 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
         %159 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
         %160 = stablehlo.xor %153, %155 : tensor<ui32>
@@ -394,7 +394,7 @@ module @jit_testcase {
         } do {
           %226 = stablehlo.constant dense<1> : tensor<i32>
           %227 = stablehlo.add %iterArg_10, %226 : tensor<i32>
-          %228 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %228 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %229 = stablehlo.reshape %228 : (tensor<1xui32>) -> tensor<ui32>
           %230 = stablehlo.add %iterArg_11, %iterArg_12 : tensor<3xui32>
           %231 = stablehlo.broadcast_in_dim %229, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -405,7 +405,7 @@ module @jit_testcase {
           %236 = stablehlo.shift_right_logical %iterArg_12, %235 : tensor<3xui32>
           %237 = stablehlo.or %232, %236 : tensor<3xui32>
           %238 = stablehlo.xor %230, %237 : tensor<3xui32>
-          %239 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %239 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %240 = stablehlo.reshape %239 : (tensor<1xui32>) -> tensor<ui32>
           %241 = stablehlo.add %230, %238 : tensor<3xui32>
           %242 = stablehlo.broadcast_in_dim %240, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -416,7 +416,7 @@ module @jit_testcase {
           %247 = stablehlo.shift_right_logical %238, %246 : tensor<3xui32>
           %248 = stablehlo.or %243, %247 : tensor<3xui32>
           %249 = stablehlo.xor %241, %248 : tensor<3xui32>
-          %250 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %250 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %251 = stablehlo.reshape %250 : (tensor<1xui32>) -> tensor<ui32>
           %252 = stablehlo.add %241, %249 : tensor<3xui32>
           %253 = stablehlo.broadcast_in_dim %251, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -427,7 +427,7 @@ module @jit_testcase {
           %258 = stablehlo.shift_right_logical %249, %257 : tensor<3xui32>
           %259 = stablehlo.or %254, %258 : tensor<3xui32>
           %260 = stablehlo.xor %252, %259 : tensor<3xui32>
-          %261 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %261 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %262 = stablehlo.reshape %261 : (tensor<1xui32>) -> tensor<ui32>
           %263 = stablehlo.add %252, %260 : tensor<3xui32>
           %264 = stablehlo.broadcast_in_dim %262, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -453,11 +453,11 @@ module @jit_testcase {
         }
         %170 = stablehlo.concatenate %169#2, %169#3, dim = 0 : (tensor<3xui32>, tensor<3xui32>) -> tensor<6xui32>
         %171 = stablehlo.reshape %170 : (tensor<6xui32>) -> tensor<3x2xui32>
-        %172 = "stablehlo.slice"(%171) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
+        %172 = "stablehlo.slice"(%171) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
         %173 = stablehlo.reshape %172 : (tensor<1x2xui32>) -> tensor<2xui32>
-        %174 = "stablehlo.slice"(%171) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
+        %174 = "stablehlo.slice"(%171) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
         %175 = stablehlo.reshape %174 : (tensor<1x2xui32>) -> tensor<2xui32>
-        %176 = "stablehlo.slice"(%171) {limit_indices = dense<[3, 2]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
+        %176 = "stablehlo.slice"(%171) {limit_indices = array<i64: 3, 2>, start_indices = array<i64: 2, 0>, strides = array<i64: 1, 1>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
         %177 = stablehlo.reshape %176 : (tensor<1x2xui32>) -> tensor<2xui32>
         %178 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
         %179 = stablehlo.constant dense<-1.000000e+00> : tensor<f32>
@@ -468,12 +468,12 @@ module @jit_testcase {
           stablehlo.return %227 : tensor<i1>
         } do {
           %226 = stablehlo.iota dim = 0 : tensor<4xui32>
-          %227 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+          %227 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
           %228 = stablehlo.reshape %227 : (tensor<1xui32>) -> tensor<ui32>
-          %229 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+          %229 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
           %230 = stablehlo.reshape %229 : (tensor<1xui32>) -> tensor<ui32>
-          %231 = "stablehlo.slice"(%226) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-          %232 = "stablehlo.slice"(%226) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+          %231 = "stablehlo.slice"(%226) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+          %232 = "stablehlo.slice"(%226) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
           %233 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
           %234 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
           %235 = stablehlo.xor %228, %230 : tensor<ui32>
@@ -493,7 +493,7 @@ module @jit_testcase {
           } do {
             %299 = stablehlo.constant dense<1> : tensor<i32>
             %300 = stablehlo.add %iterArg_14, %299 : tensor<i32>
-            %301 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %301 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %302 = stablehlo.reshape %301 : (tensor<1xui32>) -> tensor<ui32>
             %303 = stablehlo.add %iterArg_15, %iterArg_16 : tensor<2xui32>
             %304 = stablehlo.broadcast_in_dim %302, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -504,7 +504,7 @@ module @jit_testcase {
             %309 = stablehlo.shift_right_logical %iterArg_16, %308 : tensor<2xui32>
             %310 = stablehlo.or %305, %309 : tensor<2xui32>
             %311 = stablehlo.xor %303, %310 : tensor<2xui32>
-            %312 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %312 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %313 = stablehlo.reshape %312 : (tensor<1xui32>) -> tensor<ui32>
             %314 = stablehlo.add %303, %311 : tensor<2xui32>
             %315 = stablehlo.broadcast_in_dim %313, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -515,7 +515,7 @@ module @jit_testcase {
             %320 = stablehlo.shift_right_logical %311, %319 : tensor<2xui32>
             %321 = stablehlo.or %316, %320 : tensor<2xui32>
             %322 = stablehlo.xor %314, %321 : tensor<2xui32>
-            %323 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %323 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %324 = stablehlo.reshape %323 : (tensor<1xui32>) -> tensor<ui32>
             %325 = stablehlo.add %314, %322 : tensor<2xui32>
             %326 = stablehlo.broadcast_in_dim %324, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -526,7 +526,7 @@ module @jit_testcase {
             %331 = stablehlo.shift_right_logical %322, %330 : tensor<2xui32>
             %332 = stablehlo.or %327, %331 : tensor<2xui32>
             %333 = stablehlo.xor %325, %332 : tensor<2xui32>
-            %334 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %334 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %335 = stablehlo.reshape %334 : (tensor<1xui32>) -> tensor<ui32>
             %336 = stablehlo.add %325, %333 : tensor<2xui32>
             %337 = stablehlo.broadcast_in_dim %335, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -552,19 +552,19 @@ module @jit_testcase {
           }
           %245 = stablehlo.concatenate %244#2, %244#3, dim = 0 : (tensor<2xui32>, tensor<2xui32>) -> tensor<4xui32>
           %246 = stablehlo.reshape %245 : (tensor<4xui32>) -> tensor<2x2xui32>
-          %247 = "stablehlo.slice"(%246) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+          %247 = "stablehlo.slice"(%246) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
           %248 = stablehlo.reshape %247 : (tensor<1x2xui32>) -> tensor<2xui32>
-          %249 = "stablehlo.slice"(%246) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+          %249 = "stablehlo.slice"(%246) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
           %250 = stablehlo.reshape %249 : (tensor<1x2xui32>) -> tensor<2xui32>
           %251 = stablehlo.constant dense<0> : tensor<1xui32>
           %252 = stablehlo.iota dim = 0 : tensor<1xui32>
-          %253 = "stablehlo.slice"(%250) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+          %253 = "stablehlo.slice"(%250) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
           %254 = stablehlo.reshape %253 : (tensor<1xui32>) -> tensor<ui32>
-          %255 = "stablehlo.slice"(%250) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+          %255 = "stablehlo.slice"(%250) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
           %256 = stablehlo.reshape %255 : (tensor<1xui32>) -> tensor<ui32>
           %257 = stablehlo.concatenate %252, %251, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-          %258 = "stablehlo.slice"(%257) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-          %259 = "stablehlo.slice"(%257) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+          %258 = "stablehlo.slice"(%257) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+          %259 = "stablehlo.slice"(%257) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
           %260 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
           %261 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
           %262 = stablehlo.xor %254, %256 : tensor<ui32>
@@ -584,7 +584,7 @@ module @jit_testcase {
           } do {
             %299 = stablehlo.constant dense<1> : tensor<i32>
             %300 = stablehlo.add %iterArg_14, %299 : tensor<i32>
-            %301 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %301 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %302 = stablehlo.reshape %301 : (tensor<1xui32>) -> tensor<ui32>
             %303 = stablehlo.add %iterArg_15, %iterArg_16 : tensor<1xui32>
             %304 = stablehlo.broadcast_in_dim %302, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -595,7 +595,7 @@ module @jit_testcase {
             %309 = stablehlo.shift_right_logical %iterArg_16, %308 : tensor<1xui32>
             %310 = stablehlo.or %305, %309 : tensor<1xui32>
             %311 = stablehlo.xor %303, %310 : tensor<1xui32>
-            %312 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %312 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %313 = stablehlo.reshape %312 : (tensor<1xui32>) -> tensor<ui32>
             %314 = stablehlo.add %303, %311 : tensor<1xui32>
             %315 = stablehlo.broadcast_in_dim %313, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -606,7 +606,7 @@ module @jit_testcase {
             %320 = stablehlo.shift_right_logical %311, %319 : tensor<1xui32>
             %321 = stablehlo.or %316, %320 : tensor<1xui32>
             %322 = stablehlo.xor %314, %321 : tensor<1xui32>
-            %323 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %323 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %324 = stablehlo.reshape %323 : (tensor<1xui32>) -> tensor<ui32>
             %325 = stablehlo.add %314, %322 : tensor<1xui32>
             %326 = stablehlo.broadcast_in_dim %324, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -617,7 +617,7 @@ module @jit_testcase {
             %331 = stablehlo.shift_right_logical %322, %330 : tensor<1xui32>
             %332 = stablehlo.or %327, %331 : tensor<1xui32>
             %333 = stablehlo.xor %325, %332 : tensor<1xui32>
-            %334 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %334 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %335 = stablehlo.reshape %334 : (tensor<1xui32>) -> tensor<ui32>
             %336 = stablehlo.add %325, %333 : tensor<1xui32>
             %337 = stablehlo.broadcast_in_dim %335, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -675,13 +675,13 @@ module @jit_testcase {
         %183 = stablehlo.multiply %182, %180#3 : tensor<f32>
         %184 = stablehlo.constant dense<0> : tensor<1xui32>
         %185 = stablehlo.iota dim = 0 : tensor<1xui32>
-        %186 = "stablehlo.slice"(%177) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+        %186 = "stablehlo.slice"(%177) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
         %187 = stablehlo.reshape %186 : (tensor<1xui32>) -> tensor<ui32>
-        %188 = "stablehlo.slice"(%177) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+        %188 = "stablehlo.slice"(%177) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
         %189 = stablehlo.reshape %188 : (tensor<1xui32>) -> tensor<ui32>
         %190 = stablehlo.concatenate %185, %184, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-        %191 = "stablehlo.slice"(%190) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-        %192 = "stablehlo.slice"(%190) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+        %191 = "stablehlo.slice"(%190) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+        %192 = "stablehlo.slice"(%190) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
         %193 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
         %194 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
         %195 = stablehlo.xor %187, %189 : tensor<ui32>
@@ -701,7 +701,7 @@ module @jit_testcase {
         } do {
           %226 = stablehlo.constant dense<1> : tensor<i32>
           %227 = stablehlo.add %iterArg_10, %226 : tensor<i32>
-          %228 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %228 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %229 = stablehlo.reshape %228 : (tensor<1xui32>) -> tensor<ui32>
           %230 = stablehlo.add %iterArg_11, %iterArg_12 : tensor<1xui32>
           %231 = stablehlo.broadcast_in_dim %229, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -712,7 +712,7 @@ module @jit_testcase {
           %236 = stablehlo.shift_right_logical %iterArg_12, %235 : tensor<1xui32>
           %237 = stablehlo.or %232, %236 : tensor<1xui32>
           %238 = stablehlo.xor %230, %237 : tensor<1xui32>
-          %239 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %239 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %240 = stablehlo.reshape %239 : (tensor<1xui32>) -> tensor<ui32>
           %241 = stablehlo.add %230, %238 : tensor<1xui32>
           %242 = stablehlo.broadcast_in_dim %240, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -723,7 +723,7 @@ module @jit_testcase {
           %247 = stablehlo.shift_right_logical %238, %246 : tensor<1xui32>
           %248 = stablehlo.or %243, %247 : tensor<1xui32>
           %249 = stablehlo.xor %241, %248 : tensor<1xui32>
-          %250 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %250 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %251 = stablehlo.reshape %250 : (tensor<1xui32>) -> tensor<ui32>
           %252 = stablehlo.add %241, %249 : tensor<1xui32>
           %253 = stablehlo.broadcast_in_dim %251, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -734,7 +734,7 @@ module @jit_testcase {
           %258 = stablehlo.shift_right_logical %249, %257 : tensor<1xui32>
           %259 = stablehlo.or %254, %258 : tensor<1xui32>
           %260 = stablehlo.xor %252, %259 : tensor<1xui32>
-          %261 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %261 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %262 = stablehlo.reshape %261 : (tensor<1xui32>) -> tensor<ui32>
           %263 = stablehlo.add %252, %260 : tensor<1xui32>
           %264 = stablehlo.broadcast_in_dim %262, dims = [] : (tensor<ui32>) -> tensor<1xui32>

--- a/stablehlo/testdata/random_gamma_shape_float64.mlir
+++ b/stablehlo/testdata/random_gamma_shape_float64.mlir
@@ -23,12 +23,12 @@ module @jit_testcase {
   func.func private @gamma(%arg0: tensor<2xui32>, %arg1: tensor<f32>) -> tensor<f32> {
     %0 = stablehlo.reshape %arg0 : (tensor<2xui32>) -> tensor<1x2xui32>
     %1 = stablehlo.iota dim = 0 : tensor<2xui32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x2xui32>) -> tensor<1x1xui32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x2xui32>) -> tensor<1x1xui32>
     %3 = stablehlo.reshape %2 : (tensor<1x1xui32>) -> tensor<1xui32>
-    %4 = "stablehlo.slice"(%0) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x2xui32>) -> tensor<1x1xui32>
+    %4 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 1>} : (tensor<1x2xui32>) -> tensor<1x1xui32>
     %5 = stablehlo.reshape %4 : (tensor<1x1xui32>) -> tensor<1xui32>
-    %6 = "stablehlo.slice"(%1) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-    %7 = "stablehlo.slice"(%1) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %6 = "stablehlo.slice"(%1) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+    %7 = "stablehlo.slice"(%1) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %8 = stablehlo.broadcast_in_dim %6, dims = [1] : (tensor<1xui32>) -> tensor<1x1xui32>
     %9 = stablehlo.broadcast_in_dim %7, dims = [1] : (tensor<1xui32>) -> tensor<1x1xui32>
     %10 = stablehlo.broadcast_in_dim %3, dims = [0] : (tensor<1xui32>) -> tensor<1x1xui32>
@@ -51,7 +51,7 @@ module @jit_testcase {
     } do {
       %32 = stablehlo.constant dense<1> : tensor<i32>
       %33 = stablehlo.add %iterArg_0, %32 : tensor<i32>
-      %34 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %34 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %35 = stablehlo.reshape %34 : (tensor<1xui32>) -> tensor<ui32>
       %36 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<1x1xui32>
       %37 = stablehlo.broadcast_in_dim %35, dims = [] : (tensor<ui32>) -> tensor<1x1xui32>
@@ -62,7 +62,7 @@ module @jit_testcase {
       %42 = stablehlo.shift_right_logical %iterArg_2, %41 : tensor<1x1xui32>
       %43 = stablehlo.or %38, %42 : tensor<1x1xui32>
       %44 = stablehlo.xor %36, %43 : tensor<1x1xui32>
-      %45 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %45 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %46 = stablehlo.reshape %45 : (tensor<1xui32>) -> tensor<ui32>
       %47 = stablehlo.add %36, %44 : tensor<1x1xui32>
       %48 = stablehlo.broadcast_in_dim %46, dims = [] : (tensor<ui32>) -> tensor<1x1xui32>
@@ -73,7 +73,7 @@ module @jit_testcase {
       %53 = stablehlo.shift_right_logical %44, %52 : tensor<1x1xui32>
       %54 = stablehlo.or %49, %53 : tensor<1x1xui32>
       %55 = stablehlo.xor %47, %54 : tensor<1x1xui32>
-      %56 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %56 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %57 = stablehlo.reshape %56 : (tensor<1xui32>) -> tensor<ui32>
       %58 = stablehlo.add %47, %55 : tensor<1x1xui32>
       %59 = stablehlo.broadcast_in_dim %57, dims = [] : (tensor<ui32>) -> tensor<1x1xui32>
@@ -84,7 +84,7 @@ module @jit_testcase {
       %64 = stablehlo.shift_right_logical %55, %63 : tensor<1x1xui32>
       %65 = stablehlo.or %60, %64 : tensor<1x1xui32>
       %66 = stablehlo.xor %58, %65 : tensor<1x1xui32>
-      %67 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %67 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %68 = stablehlo.reshape %67 : (tensor<1xui32>) -> tensor<ui32>
       %69 = stablehlo.add %58, %66 : tensor<1x1xui32>
       %70 = stablehlo.broadcast_in_dim %68, dims = [] : (tensor<ui32>) -> tensor<1x1xui32>
@@ -147,12 +147,12 @@ module @jit_testcase {
       %57 = stablehlo.constant dense<0.333333343> : tensor<f32>
       %58 = stablehlo.divide %57, %56 : tensor<f32>
       %59 = stablehlo.iota dim = 0 : tensor<4xui32>
-      %60 = "stablehlo.slice"(%40) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+      %60 = "stablehlo.slice"(%40) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
       %61 = stablehlo.reshape %60 : (tensor<1xui32>) -> tensor<ui32>
-      %62 = "stablehlo.slice"(%40) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+      %62 = "stablehlo.slice"(%40) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
       %63 = stablehlo.reshape %62 : (tensor<1xui32>) -> tensor<ui32>
-      %64 = "stablehlo.slice"(%59) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-      %65 = "stablehlo.slice"(%59) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+      %64 = "stablehlo.slice"(%59) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+      %65 = "stablehlo.slice"(%59) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
       %66 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
       %67 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
       %68 = stablehlo.xor %61, %63 : tensor<ui32>
@@ -172,7 +172,7 @@ module @jit_testcase {
       } do {
         %151 = stablehlo.constant dense<1> : tensor<i32>
         %152 = stablehlo.add %iterArg_4, %151 : tensor<i32>
-        %153 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %153 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %154 = stablehlo.reshape %153 : (tensor<1xui32>) -> tensor<ui32>
         %155 = stablehlo.add %iterArg_5, %iterArg_6 : tensor<2xui32>
         %156 = stablehlo.broadcast_in_dim %154, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -183,7 +183,7 @@ module @jit_testcase {
         %161 = stablehlo.shift_right_logical %iterArg_6, %160 : tensor<2xui32>
         %162 = stablehlo.or %157, %161 : tensor<2xui32>
         %163 = stablehlo.xor %155, %162 : tensor<2xui32>
-        %164 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %164 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %165 = stablehlo.reshape %164 : (tensor<1xui32>) -> tensor<ui32>
         %166 = stablehlo.add %155, %163 : tensor<2xui32>
         %167 = stablehlo.broadcast_in_dim %165, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -194,7 +194,7 @@ module @jit_testcase {
         %172 = stablehlo.shift_right_logical %163, %171 : tensor<2xui32>
         %173 = stablehlo.or %168, %172 : tensor<2xui32>
         %174 = stablehlo.xor %166, %173 : tensor<2xui32>
-        %175 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %175 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %176 = stablehlo.reshape %175 : (tensor<1xui32>) -> tensor<ui32>
         %177 = stablehlo.add %166, %174 : tensor<2xui32>
         %178 = stablehlo.broadcast_in_dim %176, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -205,7 +205,7 @@ module @jit_testcase {
         %183 = stablehlo.shift_right_logical %174, %182 : tensor<2xui32>
         %184 = stablehlo.or %179, %183 : tensor<2xui32>
         %185 = stablehlo.xor %177, %184 : tensor<2xui32>
-        %186 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %186 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %187 = stablehlo.reshape %186 : (tensor<1xui32>) -> tensor<ui32>
         %188 = stablehlo.add %177, %185 : tensor<2xui32>
         %189 = stablehlo.broadcast_in_dim %187, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -231,19 +231,19 @@ module @jit_testcase {
       }
       %78 = stablehlo.concatenate %77#2, %77#3, dim = 0 : (tensor<2xui32>, tensor<2xui32>) -> tensor<4xui32>
       %79 = stablehlo.reshape %78 : (tensor<4xui32>) -> tensor<2x2xui32>
-      %80 = "stablehlo.slice"(%79) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+      %80 = "stablehlo.slice"(%79) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
       %81 = stablehlo.reshape %80 : (tensor<1x2xui32>) -> tensor<2xui32>
-      %82 = "stablehlo.slice"(%79) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+      %82 = "stablehlo.slice"(%79) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
       %83 = stablehlo.reshape %82 : (tensor<1x2xui32>) -> tensor<2xui32>
       %84 = stablehlo.constant dense<0> : tensor<1xui32>
       %85 = stablehlo.iota dim = 0 : tensor<1xui32>
-      %86 = "stablehlo.slice"(%83) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+      %86 = "stablehlo.slice"(%83) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
       %87 = stablehlo.reshape %86 : (tensor<1xui32>) -> tensor<ui32>
-      %88 = "stablehlo.slice"(%83) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+      %88 = "stablehlo.slice"(%83) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
       %89 = stablehlo.reshape %88 : (tensor<1xui32>) -> tensor<ui32>
       %90 = stablehlo.concatenate %85, %84, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-      %91 = "stablehlo.slice"(%90) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-      %92 = "stablehlo.slice"(%90) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+      %91 = "stablehlo.slice"(%90) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+      %92 = "stablehlo.slice"(%90) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
       %93 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
       %94 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
       %95 = stablehlo.xor %87, %89 : tensor<ui32>
@@ -263,7 +263,7 @@ module @jit_testcase {
       } do {
         %151 = stablehlo.constant dense<1> : tensor<i32>
         %152 = stablehlo.add %iterArg_4, %151 : tensor<i32>
-        %153 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %153 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %154 = stablehlo.reshape %153 : (tensor<1xui32>) -> tensor<ui32>
         %155 = stablehlo.add %iterArg_5, %iterArg_6 : tensor<1xui32>
         %156 = stablehlo.broadcast_in_dim %154, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -274,7 +274,7 @@ module @jit_testcase {
         %161 = stablehlo.shift_right_logical %iterArg_6, %160 : tensor<1xui32>
         %162 = stablehlo.or %157, %161 : tensor<1xui32>
         %163 = stablehlo.xor %155, %162 : tensor<1xui32>
-        %164 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %164 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %165 = stablehlo.reshape %164 : (tensor<1xui32>) -> tensor<ui32>
         %166 = stablehlo.add %155, %163 : tensor<1xui32>
         %167 = stablehlo.broadcast_in_dim %165, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -285,7 +285,7 @@ module @jit_testcase {
         %172 = stablehlo.shift_right_logical %163, %171 : tensor<1xui32>
         %173 = stablehlo.or %168, %172 : tensor<1xui32>
         %174 = stablehlo.xor %166, %173 : tensor<1xui32>
-        %175 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %175 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %176 = stablehlo.reshape %175 : (tensor<1xui32>) -> tensor<ui32>
         %177 = stablehlo.add %166, %174 : tensor<1xui32>
         %178 = stablehlo.broadcast_in_dim %176, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -296,7 +296,7 @@ module @jit_testcase {
         %183 = stablehlo.shift_right_logical %174, %182 : tensor<1xui32>
         %184 = stablehlo.or %179, %183 : tensor<1xui32>
         %185 = stablehlo.xor %177, %184 : tensor<1xui32>
-        %186 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %186 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %187 = stablehlo.reshape %186 : (tensor<1xui32>) -> tensor<ui32>
         %188 = stablehlo.add %177, %185 : tensor<1xui32>
         %189 = stablehlo.broadcast_in_dim %187, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -366,12 +366,12 @@ module @jit_testcase {
         stablehlo.return %167 : tensor<i1>
       } do {
         %151 = stablehlo.iota dim = 0 : tensor<6xui32>
-        %152 = "stablehlo.slice"(%iterArg_5) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+        %152 = "stablehlo.slice"(%iterArg_5) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
         %153 = stablehlo.reshape %152 : (tensor<1xui32>) -> tensor<ui32>
-        %154 = "stablehlo.slice"(%iterArg_5) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+        %154 = "stablehlo.slice"(%iterArg_5) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
         %155 = stablehlo.reshape %154 : (tensor<1xui32>) -> tensor<ui32>
-        %156 = "stablehlo.slice"(%151) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<6xui32>) -> tensor<3xui32>
-        %157 = "stablehlo.slice"(%151) {limit_indices = dense<6> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<6xui32>) -> tensor<3xui32>
+        %156 = "stablehlo.slice"(%151) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<6xui32>) -> tensor<3xui32>
+        %157 = "stablehlo.slice"(%151) {limit_indices = array<i64: 6>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<6xui32>) -> tensor<3xui32>
         %158 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
         %159 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
         %160 = stablehlo.xor %153, %155 : tensor<ui32>
@@ -391,7 +391,7 @@ module @jit_testcase {
         } do {
           %226 = stablehlo.constant dense<1> : tensor<i32>
           %227 = stablehlo.add %iterArg_10, %226 : tensor<i32>
-          %228 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %228 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %229 = stablehlo.reshape %228 : (tensor<1xui32>) -> tensor<ui32>
           %230 = stablehlo.add %iterArg_11, %iterArg_12 : tensor<3xui32>
           %231 = stablehlo.broadcast_in_dim %229, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -402,7 +402,7 @@ module @jit_testcase {
           %236 = stablehlo.shift_right_logical %iterArg_12, %235 : tensor<3xui32>
           %237 = stablehlo.or %232, %236 : tensor<3xui32>
           %238 = stablehlo.xor %230, %237 : tensor<3xui32>
-          %239 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %239 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %240 = stablehlo.reshape %239 : (tensor<1xui32>) -> tensor<ui32>
           %241 = stablehlo.add %230, %238 : tensor<3xui32>
           %242 = stablehlo.broadcast_in_dim %240, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -413,7 +413,7 @@ module @jit_testcase {
           %247 = stablehlo.shift_right_logical %238, %246 : tensor<3xui32>
           %248 = stablehlo.or %243, %247 : tensor<3xui32>
           %249 = stablehlo.xor %241, %248 : tensor<3xui32>
-          %250 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %250 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %251 = stablehlo.reshape %250 : (tensor<1xui32>) -> tensor<ui32>
           %252 = stablehlo.add %241, %249 : tensor<3xui32>
           %253 = stablehlo.broadcast_in_dim %251, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -424,7 +424,7 @@ module @jit_testcase {
           %258 = stablehlo.shift_right_logical %249, %257 : tensor<3xui32>
           %259 = stablehlo.or %254, %258 : tensor<3xui32>
           %260 = stablehlo.xor %252, %259 : tensor<3xui32>
-          %261 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %261 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %262 = stablehlo.reshape %261 : (tensor<1xui32>) -> tensor<ui32>
           %263 = stablehlo.add %252, %260 : tensor<3xui32>
           %264 = stablehlo.broadcast_in_dim %262, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -450,11 +450,11 @@ module @jit_testcase {
         }
         %170 = stablehlo.concatenate %169#2, %169#3, dim = 0 : (tensor<3xui32>, tensor<3xui32>) -> tensor<6xui32>
         %171 = stablehlo.reshape %170 : (tensor<6xui32>) -> tensor<3x2xui32>
-        %172 = "stablehlo.slice"(%171) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
+        %172 = "stablehlo.slice"(%171) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
         %173 = stablehlo.reshape %172 : (tensor<1x2xui32>) -> tensor<2xui32>
-        %174 = "stablehlo.slice"(%171) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
+        %174 = "stablehlo.slice"(%171) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
         %175 = stablehlo.reshape %174 : (tensor<1x2xui32>) -> tensor<2xui32>
-        %176 = "stablehlo.slice"(%171) {limit_indices = dense<[3, 2]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
+        %176 = "stablehlo.slice"(%171) {limit_indices = array<i64: 3, 2>, start_indices = array<i64: 2, 0>, strides = array<i64: 1, 1>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
         %177 = stablehlo.reshape %176 : (tensor<1x2xui32>) -> tensor<2xui32>
         %178 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
         %179 = stablehlo.constant dense<-1.000000e+00> : tensor<f32>
@@ -465,12 +465,12 @@ module @jit_testcase {
           stablehlo.return %227 : tensor<i1>
         } do {
           %226 = stablehlo.iota dim = 0 : tensor<4xui32>
-          %227 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+          %227 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
           %228 = stablehlo.reshape %227 : (tensor<1xui32>) -> tensor<ui32>
-          %229 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+          %229 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
           %230 = stablehlo.reshape %229 : (tensor<1xui32>) -> tensor<ui32>
-          %231 = "stablehlo.slice"(%226) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-          %232 = "stablehlo.slice"(%226) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+          %231 = "stablehlo.slice"(%226) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+          %232 = "stablehlo.slice"(%226) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
           %233 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
           %234 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
           %235 = stablehlo.xor %228, %230 : tensor<ui32>
@@ -490,7 +490,7 @@ module @jit_testcase {
           } do {
             %299 = stablehlo.constant dense<1> : tensor<i32>
             %300 = stablehlo.add %iterArg_14, %299 : tensor<i32>
-            %301 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %301 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %302 = stablehlo.reshape %301 : (tensor<1xui32>) -> tensor<ui32>
             %303 = stablehlo.add %iterArg_15, %iterArg_16 : tensor<2xui32>
             %304 = stablehlo.broadcast_in_dim %302, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -501,7 +501,7 @@ module @jit_testcase {
             %309 = stablehlo.shift_right_logical %iterArg_16, %308 : tensor<2xui32>
             %310 = stablehlo.or %305, %309 : tensor<2xui32>
             %311 = stablehlo.xor %303, %310 : tensor<2xui32>
-            %312 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %312 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %313 = stablehlo.reshape %312 : (tensor<1xui32>) -> tensor<ui32>
             %314 = stablehlo.add %303, %311 : tensor<2xui32>
             %315 = stablehlo.broadcast_in_dim %313, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -512,7 +512,7 @@ module @jit_testcase {
             %320 = stablehlo.shift_right_logical %311, %319 : tensor<2xui32>
             %321 = stablehlo.or %316, %320 : tensor<2xui32>
             %322 = stablehlo.xor %314, %321 : tensor<2xui32>
-            %323 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %323 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %324 = stablehlo.reshape %323 : (tensor<1xui32>) -> tensor<ui32>
             %325 = stablehlo.add %314, %322 : tensor<2xui32>
             %326 = stablehlo.broadcast_in_dim %324, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -523,7 +523,7 @@ module @jit_testcase {
             %331 = stablehlo.shift_right_logical %322, %330 : tensor<2xui32>
             %332 = stablehlo.or %327, %331 : tensor<2xui32>
             %333 = stablehlo.xor %325, %332 : tensor<2xui32>
-            %334 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %334 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %335 = stablehlo.reshape %334 : (tensor<1xui32>) -> tensor<ui32>
             %336 = stablehlo.add %325, %333 : tensor<2xui32>
             %337 = stablehlo.broadcast_in_dim %335, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -549,19 +549,19 @@ module @jit_testcase {
           }
           %245 = stablehlo.concatenate %244#2, %244#3, dim = 0 : (tensor<2xui32>, tensor<2xui32>) -> tensor<4xui32>
           %246 = stablehlo.reshape %245 : (tensor<4xui32>) -> tensor<2x2xui32>
-          %247 = "stablehlo.slice"(%246) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+          %247 = "stablehlo.slice"(%246) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
           %248 = stablehlo.reshape %247 : (tensor<1x2xui32>) -> tensor<2xui32>
-          %249 = "stablehlo.slice"(%246) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+          %249 = "stablehlo.slice"(%246) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
           %250 = stablehlo.reshape %249 : (tensor<1x2xui32>) -> tensor<2xui32>
           %251 = stablehlo.constant dense<0> : tensor<1xui32>
           %252 = stablehlo.iota dim = 0 : tensor<1xui32>
-          %253 = "stablehlo.slice"(%250) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+          %253 = "stablehlo.slice"(%250) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
           %254 = stablehlo.reshape %253 : (tensor<1xui32>) -> tensor<ui32>
-          %255 = "stablehlo.slice"(%250) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+          %255 = "stablehlo.slice"(%250) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
           %256 = stablehlo.reshape %255 : (tensor<1xui32>) -> tensor<ui32>
           %257 = stablehlo.concatenate %252, %251, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-          %258 = "stablehlo.slice"(%257) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-          %259 = "stablehlo.slice"(%257) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+          %258 = "stablehlo.slice"(%257) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+          %259 = "stablehlo.slice"(%257) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
           %260 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
           %261 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
           %262 = stablehlo.xor %254, %256 : tensor<ui32>
@@ -581,7 +581,7 @@ module @jit_testcase {
           } do {
             %299 = stablehlo.constant dense<1> : tensor<i32>
             %300 = stablehlo.add %iterArg_14, %299 : tensor<i32>
-            %301 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %301 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %302 = stablehlo.reshape %301 : (tensor<1xui32>) -> tensor<ui32>
             %303 = stablehlo.add %iterArg_15, %iterArg_16 : tensor<1xui32>
             %304 = stablehlo.broadcast_in_dim %302, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -592,7 +592,7 @@ module @jit_testcase {
             %309 = stablehlo.shift_right_logical %iterArg_16, %308 : tensor<1xui32>
             %310 = stablehlo.or %305, %309 : tensor<1xui32>
             %311 = stablehlo.xor %303, %310 : tensor<1xui32>
-            %312 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %312 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %313 = stablehlo.reshape %312 : (tensor<1xui32>) -> tensor<ui32>
             %314 = stablehlo.add %303, %311 : tensor<1xui32>
             %315 = stablehlo.broadcast_in_dim %313, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -603,7 +603,7 @@ module @jit_testcase {
             %320 = stablehlo.shift_right_logical %311, %319 : tensor<1xui32>
             %321 = stablehlo.or %316, %320 : tensor<1xui32>
             %322 = stablehlo.xor %314, %321 : tensor<1xui32>
-            %323 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %323 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %324 = stablehlo.reshape %323 : (tensor<1xui32>) -> tensor<ui32>
             %325 = stablehlo.add %314, %322 : tensor<1xui32>
             %326 = stablehlo.broadcast_in_dim %324, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -614,7 +614,7 @@ module @jit_testcase {
             %331 = stablehlo.shift_right_logical %322, %330 : tensor<1xui32>
             %332 = stablehlo.or %327, %331 : tensor<1xui32>
             %333 = stablehlo.xor %325, %332 : tensor<1xui32>
-            %334 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %334 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %335 = stablehlo.reshape %334 : (tensor<1xui32>) -> tensor<ui32>
             %336 = stablehlo.add %325, %333 : tensor<1xui32>
             %337 = stablehlo.broadcast_in_dim %335, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -672,13 +672,13 @@ module @jit_testcase {
         %183 = stablehlo.multiply %182, %180#3 : tensor<f32>
         %184 = stablehlo.constant dense<0> : tensor<1xui32>
         %185 = stablehlo.iota dim = 0 : tensor<1xui32>
-        %186 = "stablehlo.slice"(%177) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+        %186 = "stablehlo.slice"(%177) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
         %187 = stablehlo.reshape %186 : (tensor<1xui32>) -> tensor<ui32>
-        %188 = "stablehlo.slice"(%177) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+        %188 = "stablehlo.slice"(%177) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
         %189 = stablehlo.reshape %188 : (tensor<1xui32>) -> tensor<ui32>
         %190 = stablehlo.concatenate %185, %184, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-        %191 = "stablehlo.slice"(%190) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-        %192 = "stablehlo.slice"(%190) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+        %191 = "stablehlo.slice"(%190) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+        %192 = "stablehlo.slice"(%190) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
         %193 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
         %194 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
         %195 = stablehlo.xor %187, %189 : tensor<ui32>
@@ -698,7 +698,7 @@ module @jit_testcase {
         } do {
           %226 = stablehlo.constant dense<1> : tensor<i32>
           %227 = stablehlo.add %iterArg_10, %226 : tensor<i32>
-          %228 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %228 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %229 = stablehlo.reshape %228 : (tensor<1xui32>) -> tensor<ui32>
           %230 = stablehlo.add %iterArg_11, %iterArg_12 : tensor<1xui32>
           %231 = stablehlo.broadcast_in_dim %229, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -709,7 +709,7 @@ module @jit_testcase {
           %236 = stablehlo.shift_right_logical %iterArg_12, %235 : tensor<1xui32>
           %237 = stablehlo.or %232, %236 : tensor<1xui32>
           %238 = stablehlo.xor %230, %237 : tensor<1xui32>
-          %239 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %239 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %240 = stablehlo.reshape %239 : (tensor<1xui32>) -> tensor<ui32>
           %241 = stablehlo.add %230, %238 : tensor<1xui32>
           %242 = stablehlo.broadcast_in_dim %240, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -720,7 +720,7 @@ module @jit_testcase {
           %247 = stablehlo.shift_right_logical %238, %246 : tensor<1xui32>
           %248 = stablehlo.or %243, %247 : tensor<1xui32>
           %249 = stablehlo.xor %241, %248 : tensor<1xui32>
-          %250 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %250 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %251 = stablehlo.reshape %250 : (tensor<1xui32>) -> tensor<ui32>
           %252 = stablehlo.add %241, %249 : tensor<1xui32>
           %253 = stablehlo.broadcast_in_dim %251, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -731,7 +731,7 @@ module @jit_testcase {
           %258 = stablehlo.shift_right_logical %249, %257 : tensor<1xui32>
           %259 = stablehlo.or %254, %258 : tensor<1xui32>
           %260 = stablehlo.xor %252, %259 : tensor<1xui32>
-          %261 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %261 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %262 = stablehlo.reshape %261 : (tensor<1xui32>) -> tensor<ui32>
           %263 = stablehlo.add %252, %260 : tensor<1xui32>
           %264 = stablehlo.broadcast_in_dim %262, dims = [] : (tensor<ui32>) -> tensor<1xui32>

--- a/stablehlo/testdata/random_gamma_shape_float64_3.mlir
+++ b/stablehlo/testdata/random_gamma_shape_float64_3.mlir
@@ -23,12 +23,12 @@ module @jit_testcase {
   func.func private @gamma(%arg0: tensor<2xui32>, %arg1: tensor<3xf32>) -> tensor<3xf32> {
     %0 = stablehlo.reshape %arg0 : (tensor<2xui32>) -> tensor<1x2xui32>
     %1 = stablehlo.iota dim = 0 : tensor<6xui32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x2xui32>) -> tensor<1x1xui32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<1x2xui32>) -> tensor<1x1xui32>
     %3 = stablehlo.reshape %2 : (tensor<1x1xui32>) -> tensor<1xui32>
-    %4 = "stablehlo.slice"(%0) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<[0, 1]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<1x2xui32>) -> tensor<1x1xui32>
+    %4 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 1>, strides = array<i64: 1, 1>} : (tensor<1x2xui32>) -> tensor<1x1xui32>
     %5 = stablehlo.reshape %4 : (tensor<1x1xui32>) -> tensor<1xui32>
-    %6 = "stablehlo.slice"(%1) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<6xui32>) -> tensor<3xui32>
-    %7 = "stablehlo.slice"(%1) {limit_indices = dense<6> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<6xui32>) -> tensor<3xui32>
+    %6 = "stablehlo.slice"(%1) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<6xui32>) -> tensor<3xui32>
+    %7 = "stablehlo.slice"(%1) {limit_indices = array<i64: 6>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<6xui32>) -> tensor<3xui32>
     %8 = stablehlo.broadcast_in_dim %6, dims = [1] : (tensor<3xui32>) -> tensor<1x3xui32>
     %9 = stablehlo.broadcast_in_dim %7, dims = [1] : (tensor<3xui32>) -> tensor<1x3xui32>
     %10 = stablehlo.broadcast_in_dim %3, dims = [0] : (tensor<1xui32>) -> tensor<1x1xui32>
@@ -53,7 +53,7 @@ module @jit_testcase {
     } do {
       %32 = stablehlo.constant dense<1> : tensor<i32>
       %33 = stablehlo.add %iterArg_0, %32 : tensor<i32>
-      %34 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %34 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %35 = stablehlo.reshape %34 : (tensor<1xui32>) -> tensor<ui32>
       %36 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<1x3xui32>
       %37 = stablehlo.broadcast_in_dim %35, dims = [] : (tensor<ui32>) -> tensor<1x3xui32>
@@ -64,7 +64,7 @@ module @jit_testcase {
       %42 = stablehlo.shift_right_logical %iterArg_2, %41 : tensor<1x3xui32>
       %43 = stablehlo.or %38, %42 : tensor<1x3xui32>
       %44 = stablehlo.xor %36, %43 : tensor<1x3xui32>
-      %45 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %45 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %46 = stablehlo.reshape %45 : (tensor<1xui32>) -> tensor<ui32>
       %47 = stablehlo.add %36, %44 : tensor<1x3xui32>
       %48 = stablehlo.broadcast_in_dim %46, dims = [] : (tensor<ui32>) -> tensor<1x3xui32>
@@ -75,7 +75,7 @@ module @jit_testcase {
       %53 = stablehlo.shift_right_logical %44, %52 : tensor<1x3xui32>
       %54 = stablehlo.or %49, %53 : tensor<1x3xui32>
       %55 = stablehlo.xor %47, %54 : tensor<1x3xui32>
-      %56 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %56 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %57 = stablehlo.reshape %56 : (tensor<1xui32>) -> tensor<ui32>
       %58 = stablehlo.add %47, %55 : tensor<1x3xui32>
       %59 = stablehlo.broadcast_in_dim %57, dims = [] : (tensor<ui32>) -> tensor<1x3xui32>
@@ -86,7 +86,7 @@ module @jit_testcase {
       %64 = stablehlo.shift_right_logical %55, %63 : tensor<1x3xui32>
       %65 = stablehlo.or %60, %64 : tensor<1x3xui32>
       %66 = stablehlo.xor %58, %65 : tensor<1x3xui32>
-      %67 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %67 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %68 = stablehlo.reshape %67 : (tensor<1xui32>) -> tensor<ui32>
       %69 = stablehlo.add %58, %66 : tensor<1x3xui32>
       %70 = stablehlo.broadcast_in_dim %68, dims = [] : (tensor<ui32>) -> tensor<1x3xui32>
@@ -150,12 +150,12 @@ module @jit_testcase {
       %57 = stablehlo.constant dense<0.333333343> : tensor<f32>
       %58 = stablehlo.divide %57, %56 : tensor<f32>
       %59 = stablehlo.iota dim = 0 : tensor<4xui32>
-      %60 = "stablehlo.slice"(%40) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+      %60 = "stablehlo.slice"(%40) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
       %61 = stablehlo.reshape %60 : (tensor<1xui32>) -> tensor<ui32>
-      %62 = "stablehlo.slice"(%40) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+      %62 = "stablehlo.slice"(%40) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
       %63 = stablehlo.reshape %62 : (tensor<1xui32>) -> tensor<ui32>
-      %64 = "stablehlo.slice"(%59) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-      %65 = "stablehlo.slice"(%59) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+      %64 = "stablehlo.slice"(%59) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+      %65 = "stablehlo.slice"(%59) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
       %66 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
       %67 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
       %68 = stablehlo.xor %61, %63 : tensor<ui32>
@@ -175,7 +175,7 @@ module @jit_testcase {
       } do {
         %151 = stablehlo.constant dense<1> : tensor<i32>
         %152 = stablehlo.add %iterArg_4, %151 : tensor<i32>
-        %153 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %153 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %154 = stablehlo.reshape %153 : (tensor<1xui32>) -> tensor<ui32>
         %155 = stablehlo.add %iterArg_5, %iterArg_6 : tensor<2xui32>
         %156 = stablehlo.broadcast_in_dim %154, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -186,7 +186,7 @@ module @jit_testcase {
         %161 = stablehlo.shift_right_logical %iterArg_6, %160 : tensor<2xui32>
         %162 = stablehlo.or %157, %161 : tensor<2xui32>
         %163 = stablehlo.xor %155, %162 : tensor<2xui32>
-        %164 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %164 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %165 = stablehlo.reshape %164 : (tensor<1xui32>) -> tensor<ui32>
         %166 = stablehlo.add %155, %163 : tensor<2xui32>
         %167 = stablehlo.broadcast_in_dim %165, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -197,7 +197,7 @@ module @jit_testcase {
         %172 = stablehlo.shift_right_logical %163, %171 : tensor<2xui32>
         %173 = stablehlo.or %168, %172 : tensor<2xui32>
         %174 = stablehlo.xor %166, %173 : tensor<2xui32>
-        %175 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %175 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %176 = stablehlo.reshape %175 : (tensor<1xui32>) -> tensor<ui32>
         %177 = stablehlo.add %166, %174 : tensor<2xui32>
         %178 = stablehlo.broadcast_in_dim %176, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -208,7 +208,7 @@ module @jit_testcase {
         %183 = stablehlo.shift_right_logical %174, %182 : tensor<2xui32>
         %184 = stablehlo.or %179, %183 : tensor<2xui32>
         %185 = stablehlo.xor %177, %184 : tensor<2xui32>
-        %186 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %186 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %187 = stablehlo.reshape %186 : (tensor<1xui32>) -> tensor<ui32>
         %188 = stablehlo.add %177, %185 : tensor<2xui32>
         %189 = stablehlo.broadcast_in_dim %187, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -234,19 +234,19 @@ module @jit_testcase {
       }
       %78 = stablehlo.concatenate %77#2, %77#3, dim = 0 : (tensor<2xui32>, tensor<2xui32>) -> tensor<4xui32>
       %79 = stablehlo.reshape %78 : (tensor<4xui32>) -> tensor<2x2xui32>
-      %80 = "stablehlo.slice"(%79) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+      %80 = "stablehlo.slice"(%79) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
       %81 = stablehlo.reshape %80 : (tensor<1x2xui32>) -> tensor<2xui32>
-      %82 = "stablehlo.slice"(%79) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+      %82 = "stablehlo.slice"(%79) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
       %83 = stablehlo.reshape %82 : (tensor<1x2xui32>) -> tensor<2xui32>
       %84 = stablehlo.constant dense<0> : tensor<1xui32>
       %85 = stablehlo.iota dim = 0 : tensor<1xui32>
-      %86 = "stablehlo.slice"(%83) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+      %86 = "stablehlo.slice"(%83) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
       %87 = stablehlo.reshape %86 : (tensor<1xui32>) -> tensor<ui32>
-      %88 = "stablehlo.slice"(%83) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+      %88 = "stablehlo.slice"(%83) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
       %89 = stablehlo.reshape %88 : (tensor<1xui32>) -> tensor<ui32>
       %90 = stablehlo.concatenate %85, %84, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-      %91 = "stablehlo.slice"(%90) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-      %92 = "stablehlo.slice"(%90) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+      %91 = "stablehlo.slice"(%90) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+      %92 = "stablehlo.slice"(%90) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
       %93 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
       %94 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
       %95 = stablehlo.xor %87, %89 : tensor<ui32>
@@ -266,7 +266,7 @@ module @jit_testcase {
       } do {
         %151 = stablehlo.constant dense<1> : tensor<i32>
         %152 = stablehlo.add %iterArg_4, %151 : tensor<i32>
-        %153 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %153 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %154 = stablehlo.reshape %153 : (tensor<1xui32>) -> tensor<ui32>
         %155 = stablehlo.add %iterArg_5, %iterArg_6 : tensor<1xui32>
         %156 = stablehlo.broadcast_in_dim %154, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -277,7 +277,7 @@ module @jit_testcase {
         %161 = stablehlo.shift_right_logical %iterArg_6, %160 : tensor<1xui32>
         %162 = stablehlo.or %157, %161 : tensor<1xui32>
         %163 = stablehlo.xor %155, %162 : tensor<1xui32>
-        %164 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %164 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %165 = stablehlo.reshape %164 : (tensor<1xui32>) -> tensor<ui32>
         %166 = stablehlo.add %155, %163 : tensor<1xui32>
         %167 = stablehlo.broadcast_in_dim %165, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -288,7 +288,7 @@ module @jit_testcase {
         %172 = stablehlo.shift_right_logical %163, %171 : tensor<1xui32>
         %173 = stablehlo.or %168, %172 : tensor<1xui32>
         %174 = stablehlo.xor %166, %173 : tensor<1xui32>
-        %175 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %175 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %176 = stablehlo.reshape %175 : (tensor<1xui32>) -> tensor<ui32>
         %177 = stablehlo.add %166, %174 : tensor<1xui32>
         %178 = stablehlo.broadcast_in_dim %176, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -299,7 +299,7 @@ module @jit_testcase {
         %183 = stablehlo.shift_right_logical %174, %182 : tensor<1xui32>
         %184 = stablehlo.or %179, %183 : tensor<1xui32>
         %185 = stablehlo.xor %177, %184 : tensor<1xui32>
-        %186 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+        %186 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
         %187 = stablehlo.reshape %186 : (tensor<1xui32>) -> tensor<ui32>
         %188 = stablehlo.add %177, %185 : tensor<1xui32>
         %189 = stablehlo.broadcast_in_dim %187, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -369,12 +369,12 @@ module @jit_testcase {
         stablehlo.return %167 : tensor<i1>
       } do {
         %151 = stablehlo.iota dim = 0 : tensor<6xui32>
-        %152 = "stablehlo.slice"(%iterArg_5) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+        %152 = "stablehlo.slice"(%iterArg_5) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
         %153 = stablehlo.reshape %152 : (tensor<1xui32>) -> tensor<ui32>
-        %154 = "stablehlo.slice"(%iterArg_5) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+        %154 = "stablehlo.slice"(%iterArg_5) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
         %155 = stablehlo.reshape %154 : (tensor<1xui32>) -> tensor<ui32>
-        %156 = "stablehlo.slice"(%151) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<6xui32>) -> tensor<3xui32>
-        %157 = "stablehlo.slice"(%151) {limit_indices = dense<6> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<6xui32>) -> tensor<3xui32>
+        %156 = "stablehlo.slice"(%151) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<6xui32>) -> tensor<3xui32>
+        %157 = "stablehlo.slice"(%151) {limit_indices = array<i64: 6>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<6xui32>) -> tensor<3xui32>
         %158 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
         %159 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
         %160 = stablehlo.xor %153, %155 : tensor<ui32>
@@ -394,7 +394,7 @@ module @jit_testcase {
         } do {
           %226 = stablehlo.constant dense<1> : tensor<i32>
           %227 = stablehlo.add %iterArg_10, %226 : tensor<i32>
-          %228 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %228 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %229 = stablehlo.reshape %228 : (tensor<1xui32>) -> tensor<ui32>
           %230 = stablehlo.add %iterArg_11, %iterArg_12 : tensor<3xui32>
           %231 = stablehlo.broadcast_in_dim %229, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -405,7 +405,7 @@ module @jit_testcase {
           %236 = stablehlo.shift_right_logical %iterArg_12, %235 : tensor<3xui32>
           %237 = stablehlo.or %232, %236 : tensor<3xui32>
           %238 = stablehlo.xor %230, %237 : tensor<3xui32>
-          %239 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %239 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %240 = stablehlo.reshape %239 : (tensor<1xui32>) -> tensor<ui32>
           %241 = stablehlo.add %230, %238 : tensor<3xui32>
           %242 = stablehlo.broadcast_in_dim %240, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -416,7 +416,7 @@ module @jit_testcase {
           %247 = stablehlo.shift_right_logical %238, %246 : tensor<3xui32>
           %248 = stablehlo.or %243, %247 : tensor<3xui32>
           %249 = stablehlo.xor %241, %248 : tensor<3xui32>
-          %250 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %250 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %251 = stablehlo.reshape %250 : (tensor<1xui32>) -> tensor<ui32>
           %252 = stablehlo.add %241, %249 : tensor<3xui32>
           %253 = stablehlo.broadcast_in_dim %251, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -427,7 +427,7 @@ module @jit_testcase {
           %258 = stablehlo.shift_right_logical %249, %257 : tensor<3xui32>
           %259 = stablehlo.or %254, %258 : tensor<3xui32>
           %260 = stablehlo.xor %252, %259 : tensor<3xui32>
-          %261 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %261 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %262 = stablehlo.reshape %261 : (tensor<1xui32>) -> tensor<ui32>
           %263 = stablehlo.add %252, %260 : tensor<3xui32>
           %264 = stablehlo.broadcast_in_dim %262, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -453,11 +453,11 @@ module @jit_testcase {
         }
         %170 = stablehlo.concatenate %169#2, %169#3, dim = 0 : (tensor<3xui32>, tensor<3xui32>) -> tensor<6xui32>
         %171 = stablehlo.reshape %170 : (tensor<6xui32>) -> tensor<3x2xui32>
-        %172 = "stablehlo.slice"(%171) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
+        %172 = "stablehlo.slice"(%171) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
         %173 = stablehlo.reshape %172 : (tensor<1x2xui32>) -> tensor<2xui32>
-        %174 = "stablehlo.slice"(%171) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
+        %174 = "stablehlo.slice"(%171) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
         %175 = stablehlo.reshape %174 : (tensor<1x2xui32>) -> tensor<2xui32>
-        %176 = "stablehlo.slice"(%171) {limit_indices = dense<[3, 2]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
+        %176 = "stablehlo.slice"(%171) {limit_indices = array<i64: 3, 2>, start_indices = array<i64: 2, 0>, strides = array<i64: 1, 1>} : (tensor<3x2xui32>) -> tensor<1x2xui32>
         %177 = stablehlo.reshape %176 : (tensor<1x2xui32>) -> tensor<2xui32>
         %178 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
         %179 = stablehlo.constant dense<-1.000000e+00> : tensor<f32>
@@ -468,12 +468,12 @@ module @jit_testcase {
           stablehlo.return %227 : tensor<i1>
         } do {
           %226 = stablehlo.iota dim = 0 : tensor<4xui32>
-          %227 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+          %227 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
           %228 = stablehlo.reshape %227 : (tensor<1xui32>) -> tensor<ui32>
-          %229 = "stablehlo.slice"(%iterArg_10) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+          %229 = "stablehlo.slice"(%iterArg_10) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
           %230 = stablehlo.reshape %229 : (tensor<1xui32>) -> tensor<ui32>
-          %231 = "stablehlo.slice"(%226) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-          %232 = "stablehlo.slice"(%226) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+          %231 = "stablehlo.slice"(%226) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+          %232 = "stablehlo.slice"(%226) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
           %233 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
           %234 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
           %235 = stablehlo.xor %228, %230 : tensor<ui32>
@@ -493,7 +493,7 @@ module @jit_testcase {
           } do {
             %299 = stablehlo.constant dense<1> : tensor<i32>
             %300 = stablehlo.add %iterArg_14, %299 : tensor<i32>
-            %301 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %301 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %302 = stablehlo.reshape %301 : (tensor<1xui32>) -> tensor<ui32>
             %303 = stablehlo.add %iterArg_15, %iterArg_16 : tensor<2xui32>
             %304 = stablehlo.broadcast_in_dim %302, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -504,7 +504,7 @@ module @jit_testcase {
             %309 = stablehlo.shift_right_logical %iterArg_16, %308 : tensor<2xui32>
             %310 = stablehlo.or %305, %309 : tensor<2xui32>
             %311 = stablehlo.xor %303, %310 : tensor<2xui32>
-            %312 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %312 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %313 = stablehlo.reshape %312 : (tensor<1xui32>) -> tensor<ui32>
             %314 = stablehlo.add %303, %311 : tensor<2xui32>
             %315 = stablehlo.broadcast_in_dim %313, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -515,7 +515,7 @@ module @jit_testcase {
             %320 = stablehlo.shift_right_logical %311, %319 : tensor<2xui32>
             %321 = stablehlo.or %316, %320 : tensor<2xui32>
             %322 = stablehlo.xor %314, %321 : tensor<2xui32>
-            %323 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %323 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %324 = stablehlo.reshape %323 : (tensor<1xui32>) -> tensor<ui32>
             %325 = stablehlo.add %314, %322 : tensor<2xui32>
             %326 = stablehlo.broadcast_in_dim %324, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -526,7 +526,7 @@ module @jit_testcase {
             %331 = stablehlo.shift_right_logical %322, %330 : tensor<2xui32>
             %332 = stablehlo.or %327, %331 : tensor<2xui32>
             %333 = stablehlo.xor %325, %332 : tensor<2xui32>
-            %334 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %334 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %335 = stablehlo.reshape %334 : (tensor<1xui32>) -> tensor<ui32>
             %336 = stablehlo.add %325, %333 : tensor<2xui32>
             %337 = stablehlo.broadcast_in_dim %335, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -552,19 +552,19 @@ module @jit_testcase {
           }
           %245 = stablehlo.concatenate %244#2, %244#3, dim = 0 : (tensor<2xui32>, tensor<2xui32>) -> tensor<4xui32>
           %246 = stablehlo.reshape %245 : (tensor<4xui32>) -> tensor<2x2xui32>
-          %247 = "stablehlo.slice"(%246) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+          %247 = "stablehlo.slice"(%246) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
           %248 = stablehlo.reshape %247 : (tensor<1x2xui32>) -> tensor<2xui32>
-          %249 = "stablehlo.slice"(%246) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+          %249 = "stablehlo.slice"(%246) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
           %250 = stablehlo.reshape %249 : (tensor<1x2xui32>) -> tensor<2xui32>
           %251 = stablehlo.constant dense<0> : tensor<1xui32>
           %252 = stablehlo.iota dim = 0 : tensor<1xui32>
-          %253 = "stablehlo.slice"(%250) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+          %253 = "stablehlo.slice"(%250) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
           %254 = stablehlo.reshape %253 : (tensor<1xui32>) -> tensor<ui32>
-          %255 = "stablehlo.slice"(%250) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+          %255 = "stablehlo.slice"(%250) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
           %256 = stablehlo.reshape %255 : (tensor<1xui32>) -> tensor<ui32>
           %257 = stablehlo.concatenate %252, %251, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-          %258 = "stablehlo.slice"(%257) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-          %259 = "stablehlo.slice"(%257) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+          %258 = "stablehlo.slice"(%257) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+          %259 = "stablehlo.slice"(%257) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
           %260 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
           %261 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
           %262 = stablehlo.xor %254, %256 : tensor<ui32>
@@ -584,7 +584,7 @@ module @jit_testcase {
           } do {
             %299 = stablehlo.constant dense<1> : tensor<i32>
             %300 = stablehlo.add %iterArg_14, %299 : tensor<i32>
-            %301 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %301 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %302 = stablehlo.reshape %301 : (tensor<1xui32>) -> tensor<ui32>
             %303 = stablehlo.add %iterArg_15, %iterArg_16 : tensor<1xui32>
             %304 = stablehlo.broadcast_in_dim %302, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -595,7 +595,7 @@ module @jit_testcase {
             %309 = stablehlo.shift_right_logical %iterArg_16, %308 : tensor<1xui32>
             %310 = stablehlo.or %305, %309 : tensor<1xui32>
             %311 = stablehlo.xor %303, %310 : tensor<1xui32>
-            %312 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %312 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %313 = stablehlo.reshape %312 : (tensor<1xui32>) -> tensor<ui32>
             %314 = stablehlo.add %303, %311 : tensor<1xui32>
             %315 = stablehlo.broadcast_in_dim %313, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -606,7 +606,7 @@ module @jit_testcase {
             %320 = stablehlo.shift_right_logical %311, %319 : tensor<1xui32>
             %321 = stablehlo.or %316, %320 : tensor<1xui32>
             %322 = stablehlo.xor %314, %321 : tensor<1xui32>
-            %323 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %323 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %324 = stablehlo.reshape %323 : (tensor<1xui32>) -> tensor<ui32>
             %325 = stablehlo.add %314, %322 : tensor<1xui32>
             %326 = stablehlo.broadcast_in_dim %324, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -617,7 +617,7 @@ module @jit_testcase {
             %331 = stablehlo.shift_right_logical %322, %330 : tensor<1xui32>
             %332 = stablehlo.or %327, %331 : tensor<1xui32>
             %333 = stablehlo.xor %325, %332 : tensor<1xui32>
-            %334 = "stablehlo.slice"(%iterArg_20) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+            %334 = "stablehlo.slice"(%iterArg_20) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
             %335 = stablehlo.reshape %334 : (tensor<1xui32>) -> tensor<ui32>
             %336 = stablehlo.add %325, %333 : tensor<1xui32>
             %337 = stablehlo.broadcast_in_dim %335, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -675,13 +675,13 @@ module @jit_testcase {
         %183 = stablehlo.multiply %182, %180#3 : tensor<f32>
         %184 = stablehlo.constant dense<0> : tensor<1xui32>
         %185 = stablehlo.iota dim = 0 : tensor<1xui32>
-        %186 = "stablehlo.slice"(%177) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+        %186 = "stablehlo.slice"(%177) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
         %187 = stablehlo.reshape %186 : (tensor<1xui32>) -> tensor<ui32>
-        %188 = "stablehlo.slice"(%177) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+        %188 = "stablehlo.slice"(%177) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
         %189 = stablehlo.reshape %188 : (tensor<1xui32>) -> tensor<ui32>
         %190 = stablehlo.concatenate %185, %184, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-        %191 = "stablehlo.slice"(%190) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-        %192 = "stablehlo.slice"(%190) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+        %191 = "stablehlo.slice"(%190) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+        %192 = "stablehlo.slice"(%190) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
         %193 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
         %194 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
         %195 = stablehlo.xor %187, %189 : tensor<ui32>
@@ -701,7 +701,7 @@ module @jit_testcase {
         } do {
           %226 = stablehlo.constant dense<1> : tensor<i32>
           %227 = stablehlo.add %iterArg_10, %226 : tensor<i32>
-          %228 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %228 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %229 = stablehlo.reshape %228 : (tensor<1xui32>) -> tensor<ui32>
           %230 = stablehlo.add %iterArg_11, %iterArg_12 : tensor<1xui32>
           %231 = stablehlo.broadcast_in_dim %229, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -712,7 +712,7 @@ module @jit_testcase {
           %236 = stablehlo.shift_right_logical %iterArg_12, %235 : tensor<1xui32>
           %237 = stablehlo.or %232, %236 : tensor<1xui32>
           %238 = stablehlo.xor %230, %237 : tensor<1xui32>
-          %239 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %239 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %240 = stablehlo.reshape %239 : (tensor<1xui32>) -> tensor<ui32>
           %241 = stablehlo.add %230, %238 : tensor<1xui32>
           %242 = stablehlo.broadcast_in_dim %240, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -723,7 +723,7 @@ module @jit_testcase {
           %247 = stablehlo.shift_right_logical %238, %246 : tensor<1xui32>
           %248 = stablehlo.or %243, %247 : tensor<1xui32>
           %249 = stablehlo.xor %241, %248 : tensor<1xui32>
-          %250 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %250 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %251 = stablehlo.reshape %250 : (tensor<1xui32>) -> tensor<ui32>
           %252 = stablehlo.add %241, %249 : tensor<1xui32>
           %253 = stablehlo.broadcast_in_dim %251, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -734,7 +734,7 @@ module @jit_testcase {
           %258 = stablehlo.shift_right_logical %249, %257 : tensor<1xui32>
           %259 = stablehlo.or %254, %258 : tensor<1xui32>
           %260 = stablehlo.xor %252, %259 : tensor<1xui32>
-          %261 = "stablehlo.slice"(%iterArg_16) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+          %261 = "stablehlo.slice"(%iterArg_16) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
           %262 = stablehlo.reshape %261 : (tensor<1xui32>) -> tensor<ui32>
           %263 = stablehlo.add %252, %260 : tensor<1xui32>
           %264 = stablehlo.broadcast_in_dim %262, dims = [] : (tensor<ui32>) -> tensor<1xui32>

--- a/stablehlo/testdata/random_randint_shape_int16.mlir
+++ b/stablehlo/testdata/random_randint_shape_int16.mlir
@@ -25,12 +25,12 @@ module @jit_testcase {
     %17 = call @clip_1(%14, %15, %16) : (tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<i32>
     %18 = stablehlo.convert %17 : (tensor<i32>) -> tensor<i16>
     %19 = stablehlo.iota dim = 0 : tensor<4xui32>
-    %20 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %20 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %21 = stablehlo.reshape %20 : (tensor<1xui32>) -> tensor<ui32>
-    %22 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %22 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %23 = stablehlo.reshape %22 : (tensor<1xui32>) -> tensor<ui32>
-    %24 = "stablehlo.slice"(%19) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-    %25 = "stablehlo.slice"(%19) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+    %24 = "stablehlo.slice"(%19) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+    %25 = "stablehlo.slice"(%19) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
     %26 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %27 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %28 = stablehlo.xor %21, %23 : tensor<ui32>
@@ -50,7 +50,7 @@ module @jit_testcase {
     } do {
       %148 = stablehlo.constant dense<1> : tensor<i32>
       %149 = stablehlo.add %iterArg_0, %148 : tensor<i32>
-      %150 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %150 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %151 = stablehlo.reshape %150 : (tensor<1xui32>) -> tensor<ui32>
       %152 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<2xui32>
       %153 = stablehlo.broadcast_in_dim %151, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -61,7 +61,7 @@ module @jit_testcase {
       %158 = stablehlo.shift_right_logical %iterArg_2, %157 : tensor<2xui32>
       %159 = stablehlo.or %154, %158 : tensor<2xui32>
       %160 = stablehlo.xor %152, %159 : tensor<2xui32>
-      %161 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %161 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %162 = stablehlo.reshape %161 : (tensor<1xui32>) -> tensor<ui32>
       %163 = stablehlo.add %152, %160 : tensor<2xui32>
       %164 = stablehlo.broadcast_in_dim %162, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -72,7 +72,7 @@ module @jit_testcase {
       %169 = stablehlo.shift_right_logical %160, %168 : tensor<2xui32>
       %170 = stablehlo.or %165, %169 : tensor<2xui32>
       %171 = stablehlo.xor %163, %170 : tensor<2xui32>
-      %172 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %172 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %173 = stablehlo.reshape %172 : (tensor<1xui32>) -> tensor<ui32>
       %174 = stablehlo.add %163, %171 : tensor<2xui32>
       %175 = stablehlo.broadcast_in_dim %173, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -83,7 +83,7 @@ module @jit_testcase {
       %180 = stablehlo.shift_right_logical %171, %179 : tensor<2xui32>
       %181 = stablehlo.or %176, %180 : tensor<2xui32>
       %182 = stablehlo.xor %174, %181 : tensor<2xui32>
-      %183 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %183 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %184 = stablehlo.reshape %183 : (tensor<1xui32>) -> tensor<ui32>
       %185 = stablehlo.add %174, %182 : tensor<2xui32>
       %186 = stablehlo.broadcast_in_dim %184, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -109,19 +109,19 @@ module @jit_testcase {
     }
     %38 = stablehlo.concatenate %37#2, %37#3, dim = 0 : (tensor<2xui32>, tensor<2xui32>) -> tensor<4xui32>
     %39 = stablehlo.reshape %38 : (tensor<4xui32>) -> tensor<2x2xui32>
-    %40 = "stablehlo.slice"(%39) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+    %40 = "stablehlo.slice"(%39) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
     %41 = stablehlo.reshape %40 : (tensor<1x2xui32>) -> tensor<2xui32>
-    %42 = "stablehlo.slice"(%39) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+    %42 = "stablehlo.slice"(%39) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
     %43 = stablehlo.reshape %42 : (tensor<1x2xui32>) -> tensor<2xui32>
     %44 = stablehlo.constant dense<0> : tensor<1xui32>
     %45 = stablehlo.iota dim = 0 : tensor<1xui32>
-    %46 = "stablehlo.slice"(%41) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %46 = "stablehlo.slice"(%41) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %47 = stablehlo.reshape %46 : (tensor<1xui32>) -> tensor<ui32>
-    %48 = "stablehlo.slice"(%41) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %48 = "stablehlo.slice"(%41) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %49 = stablehlo.reshape %48 : (tensor<1xui32>) -> tensor<ui32>
     %50 = stablehlo.concatenate %45, %44, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-    %51 = "stablehlo.slice"(%50) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-    %52 = "stablehlo.slice"(%50) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %51 = "stablehlo.slice"(%50) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+    %52 = "stablehlo.slice"(%50) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %53 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %54 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %55 = stablehlo.xor %47, %49 : tensor<ui32>
@@ -141,7 +141,7 @@ module @jit_testcase {
     } do {
       %148 = stablehlo.constant dense<1> : tensor<i32>
       %149 = stablehlo.add %iterArg_0, %148 : tensor<i32>
-      %150 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %150 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %151 = stablehlo.reshape %150 : (tensor<1xui32>) -> tensor<ui32>
       %152 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<1xui32>
       %153 = stablehlo.broadcast_in_dim %151, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -152,7 +152,7 @@ module @jit_testcase {
       %158 = stablehlo.shift_right_logical %iterArg_2, %157 : tensor<1xui32>
       %159 = stablehlo.or %154, %158 : tensor<1xui32>
       %160 = stablehlo.xor %152, %159 : tensor<1xui32>
-      %161 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %161 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %162 = stablehlo.reshape %161 : (tensor<1xui32>) -> tensor<ui32>
       %163 = stablehlo.add %152, %160 : tensor<1xui32>
       %164 = stablehlo.broadcast_in_dim %162, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -163,7 +163,7 @@ module @jit_testcase {
       %169 = stablehlo.shift_right_logical %160, %168 : tensor<1xui32>
       %170 = stablehlo.or %165, %169 : tensor<1xui32>
       %171 = stablehlo.xor %163, %170 : tensor<1xui32>
-      %172 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %172 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %173 = stablehlo.reshape %172 : (tensor<1xui32>) -> tensor<ui32>
       %174 = stablehlo.add %163, %171 : tensor<1xui32>
       %175 = stablehlo.broadcast_in_dim %173, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -174,7 +174,7 @@ module @jit_testcase {
       %180 = stablehlo.shift_right_logical %171, %179 : tensor<1xui32>
       %181 = stablehlo.or %176, %180 : tensor<1xui32>
       %182 = stablehlo.xor %174, %181 : tensor<1xui32>
-      %183 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %183 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %184 = stablehlo.reshape %183 : (tensor<1xui32>) -> tensor<ui32>
       %185 = stablehlo.add %174, %182 : tensor<1xui32>
       %186 = stablehlo.broadcast_in_dim %184, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -220,13 +220,13 @@ module @jit_testcase {
     %84 = stablehlo.reshape %83 : (tensor<1xui16>) -> tensor<ui16>
     %85 = stablehlo.constant dense<0> : tensor<1xui32>
     %86 = stablehlo.iota dim = 0 : tensor<1xui32>
-    %87 = "stablehlo.slice"(%43) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %87 = "stablehlo.slice"(%43) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %88 = stablehlo.reshape %87 : (tensor<1xui32>) -> tensor<ui32>
-    %89 = "stablehlo.slice"(%43) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %89 = "stablehlo.slice"(%43) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %90 = stablehlo.reshape %89 : (tensor<1xui32>) -> tensor<ui32>
     %91 = stablehlo.concatenate %86, %85, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-    %92 = "stablehlo.slice"(%91) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-    %93 = "stablehlo.slice"(%91) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %92 = "stablehlo.slice"(%91) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+    %93 = "stablehlo.slice"(%91) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %94 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %95 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %96 = stablehlo.xor %88, %90 : tensor<ui32>
@@ -246,7 +246,7 @@ module @jit_testcase {
     } do {
       %148 = stablehlo.constant dense<1> : tensor<i32>
       %149 = stablehlo.add %iterArg_0, %148 : tensor<i32>
-      %150 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %150 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %151 = stablehlo.reshape %150 : (tensor<1xui32>) -> tensor<ui32>
       %152 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<1xui32>
       %153 = stablehlo.broadcast_in_dim %151, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -257,7 +257,7 @@ module @jit_testcase {
       %158 = stablehlo.shift_right_logical %iterArg_2, %157 : tensor<1xui32>
       %159 = stablehlo.or %154, %158 : tensor<1xui32>
       %160 = stablehlo.xor %152, %159 : tensor<1xui32>
-      %161 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %161 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %162 = stablehlo.reshape %161 : (tensor<1xui32>) -> tensor<ui32>
       %163 = stablehlo.add %152, %160 : tensor<1xui32>
       %164 = stablehlo.broadcast_in_dim %162, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -268,7 +268,7 @@ module @jit_testcase {
       %169 = stablehlo.shift_right_logical %160, %168 : tensor<1xui32>
       %170 = stablehlo.or %165, %169 : tensor<1xui32>
       %171 = stablehlo.xor %163, %170 : tensor<1xui32>
-      %172 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %172 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %173 = stablehlo.reshape %172 : (tensor<1xui32>) -> tensor<ui32>
       %174 = stablehlo.add %163, %171 : tensor<1xui32>
       %175 = stablehlo.broadcast_in_dim %173, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -279,7 +279,7 @@ module @jit_testcase {
       %180 = stablehlo.shift_right_logical %171, %179 : tensor<1xui32>
       %181 = stablehlo.or %176, %180 : tensor<1xui32>
       %182 = stablehlo.xor %174, %181 : tensor<1xui32>
-      %183 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %183 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %184 = stablehlo.reshape %183 : (tensor<1xui32>) -> tensor<ui32>
       %185 = stablehlo.add %174, %182 : tensor<1xui32>
       %186 = stablehlo.broadcast_in_dim %184, dims = [] : (tensor<ui32>) -> tensor<1xui32>

--- a/stablehlo/testdata/random_randint_shape_int16_32.mlir
+++ b/stablehlo/testdata/random_randint_shape_int16_32.mlir
@@ -27,12 +27,12 @@ module @jit_testcase {
     %19 = stablehlo.broadcast_in_dim %13, dims = [] : (tensor<i16>) -> tensor<1xi16>
     %20 = stablehlo.broadcast_in_dim %18, dims = [] : (tensor<i16>) -> tensor<1xi16>
     %21 = stablehlo.iota dim = 0 : tensor<4xui32>
-    %22 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %22 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %23 = stablehlo.reshape %22 : (tensor<1xui32>) -> tensor<ui32>
-    %24 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %24 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %25 = stablehlo.reshape %24 : (tensor<1xui32>) -> tensor<ui32>
-    %26 = "stablehlo.slice"(%21) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-    %27 = "stablehlo.slice"(%21) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+    %26 = "stablehlo.slice"(%21) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+    %27 = "stablehlo.slice"(%21) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
     %28 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %29 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %30 = stablehlo.xor %23, %25 : tensor<ui32>
@@ -52,7 +52,7 @@ module @jit_testcase {
     } do {
       %145 = stablehlo.constant dense<1> : tensor<i32>
       %146 = stablehlo.add %iterArg_0, %145 : tensor<i32>
-      %147 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %147 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %148 = stablehlo.reshape %147 : (tensor<1xui32>) -> tensor<ui32>
       %149 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<2xui32>
       %150 = stablehlo.broadcast_in_dim %148, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -63,7 +63,7 @@ module @jit_testcase {
       %155 = stablehlo.shift_right_logical %iterArg_2, %154 : tensor<2xui32>
       %156 = stablehlo.or %151, %155 : tensor<2xui32>
       %157 = stablehlo.xor %149, %156 : tensor<2xui32>
-      %158 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %158 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %159 = stablehlo.reshape %158 : (tensor<1xui32>) -> tensor<ui32>
       %160 = stablehlo.add %149, %157 : tensor<2xui32>
       %161 = stablehlo.broadcast_in_dim %159, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -74,7 +74,7 @@ module @jit_testcase {
       %166 = stablehlo.shift_right_logical %157, %165 : tensor<2xui32>
       %167 = stablehlo.or %162, %166 : tensor<2xui32>
       %168 = stablehlo.xor %160, %167 : tensor<2xui32>
-      %169 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %169 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %170 = stablehlo.reshape %169 : (tensor<1xui32>) -> tensor<ui32>
       %171 = stablehlo.add %160, %168 : tensor<2xui32>
       %172 = stablehlo.broadcast_in_dim %170, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -85,7 +85,7 @@ module @jit_testcase {
       %177 = stablehlo.shift_right_logical %168, %176 : tensor<2xui32>
       %178 = stablehlo.or %173, %177 : tensor<2xui32>
       %179 = stablehlo.xor %171, %178 : tensor<2xui32>
-      %180 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %180 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %181 = stablehlo.reshape %180 : (tensor<1xui32>) -> tensor<ui32>
       %182 = stablehlo.add %171, %179 : tensor<2xui32>
       %183 = stablehlo.broadcast_in_dim %181, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -111,17 +111,17 @@ module @jit_testcase {
     }
     %40 = stablehlo.concatenate %39#2, %39#3, dim = 0 : (tensor<2xui32>, tensor<2xui32>) -> tensor<4xui32>
     %41 = stablehlo.reshape %40 : (tensor<4xui32>) -> tensor<2x2xui32>
-    %42 = "stablehlo.slice"(%41) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+    %42 = "stablehlo.slice"(%41) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
     %43 = stablehlo.reshape %42 : (tensor<1x2xui32>) -> tensor<2xui32>
-    %44 = "stablehlo.slice"(%41) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+    %44 = "stablehlo.slice"(%41) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
     %45 = stablehlo.reshape %44 : (tensor<1x2xui32>) -> tensor<2xui32>
     %46 = stablehlo.iota dim = 0 : tensor<16xui32>
-    %47 = "stablehlo.slice"(%43) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %47 = "stablehlo.slice"(%43) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %48 = stablehlo.reshape %47 : (tensor<1xui32>) -> tensor<ui32>
-    %49 = "stablehlo.slice"(%43) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %49 = "stablehlo.slice"(%43) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %50 = stablehlo.reshape %49 : (tensor<1xui32>) -> tensor<ui32>
-    %51 = "stablehlo.slice"(%46) {limit_indices = dense<8> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<16xui32>) -> tensor<8xui32>
-    %52 = "stablehlo.slice"(%46) {limit_indices = dense<16> : tensor<1xi64>, start_indices = dense<8> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<16xui32>) -> tensor<8xui32>
+    %51 = "stablehlo.slice"(%46) {limit_indices = array<i64: 8>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<16xui32>) -> tensor<8xui32>
+    %52 = "stablehlo.slice"(%46) {limit_indices = array<i64: 16>, start_indices = array<i64: 8>, strides = array<i64: 1>} : (tensor<16xui32>) -> tensor<8xui32>
     %53 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %54 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %55 = stablehlo.xor %48, %50 : tensor<ui32>
@@ -141,7 +141,7 @@ module @jit_testcase {
     } do {
       %145 = stablehlo.constant dense<1> : tensor<i32>
       %146 = stablehlo.add %iterArg_0, %145 : tensor<i32>
-      %147 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %147 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %148 = stablehlo.reshape %147 : (tensor<1xui32>) -> tensor<ui32>
       %149 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<8xui32>
       %150 = stablehlo.broadcast_in_dim %148, dims = [] : (tensor<ui32>) -> tensor<8xui32>
@@ -152,7 +152,7 @@ module @jit_testcase {
       %155 = stablehlo.shift_right_logical %iterArg_2, %154 : tensor<8xui32>
       %156 = stablehlo.or %151, %155 : tensor<8xui32>
       %157 = stablehlo.xor %149, %156 : tensor<8xui32>
-      %158 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %158 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %159 = stablehlo.reshape %158 : (tensor<1xui32>) -> tensor<ui32>
       %160 = stablehlo.add %149, %157 : tensor<8xui32>
       %161 = stablehlo.broadcast_in_dim %159, dims = [] : (tensor<ui32>) -> tensor<8xui32>
@@ -163,7 +163,7 @@ module @jit_testcase {
       %166 = stablehlo.shift_right_logical %157, %165 : tensor<8xui32>
       %167 = stablehlo.or %162, %166 : tensor<8xui32>
       %168 = stablehlo.xor %160, %167 : tensor<8xui32>
-      %169 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %169 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %170 = stablehlo.reshape %169 : (tensor<1xui32>) -> tensor<ui32>
       %171 = stablehlo.add %160, %168 : tensor<8xui32>
       %172 = stablehlo.broadcast_in_dim %170, dims = [] : (tensor<ui32>) -> tensor<8xui32>
@@ -174,7 +174,7 @@ module @jit_testcase {
       %177 = stablehlo.shift_right_logical %168, %176 : tensor<8xui32>
       %178 = stablehlo.or %173, %177 : tensor<8xui32>
       %179 = stablehlo.xor %171, %178 : tensor<8xui32>
-      %180 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %180 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %181 = stablehlo.reshape %180 : (tensor<1xui32>) -> tensor<ui32>
       %182 = stablehlo.add %171, %179 : tensor<8xui32>
       %183 = stablehlo.broadcast_in_dim %181, dims = [] : (tensor<ui32>) -> tensor<8xui32>
@@ -214,12 +214,12 @@ module @jit_testcase {
     %78 = stablehlo.reshape %77 : (tensor<16x2xui32>) -> tensor<32xui32>
     %79 = stablehlo.convert %78 : (tensor<32xui32>) -> tensor<32xui16>
     %80 = stablehlo.iota dim = 0 : tensor<16xui32>
-    %81 = "stablehlo.slice"(%45) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %81 = "stablehlo.slice"(%45) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %82 = stablehlo.reshape %81 : (tensor<1xui32>) -> tensor<ui32>
-    %83 = "stablehlo.slice"(%45) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %83 = "stablehlo.slice"(%45) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %84 = stablehlo.reshape %83 : (tensor<1xui32>) -> tensor<ui32>
-    %85 = "stablehlo.slice"(%80) {limit_indices = dense<8> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<16xui32>) -> tensor<8xui32>
-    %86 = "stablehlo.slice"(%80) {limit_indices = dense<16> : tensor<1xi64>, start_indices = dense<8> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<16xui32>) -> tensor<8xui32>
+    %85 = "stablehlo.slice"(%80) {limit_indices = array<i64: 8>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<16xui32>) -> tensor<8xui32>
+    %86 = "stablehlo.slice"(%80) {limit_indices = array<i64: 16>, start_indices = array<i64: 8>, strides = array<i64: 1>} : (tensor<16xui32>) -> tensor<8xui32>
     %87 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %88 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %89 = stablehlo.xor %82, %84 : tensor<ui32>
@@ -239,7 +239,7 @@ module @jit_testcase {
     } do {
       %145 = stablehlo.constant dense<1> : tensor<i32>
       %146 = stablehlo.add %iterArg_0, %145 : tensor<i32>
-      %147 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %147 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %148 = stablehlo.reshape %147 : (tensor<1xui32>) -> tensor<ui32>
       %149 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<8xui32>
       %150 = stablehlo.broadcast_in_dim %148, dims = [] : (tensor<ui32>) -> tensor<8xui32>
@@ -250,7 +250,7 @@ module @jit_testcase {
       %155 = stablehlo.shift_right_logical %iterArg_2, %154 : tensor<8xui32>
       %156 = stablehlo.or %151, %155 : tensor<8xui32>
       %157 = stablehlo.xor %149, %156 : tensor<8xui32>
-      %158 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %158 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %159 = stablehlo.reshape %158 : (tensor<1xui32>) -> tensor<ui32>
       %160 = stablehlo.add %149, %157 : tensor<8xui32>
       %161 = stablehlo.broadcast_in_dim %159, dims = [] : (tensor<ui32>) -> tensor<8xui32>
@@ -261,7 +261,7 @@ module @jit_testcase {
       %166 = stablehlo.shift_right_logical %157, %165 : tensor<8xui32>
       %167 = stablehlo.or %162, %166 : tensor<8xui32>
       %168 = stablehlo.xor %160, %167 : tensor<8xui32>
-      %169 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %169 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %170 = stablehlo.reshape %169 : (tensor<1xui32>) -> tensor<ui32>
       %171 = stablehlo.add %160, %168 : tensor<8xui32>
       %172 = stablehlo.broadcast_in_dim %170, dims = [] : (tensor<ui32>) -> tensor<8xui32>
@@ -272,7 +272,7 @@ module @jit_testcase {
       %177 = stablehlo.shift_right_logical %168, %176 : tensor<8xui32>
       %178 = stablehlo.or %173, %177 : tensor<8xui32>
       %179 = stablehlo.xor %171, %178 : tensor<8xui32>
-      %180 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %180 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %181 = stablehlo.reshape %180 : (tensor<1xui32>) -> tensor<ui32>
       %182 = stablehlo.add %171, %179 : tensor<8xui32>
       %183 = stablehlo.broadcast_in_dim %181, dims = [] : (tensor<ui32>) -> tensor<8xui32>

--- a/stablehlo/testdata/random_randint_shape_int16_5_4.mlir
+++ b/stablehlo/testdata/random_randint_shape_int16_5_4.mlir
@@ -27,12 +27,12 @@ module @jit_testcase {
     %19 = stablehlo.broadcast_in_dim %13, dims = [] : (tensor<i16>) -> tensor<1x1xi16>
     %20 = stablehlo.broadcast_in_dim %18, dims = [] : (tensor<i16>) -> tensor<1x1xi16>
     %21 = stablehlo.iota dim = 0 : tensor<4xui32>
-    %22 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %22 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %23 = stablehlo.reshape %22 : (tensor<1xui32>) -> tensor<ui32>
-    %24 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %24 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %25 = stablehlo.reshape %24 : (tensor<1xui32>) -> tensor<ui32>
-    %26 = "stablehlo.slice"(%21) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-    %27 = "stablehlo.slice"(%21) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+    %26 = "stablehlo.slice"(%21) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+    %27 = "stablehlo.slice"(%21) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
     %28 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %29 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %30 = stablehlo.xor %23, %25 : tensor<ui32>
@@ -52,7 +52,7 @@ module @jit_testcase {
     } do {
       %147 = stablehlo.constant dense<1> : tensor<i32>
       %148 = stablehlo.add %iterArg_0, %147 : tensor<i32>
-      %149 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %149 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %150 = stablehlo.reshape %149 : (tensor<1xui32>) -> tensor<ui32>
       %151 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<2xui32>
       %152 = stablehlo.broadcast_in_dim %150, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -63,7 +63,7 @@ module @jit_testcase {
       %157 = stablehlo.shift_right_logical %iterArg_2, %156 : tensor<2xui32>
       %158 = stablehlo.or %153, %157 : tensor<2xui32>
       %159 = stablehlo.xor %151, %158 : tensor<2xui32>
-      %160 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %160 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %161 = stablehlo.reshape %160 : (tensor<1xui32>) -> tensor<ui32>
       %162 = stablehlo.add %151, %159 : tensor<2xui32>
       %163 = stablehlo.broadcast_in_dim %161, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -74,7 +74,7 @@ module @jit_testcase {
       %168 = stablehlo.shift_right_logical %159, %167 : tensor<2xui32>
       %169 = stablehlo.or %164, %168 : tensor<2xui32>
       %170 = stablehlo.xor %162, %169 : tensor<2xui32>
-      %171 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %171 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %172 = stablehlo.reshape %171 : (tensor<1xui32>) -> tensor<ui32>
       %173 = stablehlo.add %162, %170 : tensor<2xui32>
       %174 = stablehlo.broadcast_in_dim %172, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -85,7 +85,7 @@ module @jit_testcase {
       %179 = stablehlo.shift_right_logical %170, %178 : tensor<2xui32>
       %180 = stablehlo.or %175, %179 : tensor<2xui32>
       %181 = stablehlo.xor %173, %180 : tensor<2xui32>
-      %182 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %182 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %183 = stablehlo.reshape %182 : (tensor<1xui32>) -> tensor<ui32>
       %184 = stablehlo.add %173, %181 : tensor<2xui32>
       %185 = stablehlo.broadcast_in_dim %183, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -111,17 +111,17 @@ module @jit_testcase {
     }
     %40 = stablehlo.concatenate %39#2, %39#3, dim = 0 : (tensor<2xui32>, tensor<2xui32>) -> tensor<4xui32>
     %41 = stablehlo.reshape %40 : (tensor<4xui32>) -> tensor<2x2xui32>
-    %42 = "stablehlo.slice"(%41) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+    %42 = "stablehlo.slice"(%41) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
     %43 = stablehlo.reshape %42 : (tensor<1x2xui32>) -> tensor<2xui32>
-    %44 = "stablehlo.slice"(%41) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+    %44 = "stablehlo.slice"(%41) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
     %45 = stablehlo.reshape %44 : (tensor<1x2xui32>) -> tensor<2xui32>
     %46 = stablehlo.iota dim = 0 : tensor<10xui32>
-    %47 = "stablehlo.slice"(%43) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %47 = "stablehlo.slice"(%43) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %48 = stablehlo.reshape %47 : (tensor<1xui32>) -> tensor<ui32>
-    %49 = "stablehlo.slice"(%43) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %49 = "stablehlo.slice"(%43) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %50 = stablehlo.reshape %49 : (tensor<1xui32>) -> tensor<ui32>
-    %51 = "stablehlo.slice"(%46) {limit_indices = dense<5> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<10xui32>) -> tensor<5xui32>
-    %52 = "stablehlo.slice"(%46) {limit_indices = dense<10> : tensor<1xi64>, start_indices = dense<5> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<10xui32>) -> tensor<5xui32>
+    %51 = "stablehlo.slice"(%46) {limit_indices = array<i64: 5>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<10xui32>) -> tensor<5xui32>
+    %52 = "stablehlo.slice"(%46) {limit_indices = array<i64: 10>, start_indices = array<i64: 5>, strides = array<i64: 1>} : (tensor<10xui32>) -> tensor<5xui32>
     %53 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %54 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %55 = stablehlo.xor %48, %50 : tensor<ui32>
@@ -141,7 +141,7 @@ module @jit_testcase {
     } do {
       %147 = stablehlo.constant dense<1> : tensor<i32>
       %148 = stablehlo.add %iterArg_0, %147 : tensor<i32>
-      %149 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %149 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %150 = stablehlo.reshape %149 : (tensor<1xui32>) -> tensor<ui32>
       %151 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<5xui32>
       %152 = stablehlo.broadcast_in_dim %150, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -152,7 +152,7 @@ module @jit_testcase {
       %157 = stablehlo.shift_right_logical %iterArg_2, %156 : tensor<5xui32>
       %158 = stablehlo.or %153, %157 : tensor<5xui32>
       %159 = stablehlo.xor %151, %158 : tensor<5xui32>
-      %160 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %160 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %161 = stablehlo.reshape %160 : (tensor<1xui32>) -> tensor<ui32>
       %162 = stablehlo.add %151, %159 : tensor<5xui32>
       %163 = stablehlo.broadcast_in_dim %161, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -163,7 +163,7 @@ module @jit_testcase {
       %168 = stablehlo.shift_right_logical %159, %167 : tensor<5xui32>
       %169 = stablehlo.or %164, %168 : tensor<5xui32>
       %170 = stablehlo.xor %162, %169 : tensor<5xui32>
-      %171 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %171 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %172 = stablehlo.reshape %171 : (tensor<1xui32>) -> tensor<ui32>
       %173 = stablehlo.add %162, %170 : tensor<5xui32>
       %174 = stablehlo.broadcast_in_dim %172, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -174,7 +174,7 @@ module @jit_testcase {
       %179 = stablehlo.shift_right_logical %170, %178 : tensor<5xui32>
       %180 = stablehlo.or %175, %179 : tensor<5xui32>
       %181 = stablehlo.xor %173, %180 : tensor<5xui32>
-      %182 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %182 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %183 = stablehlo.reshape %182 : (tensor<1xui32>) -> tensor<ui32>
       %184 = stablehlo.add %173, %181 : tensor<5xui32>
       %185 = stablehlo.broadcast_in_dim %183, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -215,12 +215,12 @@ module @jit_testcase {
     %79 = stablehlo.convert %78 : (tensor<20xui32>) -> tensor<20xui16>
     %80 = stablehlo.reshape %79 : (tensor<20xui16>) -> tensor<5x4xui16>
     %81 = stablehlo.iota dim = 0 : tensor<10xui32>
-    %82 = "stablehlo.slice"(%45) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %82 = "stablehlo.slice"(%45) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %83 = stablehlo.reshape %82 : (tensor<1xui32>) -> tensor<ui32>
-    %84 = "stablehlo.slice"(%45) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %84 = "stablehlo.slice"(%45) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %85 = stablehlo.reshape %84 : (tensor<1xui32>) -> tensor<ui32>
-    %86 = "stablehlo.slice"(%81) {limit_indices = dense<5> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<10xui32>) -> tensor<5xui32>
-    %87 = "stablehlo.slice"(%81) {limit_indices = dense<10> : tensor<1xi64>, start_indices = dense<5> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<10xui32>) -> tensor<5xui32>
+    %86 = "stablehlo.slice"(%81) {limit_indices = array<i64: 5>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<10xui32>) -> tensor<5xui32>
+    %87 = "stablehlo.slice"(%81) {limit_indices = array<i64: 10>, start_indices = array<i64: 5>, strides = array<i64: 1>} : (tensor<10xui32>) -> tensor<5xui32>
     %88 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %89 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %90 = stablehlo.xor %83, %85 : tensor<ui32>
@@ -240,7 +240,7 @@ module @jit_testcase {
     } do {
       %147 = stablehlo.constant dense<1> : tensor<i32>
       %148 = stablehlo.add %iterArg_0, %147 : tensor<i32>
-      %149 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %149 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %150 = stablehlo.reshape %149 : (tensor<1xui32>) -> tensor<ui32>
       %151 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<5xui32>
       %152 = stablehlo.broadcast_in_dim %150, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -251,7 +251,7 @@ module @jit_testcase {
       %157 = stablehlo.shift_right_logical %iterArg_2, %156 : tensor<5xui32>
       %158 = stablehlo.or %153, %157 : tensor<5xui32>
       %159 = stablehlo.xor %151, %158 : tensor<5xui32>
-      %160 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %160 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %161 = stablehlo.reshape %160 : (tensor<1xui32>) -> tensor<ui32>
       %162 = stablehlo.add %151, %159 : tensor<5xui32>
       %163 = stablehlo.broadcast_in_dim %161, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -262,7 +262,7 @@ module @jit_testcase {
       %168 = stablehlo.shift_right_logical %159, %167 : tensor<5xui32>
       %169 = stablehlo.or %164, %168 : tensor<5xui32>
       %170 = stablehlo.xor %162, %169 : tensor<5xui32>
-      %171 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %171 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %172 = stablehlo.reshape %171 : (tensor<1xui32>) -> tensor<ui32>
       %173 = stablehlo.add %162, %170 : tensor<5xui32>
       %174 = stablehlo.broadcast_in_dim %172, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -273,7 +273,7 @@ module @jit_testcase {
       %179 = stablehlo.shift_right_logical %170, %178 : tensor<5xui32>
       %180 = stablehlo.or %175, %179 : tensor<5xui32>
       %181 = stablehlo.xor %173, %180 : tensor<5xui32>
-      %182 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %182 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %183 = stablehlo.reshape %182 : (tensor<1xui32>) -> tensor<ui32>
       %184 = stablehlo.add %173, %181 : tensor<5xui32>
       %185 = stablehlo.broadcast_in_dim %183, dims = [] : (tensor<ui32>) -> tensor<5xui32>

--- a/stablehlo/testdata/random_randint_shape_int32.mlir
+++ b/stablehlo/testdata/random_randint_shape_int32.mlir
@@ -24,12 +24,12 @@ module @jit_testcase {
     %16 = call @clip_1(%13, %14, %15) : (tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<i32>
     %17 = stablehlo.convert %16 : tensor<i32>
     %18 = stablehlo.iota dim = 0 : tensor<4xui32>
-    %19 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %19 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %20 = stablehlo.reshape %19 : (tensor<1xui32>) -> tensor<ui32>
-    %21 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %21 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %22 = stablehlo.reshape %21 : (tensor<1xui32>) -> tensor<ui32>
-    %23 = "stablehlo.slice"(%18) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-    %24 = "stablehlo.slice"(%18) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+    %23 = "stablehlo.slice"(%18) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+    %24 = "stablehlo.slice"(%18) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
     %25 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %26 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %27 = stablehlo.xor %20, %22 : tensor<ui32>
@@ -49,7 +49,7 @@ module @jit_testcase {
     } do {
       %117 = stablehlo.constant dense<1> : tensor<i32>
       %118 = stablehlo.add %iterArg_0, %117 : tensor<i32>
-      %119 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %119 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %120 = stablehlo.reshape %119 : (tensor<1xui32>) -> tensor<ui32>
       %121 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<2xui32>
       %122 = stablehlo.broadcast_in_dim %120, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -60,7 +60,7 @@ module @jit_testcase {
       %127 = stablehlo.shift_right_logical %iterArg_2, %126 : tensor<2xui32>
       %128 = stablehlo.or %123, %127 : tensor<2xui32>
       %129 = stablehlo.xor %121, %128 : tensor<2xui32>
-      %130 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %130 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %131 = stablehlo.reshape %130 : (tensor<1xui32>) -> tensor<ui32>
       %132 = stablehlo.add %121, %129 : tensor<2xui32>
       %133 = stablehlo.broadcast_in_dim %131, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -71,7 +71,7 @@ module @jit_testcase {
       %138 = stablehlo.shift_right_logical %129, %137 : tensor<2xui32>
       %139 = stablehlo.or %134, %138 : tensor<2xui32>
       %140 = stablehlo.xor %132, %139 : tensor<2xui32>
-      %141 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %141 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %142 = stablehlo.reshape %141 : (tensor<1xui32>) -> tensor<ui32>
       %143 = stablehlo.add %132, %140 : tensor<2xui32>
       %144 = stablehlo.broadcast_in_dim %142, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -82,7 +82,7 @@ module @jit_testcase {
       %149 = stablehlo.shift_right_logical %140, %148 : tensor<2xui32>
       %150 = stablehlo.or %145, %149 : tensor<2xui32>
       %151 = stablehlo.xor %143, %150 : tensor<2xui32>
-      %152 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %152 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %153 = stablehlo.reshape %152 : (tensor<1xui32>) -> tensor<ui32>
       %154 = stablehlo.add %143, %151 : tensor<2xui32>
       %155 = stablehlo.broadcast_in_dim %153, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -108,19 +108,19 @@ module @jit_testcase {
     }
     %37 = stablehlo.concatenate %36#2, %36#3, dim = 0 : (tensor<2xui32>, tensor<2xui32>) -> tensor<4xui32>
     %38 = stablehlo.reshape %37 : (tensor<4xui32>) -> tensor<2x2xui32>
-    %39 = "stablehlo.slice"(%38) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+    %39 = "stablehlo.slice"(%38) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
     %40 = stablehlo.reshape %39 : (tensor<1x2xui32>) -> tensor<2xui32>
-    %41 = "stablehlo.slice"(%38) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+    %41 = "stablehlo.slice"(%38) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
     %42 = stablehlo.reshape %41 : (tensor<1x2xui32>) -> tensor<2xui32>
     %43 = stablehlo.constant dense<0> : tensor<1xui32>
     %44 = stablehlo.iota dim = 0 : tensor<1xui32>
-    %45 = "stablehlo.slice"(%40) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %45 = "stablehlo.slice"(%40) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %46 = stablehlo.reshape %45 : (tensor<1xui32>) -> tensor<ui32>
-    %47 = "stablehlo.slice"(%40) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %47 = "stablehlo.slice"(%40) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %48 = stablehlo.reshape %47 : (tensor<1xui32>) -> tensor<ui32>
     %49 = stablehlo.concatenate %44, %43, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-    %50 = "stablehlo.slice"(%49) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-    %51 = "stablehlo.slice"(%49) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %50 = "stablehlo.slice"(%49) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+    %51 = "stablehlo.slice"(%49) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %52 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %53 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %54 = stablehlo.xor %46, %48 : tensor<ui32>
@@ -140,7 +140,7 @@ module @jit_testcase {
     } do {
       %117 = stablehlo.constant dense<1> : tensor<i32>
       %118 = stablehlo.add %iterArg_0, %117 : tensor<i32>
-      %119 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %119 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %120 = stablehlo.reshape %119 : (tensor<1xui32>) -> tensor<ui32>
       %121 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<1xui32>
       %122 = stablehlo.broadcast_in_dim %120, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -151,7 +151,7 @@ module @jit_testcase {
       %127 = stablehlo.shift_right_logical %iterArg_2, %126 : tensor<1xui32>
       %128 = stablehlo.or %123, %127 : tensor<1xui32>
       %129 = stablehlo.xor %121, %128 : tensor<1xui32>
-      %130 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %130 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %131 = stablehlo.reshape %130 : (tensor<1xui32>) -> tensor<ui32>
       %132 = stablehlo.add %121, %129 : tensor<1xui32>
       %133 = stablehlo.broadcast_in_dim %131, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -162,7 +162,7 @@ module @jit_testcase {
       %138 = stablehlo.shift_right_logical %129, %137 : tensor<1xui32>
       %139 = stablehlo.or %134, %138 : tensor<1xui32>
       %140 = stablehlo.xor %132, %139 : tensor<1xui32>
-      %141 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %141 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %142 = stablehlo.reshape %141 : (tensor<1xui32>) -> tensor<ui32>
       %143 = stablehlo.add %132, %140 : tensor<1xui32>
       %144 = stablehlo.broadcast_in_dim %142, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -173,7 +173,7 @@ module @jit_testcase {
       %149 = stablehlo.shift_right_logical %140, %148 : tensor<1xui32>
       %150 = stablehlo.or %145, %149 : tensor<1xui32>
       %151 = stablehlo.xor %143, %150 : tensor<1xui32>
-      %152 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %152 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %153 = stablehlo.reshape %152 : (tensor<1xui32>) -> tensor<ui32>
       %154 = stablehlo.add %143, %151 : tensor<1xui32>
       %155 = stablehlo.broadcast_in_dim %153, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -204,13 +204,13 @@ module @jit_testcase {
     %68 = stablehlo.reshape %67 : (tensor<1xui32>) -> tensor<ui32>
     %69 = stablehlo.constant dense<0> : tensor<1xui32>
     %70 = stablehlo.iota dim = 0 : tensor<1xui32>
-    %71 = "stablehlo.slice"(%42) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %71 = "stablehlo.slice"(%42) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %72 = stablehlo.reshape %71 : (tensor<1xui32>) -> tensor<ui32>
-    %73 = "stablehlo.slice"(%42) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %73 = "stablehlo.slice"(%42) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %74 = stablehlo.reshape %73 : (tensor<1xui32>) -> tensor<ui32>
     %75 = stablehlo.concatenate %70, %69, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-    %76 = "stablehlo.slice"(%75) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-    %77 = "stablehlo.slice"(%75) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %76 = "stablehlo.slice"(%75) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+    %77 = "stablehlo.slice"(%75) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %78 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %79 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %80 = stablehlo.xor %72, %74 : tensor<ui32>
@@ -230,7 +230,7 @@ module @jit_testcase {
     } do {
       %117 = stablehlo.constant dense<1> : tensor<i32>
       %118 = stablehlo.add %iterArg_0, %117 : tensor<i32>
-      %119 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %119 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %120 = stablehlo.reshape %119 : (tensor<1xui32>) -> tensor<ui32>
       %121 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<1xui32>
       %122 = stablehlo.broadcast_in_dim %120, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -241,7 +241,7 @@ module @jit_testcase {
       %127 = stablehlo.shift_right_logical %iterArg_2, %126 : tensor<1xui32>
       %128 = stablehlo.or %123, %127 : tensor<1xui32>
       %129 = stablehlo.xor %121, %128 : tensor<1xui32>
-      %130 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %130 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %131 = stablehlo.reshape %130 : (tensor<1xui32>) -> tensor<ui32>
       %132 = stablehlo.add %121, %129 : tensor<1xui32>
       %133 = stablehlo.broadcast_in_dim %131, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -252,7 +252,7 @@ module @jit_testcase {
       %138 = stablehlo.shift_right_logical %129, %137 : tensor<1xui32>
       %139 = stablehlo.or %134, %138 : tensor<1xui32>
       %140 = stablehlo.xor %132, %139 : tensor<1xui32>
-      %141 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %141 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %142 = stablehlo.reshape %141 : (tensor<1xui32>) -> tensor<ui32>
       %143 = stablehlo.add %132, %140 : tensor<1xui32>
       %144 = stablehlo.broadcast_in_dim %142, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -263,7 +263,7 @@ module @jit_testcase {
       %149 = stablehlo.shift_right_logical %140, %148 : tensor<1xui32>
       %150 = stablehlo.or %145, %149 : tensor<1xui32>
       %151 = stablehlo.xor %143, %150 : tensor<1xui32>
-      %152 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %152 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %153 = stablehlo.reshape %152 : (tensor<1xui32>) -> tensor<ui32>
       %154 = stablehlo.add %143, %151 : tensor<1xui32>
       %155 = stablehlo.broadcast_in_dim %153, dims = [] : (tensor<ui32>) -> tensor<1xui32>

--- a/stablehlo/testdata/random_randint_shape_int32_32.mlir
+++ b/stablehlo/testdata/random_randint_shape_int32_32.mlir
@@ -26,12 +26,12 @@ module @jit_testcase {
     %18 = stablehlo.broadcast_in_dim %12, dims = [] : (tensor<i32>) -> tensor<1xi32>
     %19 = stablehlo.broadcast_in_dim %17, dims = [] : (tensor<i32>) -> tensor<1xi32>
     %20 = stablehlo.iota dim = 0 : tensor<4xui32>
-    %21 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %21 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %22 = stablehlo.reshape %21 : (tensor<1xui32>) -> tensor<ui32>
-    %23 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %23 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %24 = stablehlo.reshape %23 : (tensor<1xui32>) -> tensor<ui32>
-    %25 = "stablehlo.slice"(%20) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-    %26 = "stablehlo.slice"(%20) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+    %25 = "stablehlo.slice"(%20) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+    %26 = "stablehlo.slice"(%20) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
     %27 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %28 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %29 = stablehlo.xor %22, %24 : tensor<ui32>
@@ -51,7 +51,7 @@ module @jit_testcase {
     } do {
       %116 = stablehlo.constant dense<1> : tensor<i32>
       %117 = stablehlo.add %iterArg_0, %116 : tensor<i32>
-      %118 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %118 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %119 = stablehlo.reshape %118 : (tensor<1xui32>) -> tensor<ui32>
       %120 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<2xui32>
       %121 = stablehlo.broadcast_in_dim %119, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -62,7 +62,7 @@ module @jit_testcase {
       %126 = stablehlo.shift_right_logical %iterArg_2, %125 : tensor<2xui32>
       %127 = stablehlo.or %122, %126 : tensor<2xui32>
       %128 = stablehlo.xor %120, %127 : tensor<2xui32>
-      %129 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %129 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %130 = stablehlo.reshape %129 : (tensor<1xui32>) -> tensor<ui32>
       %131 = stablehlo.add %120, %128 : tensor<2xui32>
       %132 = stablehlo.broadcast_in_dim %130, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -73,7 +73,7 @@ module @jit_testcase {
       %137 = stablehlo.shift_right_logical %128, %136 : tensor<2xui32>
       %138 = stablehlo.or %133, %137 : tensor<2xui32>
       %139 = stablehlo.xor %131, %138 : tensor<2xui32>
-      %140 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %140 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %141 = stablehlo.reshape %140 : (tensor<1xui32>) -> tensor<ui32>
       %142 = stablehlo.add %131, %139 : tensor<2xui32>
       %143 = stablehlo.broadcast_in_dim %141, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -84,7 +84,7 @@ module @jit_testcase {
       %148 = stablehlo.shift_right_logical %139, %147 : tensor<2xui32>
       %149 = stablehlo.or %144, %148 : tensor<2xui32>
       %150 = stablehlo.xor %142, %149 : tensor<2xui32>
-      %151 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %151 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %152 = stablehlo.reshape %151 : (tensor<1xui32>) -> tensor<ui32>
       %153 = stablehlo.add %142, %150 : tensor<2xui32>
       %154 = stablehlo.broadcast_in_dim %152, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -110,17 +110,17 @@ module @jit_testcase {
     }
     %39 = stablehlo.concatenate %38#2, %38#3, dim = 0 : (tensor<2xui32>, tensor<2xui32>) -> tensor<4xui32>
     %40 = stablehlo.reshape %39 : (tensor<4xui32>) -> tensor<2x2xui32>
-    %41 = "stablehlo.slice"(%40) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+    %41 = "stablehlo.slice"(%40) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
     %42 = stablehlo.reshape %41 : (tensor<1x2xui32>) -> tensor<2xui32>
-    %43 = "stablehlo.slice"(%40) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+    %43 = "stablehlo.slice"(%40) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
     %44 = stablehlo.reshape %43 : (tensor<1x2xui32>) -> tensor<2xui32>
     %45 = stablehlo.iota dim = 0 : tensor<32xui32>
-    %46 = "stablehlo.slice"(%42) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %46 = "stablehlo.slice"(%42) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %47 = stablehlo.reshape %46 : (tensor<1xui32>) -> tensor<ui32>
-    %48 = "stablehlo.slice"(%42) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %48 = "stablehlo.slice"(%42) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %49 = stablehlo.reshape %48 : (tensor<1xui32>) -> tensor<ui32>
-    %50 = "stablehlo.slice"(%45) {limit_indices = dense<16> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<32xui32>) -> tensor<16xui32>
-    %51 = "stablehlo.slice"(%45) {limit_indices = dense<32> : tensor<1xi64>, start_indices = dense<16> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<32xui32>) -> tensor<16xui32>
+    %50 = "stablehlo.slice"(%45) {limit_indices = array<i64: 16>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<32xui32>) -> tensor<16xui32>
+    %51 = "stablehlo.slice"(%45) {limit_indices = array<i64: 32>, start_indices = array<i64: 16>, strides = array<i64: 1>} : (tensor<32xui32>) -> tensor<16xui32>
     %52 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %53 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %54 = stablehlo.xor %47, %49 : tensor<ui32>
@@ -140,7 +140,7 @@ module @jit_testcase {
     } do {
       %116 = stablehlo.constant dense<1> : tensor<i32>
       %117 = stablehlo.add %iterArg_0, %116 : tensor<i32>
-      %118 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %118 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %119 = stablehlo.reshape %118 : (tensor<1xui32>) -> tensor<ui32>
       %120 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<16xui32>
       %121 = stablehlo.broadcast_in_dim %119, dims = [] : (tensor<ui32>) -> tensor<16xui32>
@@ -151,7 +151,7 @@ module @jit_testcase {
       %126 = stablehlo.shift_right_logical %iterArg_2, %125 : tensor<16xui32>
       %127 = stablehlo.or %122, %126 : tensor<16xui32>
       %128 = stablehlo.xor %120, %127 : tensor<16xui32>
-      %129 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %129 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %130 = stablehlo.reshape %129 : (tensor<1xui32>) -> tensor<ui32>
       %131 = stablehlo.add %120, %128 : tensor<16xui32>
       %132 = stablehlo.broadcast_in_dim %130, dims = [] : (tensor<ui32>) -> tensor<16xui32>
@@ -162,7 +162,7 @@ module @jit_testcase {
       %137 = stablehlo.shift_right_logical %128, %136 : tensor<16xui32>
       %138 = stablehlo.or %133, %137 : tensor<16xui32>
       %139 = stablehlo.xor %131, %138 : tensor<16xui32>
-      %140 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %140 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %141 = stablehlo.reshape %140 : (tensor<1xui32>) -> tensor<ui32>
       %142 = stablehlo.add %131, %139 : tensor<16xui32>
       %143 = stablehlo.broadcast_in_dim %141, dims = [] : (tensor<ui32>) -> tensor<16xui32>
@@ -173,7 +173,7 @@ module @jit_testcase {
       %148 = stablehlo.shift_right_logical %139, %147 : tensor<16xui32>
       %149 = stablehlo.or %144, %148 : tensor<16xui32>
       %150 = stablehlo.xor %142, %149 : tensor<16xui32>
-      %151 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %151 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %152 = stablehlo.reshape %151 : (tensor<1xui32>) -> tensor<ui32>
       %153 = stablehlo.add %142, %150 : tensor<16xui32>
       %154 = stablehlo.broadcast_in_dim %152, dims = [] : (tensor<ui32>) -> tensor<16xui32>
@@ -199,12 +199,12 @@ module @jit_testcase {
     }
     %64 = stablehlo.concatenate %63#2, %63#3, dim = 0 : (tensor<16xui32>, tensor<16xui32>) -> tensor<32xui32>
     %65 = stablehlo.iota dim = 0 : tensor<32xui32>
-    %66 = "stablehlo.slice"(%44) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %66 = "stablehlo.slice"(%44) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %67 = stablehlo.reshape %66 : (tensor<1xui32>) -> tensor<ui32>
-    %68 = "stablehlo.slice"(%44) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %68 = "stablehlo.slice"(%44) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %69 = stablehlo.reshape %68 : (tensor<1xui32>) -> tensor<ui32>
-    %70 = "stablehlo.slice"(%65) {limit_indices = dense<16> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<32xui32>) -> tensor<16xui32>
-    %71 = "stablehlo.slice"(%65) {limit_indices = dense<32> : tensor<1xi64>, start_indices = dense<16> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<32xui32>) -> tensor<16xui32>
+    %70 = "stablehlo.slice"(%65) {limit_indices = array<i64: 16>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<32xui32>) -> tensor<16xui32>
+    %71 = "stablehlo.slice"(%65) {limit_indices = array<i64: 32>, start_indices = array<i64: 16>, strides = array<i64: 1>} : (tensor<32xui32>) -> tensor<16xui32>
     %72 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %73 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %74 = stablehlo.xor %67, %69 : tensor<ui32>
@@ -224,7 +224,7 @@ module @jit_testcase {
     } do {
       %116 = stablehlo.constant dense<1> : tensor<i32>
       %117 = stablehlo.add %iterArg_0, %116 : tensor<i32>
-      %118 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %118 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %119 = stablehlo.reshape %118 : (tensor<1xui32>) -> tensor<ui32>
       %120 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<16xui32>
       %121 = stablehlo.broadcast_in_dim %119, dims = [] : (tensor<ui32>) -> tensor<16xui32>
@@ -235,7 +235,7 @@ module @jit_testcase {
       %126 = stablehlo.shift_right_logical %iterArg_2, %125 : tensor<16xui32>
       %127 = stablehlo.or %122, %126 : tensor<16xui32>
       %128 = stablehlo.xor %120, %127 : tensor<16xui32>
-      %129 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %129 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %130 = stablehlo.reshape %129 : (tensor<1xui32>) -> tensor<ui32>
       %131 = stablehlo.add %120, %128 : tensor<16xui32>
       %132 = stablehlo.broadcast_in_dim %130, dims = [] : (tensor<ui32>) -> tensor<16xui32>
@@ -246,7 +246,7 @@ module @jit_testcase {
       %137 = stablehlo.shift_right_logical %128, %136 : tensor<16xui32>
       %138 = stablehlo.or %133, %137 : tensor<16xui32>
       %139 = stablehlo.xor %131, %138 : tensor<16xui32>
-      %140 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %140 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %141 = stablehlo.reshape %140 : (tensor<1xui32>) -> tensor<ui32>
       %142 = stablehlo.add %131, %139 : tensor<16xui32>
       %143 = stablehlo.broadcast_in_dim %141, dims = [] : (tensor<ui32>) -> tensor<16xui32>
@@ -257,7 +257,7 @@ module @jit_testcase {
       %148 = stablehlo.shift_right_logical %139, %147 : tensor<16xui32>
       %149 = stablehlo.or %144, %148 : tensor<16xui32>
       %150 = stablehlo.xor %142, %149 : tensor<16xui32>
-      %151 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %151 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %152 = stablehlo.reshape %151 : (tensor<1xui32>) -> tensor<ui32>
       %153 = stablehlo.add %142, %150 : tensor<16xui32>
       %154 = stablehlo.broadcast_in_dim %152, dims = [] : (tensor<ui32>) -> tensor<16xui32>

--- a/stablehlo/testdata/random_randint_shape_int32_5_4.mlir
+++ b/stablehlo/testdata/random_randint_shape_int32_5_4.mlir
@@ -26,12 +26,12 @@ module @jit_testcase {
     %18 = stablehlo.broadcast_in_dim %12, dims = [] : (tensor<i32>) -> tensor<1x1xi32>
     %19 = stablehlo.broadcast_in_dim %17, dims = [] : (tensor<i32>) -> tensor<1x1xi32>
     %20 = stablehlo.iota dim = 0 : tensor<4xui32>
-    %21 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %21 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %22 = stablehlo.reshape %21 : (tensor<1xui32>) -> tensor<ui32>
-    %23 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %23 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %24 = stablehlo.reshape %23 : (tensor<1xui32>) -> tensor<ui32>
-    %25 = "stablehlo.slice"(%20) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-    %26 = "stablehlo.slice"(%20) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+    %25 = "stablehlo.slice"(%20) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+    %26 = "stablehlo.slice"(%20) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
     %27 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %28 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %29 = stablehlo.xor %22, %24 : tensor<ui32>
@@ -51,7 +51,7 @@ module @jit_testcase {
     } do {
       %118 = stablehlo.constant dense<1> : tensor<i32>
       %119 = stablehlo.add %iterArg_0, %118 : tensor<i32>
-      %120 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %120 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %121 = stablehlo.reshape %120 : (tensor<1xui32>) -> tensor<ui32>
       %122 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<2xui32>
       %123 = stablehlo.broadcast_in_dim %121, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -62,7 +62,7 @@ module @jit_testcase {
       %128 = stablehlo.shift_right_logical %iterArg_2, %127 : tensor<2xui32>
       %129 = stablehlo.or %124, %128 : tensor<2xui32>
       %130 = stablehlo.xor %122, %129 : tensor<2xui32>
-      %131 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %131 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %132 = stablehlo.reshape %131 : (tensor<1xui32>) -> tensor<ui32>
       %133 = stablehlo.add %122, %130 : tensor<2xui32>
       %134 = stablehlo.broadcast_in_dim %132, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -73,7 +73,7 @@ module @jit_testcase {
       %139 = stablehlo.shift_right_logical %130, %138 : tensor<2xui32>
       %140 = stablehlo.or %135, %139 : tensor<2xui32>
       %141 = stablehlo.xor %133, %140 : tensor<2xui32>
-      %142 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %142 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %143 = stablehlo.reshape %142 : (tensor<1xui32>) -> tensor<ui32>
       %144 = stablehlo.add %133, %141 : tensor<2xui32>
       %145 = stablehlo.broadcast_in_dim %143, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -84,7 +84,7 @@ module @jit_testcase {
       %150 = stablehlo.shift_right_logical %141, %149 : tensor<2xui32>
       %151 = stablehlo.or %146, %150 : tensor<2xui32>
       %152 = stablehlo.xor %144, %151 : tensor<2xui32>
-      %153 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %153 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %154 = stablehlo.reshape %153 : (tensor<1xui32>) -> tensor<ui32>
       %155 = stablehlo.add %144, %152 : tensor<2xui32>
       %156 = stablehlo.broadcast_in_dim %154, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -110,17 +110,17 @@ module @jit_testcase {
     }
     %39 = stablehlo.concatenate %38#2, %38#3, dim = 0 : (tensor<2xui32>, tensor<2xui32>) -> tensor<4xui32>
     %40 = stablehlo.reshape %39 : (tensor<4xui32>) -> tensor<2x2xui32>
-    %41 = "stablehlo.slice"(%40) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+    %41 = "stablehlo.slice"(%40) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
     %42 = stablehlo.reshape %41 : (tensor<1x2xui32>) -> tensor<2xui32>
-    %43 = "stablehlo.slice"(%40) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+    %43 = "stablehlo.slice"(%40) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
     %44 = stablehlo.reshape %43 : (tensor<1x2xui32>) -> tensor<2xui32>
     %45 = stablehlo.iota dim = 0 : tensor<20xui32>
-    %46 = "stablehlo.slice"(%42) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %46 = "stablehlo.slice"(%42) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %47 = stablehlo.reshape %46 : (tensor<1xui32>) -> tensor<ui32>
-    %48 = "stablehlo.slice"(%42) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %48 = "stablehlo.slice"(%42) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %49 = stablehlo.reshape %48 : (tensor<1xui32>) -> tensor<ui32>
-    %50 = "stablehlo.slice"(%45) {limit_indices = dense<10> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<20xui32>) -> tensor<10xui32>
-    %51 = "stablehlo.slice"(%45) {limit_indices = dense<20> : tensor<1xi64>, start_indices = dense<10> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<20xui32>) -> tensor<10xui32>
+    %50 = "stablehlo.slice"(%45) {limit_indices = array<i64: 10>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<20xui32>) -> tensor<10xui32>
+    %51 = "stablehlo.slice"(%45) {limit_indices = array<i64: 20>, start_indices = array<i64: 10>, strides = array<i64: 1>} : (tensor<20xui32>) -> tensor<10xui32>
     %52 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %53 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %54 = stablehlo.xor %47, %49 : tensor<ui32>
@@ -140,7 +140,7 @@ module @jit_testcase {
     } do {
       %118 = stablehlo.constant dense<1> : tensor<i32>
       %119 = stablehlo.add %iterArg_0, %118 : tensor<i32>
-      %120 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %120 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %121 = stablehlo.reshape %120 : (tensor<1xui32>) -> tensor<ui32>
       %122 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<10xui32>
       %123 = stablehlo.broadcast_in_dim %121, dims = [] : (tensor<ui32>) -> tensor<10xui32>
@@ -151,7 +151,7 @@ module @jit_testcase {
       %128 = stablehlo.shift_right_logical %iterArg_2, %127 : tensor<10xui32>
       %129 = stablehlo.or %124, %128 : tensor<10xui32>
       %130 = stablehlo.xor %122, %129 : tensor<10xui32>
-      %131 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %131 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %132 = stablehlo.reshape %131 : (tensor<1xui32>) -> tensor<ui32>
       %133 = stablehlo.add %122, %130 : tensor<10xui32>
       %134 = stablehlo.broadcast_in_dim %132, dims = [] : (tensor<ui32>) -> tensor<10xui32>
@@ -162,7 +162,7 @@ module @jit_testcase {
       %139 = stablehlo.shift_right_logical %130, %138 : tensor<10xui32>
       %140 = stablehlo.or %135, %139 : tensor<10xui32>
       %141 = stablehlo.xor %133, %140 : tensor<10xui32>
-      %142 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %142 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %143 = stablehlo.reshape %142 : (tensor<1xui32>) -> tensor<ui32>
       %144 = stablehlo.add %133, %141 : tensor<10xui32>
       %145 = stablehlo.broadcast_in_dim %143, dims = [] : (tensor<ui32>) -> tensor<10xui32>
@@ -173,7 +173,7 @@ module @jit_testcase {
       %150 = stablehlo.shift_right_logical %141, %149 : tensor<10xui32>
       %151 = stablehlo.or %146, %150 : tensor<10xui32>
       %152 = stablehlo.xor %144, %151 : tensor<10xui32>
-      %153 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %153 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %154 = stablehlo.reshape %153 : (tensor<1xui32>) -> tensor<ui32>
       %155 = stablehlo.add %144, %152 : tensor<10xui32>
       %156 = stablehlo.broadcast_in_dim %154, dims = [] : (tensor<ui32>) -> tensor<10xui32>
@@ -200,12 +200,12 @@ module @jit_testcase {
     %64 = stablehlo.concatenate %63#2, %63#3, dim = 0 : (tensor<10xui32>, tensor<10xui32>) -> tensor<20xui32>
     %65 = stablehlo.reshape %64 : (tensor<20xui32>) -> tensor<5x4xui32>
     %66 = stablehlo.iota dim = 0 : tensor<20xui32>
-    %67 = "stablehlo.slice"(%44) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %67 = "stablehlo.slice"(%44) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %68 = stablehlo.reshape %67 : (tensor<1xui32>) -> tensor<ui32>
-    %69 = "stablehlo.slice"(%44) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %69 = "stablehlo.slice"(%44) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %70 = stablehlo.reshape %69 : (tensor<1xui32>) -> tensor<ui32>
-    %71 = "stablehlo.slice"(%66) {limit_indices = dense<10> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<20xui32>) -> tensor<10xui32>
-    %72 = "stablehlo.slice"(%66) {limit_indices = dense<20> : tensor<1xi64>, start_indices = dense<10> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<20xui32>) -> tensor<10xui32>
+    %71 = "stablehlo.slice"(%66) {limit_indices = array<i64: 10>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<20xui32>) -> tensor<10xui32>
+    %72 = "stablehlo.slice"(%66) {limit_indices = array<i64: 20>, start_indices = array<i64: 10>, strides = array<i64: 1>} : (tensor<20xui32>) -> tensor<10xui32>
     %73 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %74 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %75 = stablehlo.xor %68, %70 : tensor<ui32>
@@ -225,7 +225,7 @@ module @jit_testcase {
     } do {
       %118 = stablehlo.constant dense<1> : tensor<i32>
       %119 = stablehlo.add %iterArg_0, %118 : tensor<i32>
-      %120 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %120 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %121 = stablehlo.reshape %120 : (tensor<1xui32>) -> tensor<ui32>
       %122 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<10xui32>
       %123 = stablehlo.broadcast_in_dim %121, dims = [] : (tensor<ui32>) -> tensor<10xui32>
@@ -236,7 +236,7 @@ module @jit_testcase {
       %128 = stablehlo.shift_right_logical %iterArg_2, %127 : tensor<10xui32>
       %129 = stablehlo.or %124, %128 : tensor<10xui32>
       %130 = stablehlo.xor %122, %129 : tensor<10xui32>
-      %131 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %131 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %132 = stablehlo.reshape %131 : (tensor<1xui32>) -> tensor<ui32>
       %133 = stablehlo.add %122, %130 : tensor<10xui32>
       %134 = stablehlo.broadcast_in_dim %132, dims = [] : (tensor<ui32>) -> tensor<10xui32>
@@ -247,7 +247,7 @@ module @jit_testcase {
       %139 = stablehlo.shift_right_logical %130, %138 : tensor<10xui32>
       %140 = stablehlo.or %135, %139 : tensor<10xui32>
       %141 = stablehlo.xor %133, %140 : tensor<10xui32>
-      %142 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %142 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %143 = stablehlo.reshape %142 : (tensor<1xui32>) -> tensor<ui32>
       %144 = stablehlo.add %133, %141 : tensor<10xui32>
       %145 = stablehlo.broadcast_in_dim %143, dims = [] : (tensor<ui32>) -> tensor<10xui32>
@@ -258,7 +258,7 @@ module @jit_testcase {
       %150 = stablehlo.shift_right_logical %141, %149 : tensor<10xui32>
       %151 = stablehlo.or %146, %150 : tensor<10xui32>
       %152 = stablehlo.xor %144, %151 : tensor<10xui32>
-      %153 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %153 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %154 = stablehlo.reshape %153 : (tensor<1xui32>) -> tensor<ui32>
       %155 = stablehlo.add %144, %152 : tensor<10xui32>
       %156 = stablehlo.broadcast_in_dim %154, dims = [] : (tensor<ui32>) -> tensor<10xui32>

--- a/stablehlo/testdata/random_randint_shape_int8.mlir
+++ b/stablehlo/testdata/random_randint_shape_int8.mlir
@@ -25,12 +25,12 @@ module @jit_testcase {
     %17 = call @clip_1(%14, %15, %16) : (tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<i32>
     %18 = stablehlo.convert %17 : (tensor<i32>) -> tensor<i8>
     %19 = stablehlo.iota dim = 0 : tensor<4xui32>
-    %20 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %20 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %21 = stablehlo.reshape %20 : (tensor<1xui32>) -> tensor<ui32>
-    %22 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %22 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %23 = stablehlo.reshape %22 : (tensor<1xui32>) -> tensor<ui32>
-    %24 = "stablehlo.slice"(%19) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-    %25 = "stablehlo.slice"(%19) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+    %24 = "stablehlo.slice"(%19) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+    %25 = "stablehlo.slice"(%19) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
     %26 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %27 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %28 = stablehlo.xor %21, %23 : tensor<ui32>
@@ -50,7 +50,7 @@ module @jit_testcase {
     } do {
       %148 = stablehlo.constant dense<1> : tensor<i32>
       %149 = stablehlo.add %iterArg_0, %148 : tensor<i32>
-      %150 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %150 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %151 = stablehlo.reshape %150 : (tensor<1xui32>) -> tensor<ui32>
       %152 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<2xui32>
       %153 = stablehlo.broadcast_in_dim %151, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -61,7 +61,7 @@ module @jit_testcase {
       %158 = stablehlo.shift_right_logical %iterArg_2, %157 : tensor<2xui32>
       %159 = stablehlo.or %154, %158 : tensor<2xui32>
       %160 = stablehlo.xor %152, %159 : tensor<2xui32>
-      %161 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %161 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %162 = stablehlo.reshape %161 : (tensor<1xui32>) -> tensor<ui32>
       %163 = stablehlo.add %152, %160 : tensor<2xui32>
       %164 = stablehlo.broadcast_in_dim %162, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -72,7 +72,7 @@ module @jit_testcase {
       %169 = stablehlo.shift_right_logical %160, %168 : tensor<2xui32>
       %170 = stablehlo.or %165, %169 : tensor<2xui32>
       %171 = stablehlo.xor %163, %170 : tensor<2xui32>
-      %172 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %172 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %173 = stablehlo.reshape %172 : (tensor<1xui32>) -> tensor<ui32>
       %174 = stablehlo.add %163, %171 : tensor<2xui32>
       %175 = stablehlo.broadcast_in_dim %173, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -83,7 +83,7 @@ module @jit_testcase {
       %180 = stablehlo.shift_right_logical %171, %179 : tensor<2xui32>
       %181 = stablehlo.or %176, %180 : tensor<2xui32>
       %182 = stablehlo.xor %174, %181 : tensor<2xui32>
-      %183 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %183 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %184 = stablehlo.reshape %183 : (tensor<1xui32>) -> tensor<ui32>
       %185 = stablehlo.add %174, %182 : tensor<2xui32>
       %186 = stablehlo.broadcast_in_dim %184, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -109,19 +109,19 @@ module @jit_testcase {
     }
     %38 = stablehlo.concatenate %37#2, %37#3, dim = 0 : (tensor<2xui32>, tensor<2xui32>) -> tensor<4xui32>
     %39 = stablehlo.reshape %38 : (tensor<4xui32>) -> tensor<2x2xui32>
-    %40 = "stablehlo.slice"(%39) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+    %40 = "stablehlo.slice"(%39) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
     %41 = stablehlo.reshape %40 : (tensor<1x2xui32>) -> tensor<2xui32>
-    %42 = "stablehlo.slice"(%39) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+    %42 = "stablehlo.slice"(%39) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
     %43 = stablehlo.reshape %42 : (tensor<1x2xui32>) -> tensor<2xui32>
     %44 = stablehlo.constant dense<0> : tensor<1xui32>
     %45 = stablehlo.iota dim = 0 : tensor<1xui32>
-    %46 = "stablehlo.slice"(%41) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %46 = "stablehlo.slice"(%41) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %47 = stablehlo.reshape %46 : (tensor<1xui32>) -> tensor<ui32>
-    %48 = "stablehlo.slice"(%41) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %48 = "stablehlo.slice"(%41) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %49 = stablehlo.reshape %48 : (tensor<1xui32>) -> tensor<ui32>
     %50 = stablehlo.concatenate %45, %44, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-    %51 = "stablehlo.slice"(%50) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-    %52 = "stablehlo.slice"(%50) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %51 = "stablehlo.slice"(%50) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+    %52 = "stablehlo.slice"(%50) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %53 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %54 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %55 = stablehlo.xor %47, %49 : tensor<ui32>
@@ -141,7 +141,7 @@ module @jit_testcase {
     } do {
       %148 = stablehlo.constant dense<1> : tensor<i32>
       %149 = stablehlo.add %iterArg_0, %148 : tensor<i32>
-      %150 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %150 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %151 = stablehlo.reshape %150 : (tensor<1xui32>) -> tensor<ui32>
       %152 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<1xui32>
       %153 = stablehlo.broadcast_in_dim %151, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -152,7 +152,7 @@ module @jit_testcase {
       %158 = stablehlo.shift_right_logical %iterArg_2, %157 : tensor<1xui32>
       %159 = stablehlo.or %154, %158 : tensor<1xui32>
       %160 = stablehlo.xor %152, %159 : tensor<1xui32>
-      %161 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %161 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %162 = stablehlo.reshape %161 : (tensor<1xui32>) -> tensor<ui32>
       %163 = stablehlo.add %152, %160 : tensor<1xui32>
       %164 = stablehlo.broadcast_in_dim %162, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -163,7 +163,7 @@ module @jit_testcase {
       %169 = stablehlo.shift_right_logical %160, %168 : tensor<1xui32>
       %170 = stablehlo.or %165, %169 : tensor<1xui32>
       %171 = stablehlo.xor %163, %170 : tensor<1xui32>
-      %172 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %172 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %173 = stablehlo.reshape %172 : (tensor<1xui32>) -> tensor<ui32>
       %174 = stablehlo.add %163, %171 : tensor<1xui32>
       %175 = stablehlo.broadcast_in_dim %173, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -174,7 +174,7 @@ module @jit_testcase {
       %180 = stablehlo.shift_right_logical %171, %179 : tensor<1xui32>
       %181 = stablehlo.or %176, %180 : tensor<1xui32>
       %182 = stablehlo.xor %174, %181 : tensor<1xui32>
-      %183 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %183 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %184 = stablehlo.reshape %183 : (tensor<1xui32>) -> tensor<ui32>
       %185 = stablehlo.add %174, %182 : tensor<1xui32>
       %186 = stablehlo.broadcast_in_dim %184, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -220,13 +220,13 @@ module @jit_testcase {
     %84 = stablehlo.reshape %83 : (tensor<1xui8>) -> tensor<ui8>
     %85 = stablehlo.constant dense<0> : tensor<1xui32>
     %86 = stablehlo.iota dim = 0 : tensor<1xui32>
-    %87 = "stablehlo.slice"(%43) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %87 = "stablehlo.slice"(%43) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %88 = stablehlo.reshape %87 : (tensor<1xui32>) -> tensor<ui32>
-    %89 = "stablehlo.slice"(%43) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %89 = "stablehlo.slice"(%43) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %90 = stablehlo.reshape %89 : (tensor<1xui32>) -> tensor<ui32>
     %91 = stablehlo.concatenate %86, %85, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-    %92 = "stablehlo.slice"(%91) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-    %93 = "stablehlo.slice"(%91) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %92 = "stablehlo.slice"(%91) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+    %93 = "stablehlo.slice"(%91) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %94 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %95 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %96 = stablehlo.xor %88, %90 : tensor<ui32>
@@ -246,7 +246,7 @@ module @jit_testcase {
     } do {
       %148 = stablehlo.constant dense<1> : tensor<i32>
       %149 = stablehlo.add %iterArg_0, %148 : tensor<i32>
-      %150 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %150 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %151 = stablehlo.reshape %150 : (tensor<1xui32>) -> tensor<ui32>
       %152 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<1xui32>
       %153 = stablehlo.broadcast_in_dim %151, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -257,7 +257,7 @@ module @jit_testcase {
       %158 = stablehlo.shift_right_logical %iterArg_2, %157 : tensor<1xui32>
       %159 = stablehlo.or %154, %158 : tensor<1xui32>
       %160 = stablehlo.xor %152, %159 : tensor<1xui32>
-      %161 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %161 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %162 = stablehlo.reshape %161 : (tensor<1xui32>) -> tensor<ui32>
       %163 = stablehlo.add %152, %160 : tensor<1xui32>
       %164 = stablehlo.broadcast_in_dim %162, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -268,7 +268,7 @@ module @jit_testcase {
       %169 = stablehlo.shift_right_logical %160, %168 : tensor<1xui32>
       %170 = stablehlo.or %165, %169 : tensor<1xui32>
       %171 = stablehlo.xor %163, %170 : tensor<1xui32>
-      %172 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %172 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %173 = stablehlo.reshape %172 : (tensor<1xui32>) -> tensor<ui32>
       %174 = stablehlo.add %163, %171 : tensor<1xui32>
       %175 = stablehlo.broadcast_in_dim %173, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -279,7 +279,7 @@ module @jit_testcase {
       %180 = stablehlo.shift_right_logical %171, %179 : tensor<1xui32>
       %181 = stablehlo.or %176, %180 : tensor<1xui32>
       %182 = stablehlo.xor %174, %181 : tensor<1xui32>
-      %183 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %183 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %184 = stablehlo.reshape %183 : (tensor<1xui32>) -> tensor<ui32>
       %185 = stablehlo.add %174, %182 : tensor<1xui32>
       %186 = stablehlo.broadcast_in_dim %184, dims = [] : (tensor<ui32>) -> tensor<1xui32>

--- a/stablehlo/testdata/random_randint_shape_int8_32.mlir
+++ b/stablehlo/testdata/random_randint_shape_int8_32.mlir
@@ -27,12 +27,12 @@ module @jit_testcase {
     %19 = stablehlo.broadcast_in_dim %13, dims = [] : (tensor<i8>) -> tensor<1xi8>
     %20 = stablehlo.broadcast_in_dim %18, dims = [] : (tensor<i8>) -> tensor<1xi8>
     %21 = stablehlo.iota dim = 0 : tensor<4xui32>
-    %22 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %22 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %23 = stablehlo.reshape %22 : (tensor<1xui32>) -> tensor<ui32>
-    %24 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %24 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %25 = stablehlo.reshape %24 : (tensor<1xui32>) -> tensor<ui32>
-    %26 = "stablehlo.slice"(%21) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-    %27 = "stablehlo.slice"(%21) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+    %26 = "stablehlo.slice"(%21) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+    %27 = "stablehlo.slice"(%21) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
     %28 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %29 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %30 = stablehlo.xor %23, %25 : tensor<ui32>
@@ -52,7 +52,7 @@ module @jit_testcase {
     } do {
       %145 = stablehlo.constant dense<1> : tensor<i32>
       %146 = stablehlo.add %iterArg_0, %145 : tensor<i32>
-      %147 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %147 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %148 = stablehlo.reshape %147 : (tensor<1xui32>) -> tensor<ui32>
       %149 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<2xui32>
       %150 = stablehlo.broadcast_in_dim %148, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -63,7 +63,7 @@ module @jit_testcase {
       %155 = stablehlo.shift_right_logical %iterArg_2, %154 : tensor<2xui32>
       %156 = stablehlo.or %151, %155 : tensor<2xui32>
       %157 = stablehlo.xor %149, %156 : tensor<2xui32>
-      %158 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %158 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %159 = stablehlo.reshape %158 : (tensor<1xui32>) -> tensor<ui32>
       %160 = stablehlo.add %149, %157 : tensor<2xui32>
       %161 = stablehlo.broadcast_in_dim %159, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -74,7 +74,7 @@ module @jit_testcase {
       %166 = stablehlo.shift_right_logical %157, %165 : tensor<2xui32>
       %167 = stablehlo.or %162, %166 : tensor<2xui32>
       %168 = stablehlo.xor %160, %167 : tensor<2xui32>
-      %169 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %169 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %170 = stablehlo.reshape %169 : (tensor<1xui32>) -> tensor<ui32>
       %171 = stablehlo.add %160, %168 : tensor<2xui32>
       %172 = stablehlo.broadcast_in_dim %170, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -85,7 +85,7 @@ module @jit_testcase {
       %177 = stablehlo.shift_right_logical %168, %176 : tensor<2xui32>
       %178 = stablehlo.or %173, %177 : tensor<2xui32>
       %179 = stablehlo.xor %171, %178 : tensor<2xui32>
-      %180 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %180 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %181 = stablehlo.reshape %180 : (tensor<1xui32>) -> tensor<ui32>
       %182 = stablehlo.add %171, %179 : tensor<2xui32>
       %183 = stablehlo.broadcast_in_dim %181, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -111,17 +111,17 @@ module @jit_testcase {
     }
     %40 = stablehlo.concatenate %39#2, %39#3, dim = 0 : (tensor<2xui32>, tensor<2xui32>) -> tensor<4xui32>
     %41 = stablehlo.reshape %40 : (tensor<4xui32>) -> tensor<2x2xui32>
-    %42 = "stablehlo.slice"(%41) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+    %42 = "stablehlo.slice"(%41) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
     %43 = stablehlo.reshape %42 : (tensor<1x2xui32>) -> tensor<2xui32>
-    %44 = "stablehlo.slice"(%41) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+    %44 = "stablehlo.slice"(%41) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
     %45 = stablehlo.reshape %44 : (tensor<1x2xui32>) -> tensor<2xui32>
     %46 = stablehlo.iota dim = 0 : tensor<8xui32>
-    %47 = "stablehlo.slice"(%43) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %47 = "stablehlo.slice"(%43) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %48 = stablehlo.reshape %47 : (tensor<1xui32>) -> tensor<ui32>
-    %49 = "stablehlo.slice"(%43) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %49 = "stablehlo.slice"(%43) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %50 = stablehlo.reshape %49 : (tensor<1xui32>) -> tensor<ui32>
-    %51 = "stablehlo.slice"(%46) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<8xui32>) -> tensor<4xui32>
-    %52 = "stablehlo.slice"(%46) {limit_indices = dense<8> : tensor<1xi64>, start_indices = dense<4> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<8xui32>) -> tensor<4xui32>
+    %51 = "stablehlo.slice"(%46) {limit_indices = array<i64: 4>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<8xui32>) -> tensor<4xui32>
+    %52 = "stablehlo.slice"(%46) {limit_indices = array<i64: 8>, start_indices = array<i64: 4>, strides = array<i64: 1>} : (tensor<8xui32>) -> tensor<4xui32>
     %53 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %54 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %55 = stablehlo.xor %48, %50 : tensor<ui32>
@@ -141,7 +141,7 @@ module @jit_testcase {
     } do {
       %145 = stablehlo.constant dense<1> : tensor<i32>
       %146 = stablehlo.add %iterArg_0, %145 : tensor<i32>
-      %147 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %147 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %148 = stablehlo.reshape %147 : (tensor<1xui32>) -> tensor<ui32>
       %149 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<4xui32>
       %150 = stablehlo.broadcast_in_dim %148, dims = [] : (tensor<ui32>) -> tensor<4xui32>
@@ -152,7 +152,7 @@ module @jit_testcase {
       %155 = stablehlo.shift_right_logical %iterArg_2, %154 : tensor<4xui32>
       %156 = stablehlo.or %151, %155 : tensor<4xui32>
       %157 = stablehlo.xor %149, %156 : tensor<4xui32>
-      %158 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %158 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %159 = stablehlo.reshape %158 : (tensor<1xui32>) -> tensor<ui32>
       %160 = stablehlo.add %149, %157 : tensor<4xui32>
       %161 = stablehlo.broadcast_in_dim %159, dims = [] : (tensor<ui32>) -> tensor<4xui32>
@@ -163,7 +163,7 @@ module @jit_testcase {
       %166 = stablehlo.shift_right_logical %157, %165 : tensor<4xui32>
       %167 = stablehlo.or %162, %166 : tensor<4xui32>
       %168 = stablehlo.xor %160, %167 : tensor<4xui32>
-      %169 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %169 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %170 = stablehlo.reshape %169 : (tensor<1xui32>) -> tensor<ui32>
       %171 = stablehlo.add %160, %168 : tensor<4xui32>
       %172 = stablehlo.broadcast_in_dim %170, dims = [] : (tensor<ui32>) -> tensor<4xui32>
@@ -174,7 +174,7 @@ module @jit_testcase {
       %177 = stablehlo.shift_right_logical %168, %176 : tensor<4xui32>
       %178 = stablehlo.or %173, %177 : tensor<4xui32>
       %179 = stablehlo.xor %171, %178 : tensor<4xui32>
-      %180 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %180 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %181 = stablehlo.reshape %180 : (tensor<1xui32>) -> tensor<ui32>
       %182 = stablehlo.add %171, %179 : tensor<4xui32>
       %183 = stablehlo.broadcast_in_dim %181, dims = [] : (tensor<ui32>) -> tensor<4xui32>
@@ -214,12 +214,12 @@ module @jit_testcase {
     %78 = stablehlo.reshape %77 : (tensor<8x4xui32>) -> tensor<32xui32>
     %79 = stablehlo.convert %78 : (tensor<32xui32>) -> tensor<32xui8>
     %80 = stablehlo.iota dim = 0 : tensor<8xui32>
-    %81 = "stablehlo.slice"(%45) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %81 = "stablehlo.slice"(%45) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %82 = stablehlo.reshape %81 : (tensor<1xui32>) -> tensor<ui32>
-    %83 = "stablehlo.slice"(%45) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %83 = "stablehlo.slice"(%45) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %84 = stablehlo.reshape %83 : (tensor<1xui32>) -> tensor<ui32>
-    %85 = "stablehlo.slice"(%80) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<8xui32>) -> tensor<4xui32>
-    %86 = "stablehlo.slice"(%80) {limit_indices = dense<8> : tensor<1xi64>, start_indices = dense<4> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<8xui32>) -> tensor<4xui32>
+    %85 = "stablehlo.slice"(%80) {limit_indices = array<i64: 4>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<8xui32>) -> tensor<4xui32>
+    %86 = "stablehlo.slice"(%80) {limit_indices = array<i64: 8>, start_indices = array<i64: 4>, strides = array<i64: 1>} : (tensor<8xui32>) -> tensor<4xui32>
     %87 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %88 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %89 = stablehlo.xor %82, %84 : tensor<ui32>
@@ -239,7 +239,7 @@ module @jit_testcase {
     } do {
       %145 = stablehlo.constant dense<1> : tensor<i32>
       %146 = stablehlo.add %iterArg_0, %145 : tensor<i32>
-      %147 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %147 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %148 = stablehlo.reshape %147 : (tensor<1xui32>) -> tensor<ui32>
       %149 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<4xui32>
       %150 = stablehlo.broadcast_in_dim %148, dims = [] : (tensor<ui32>) -> tensor<4xui32>
@@ -250,7 +250,7 @@ module @jit_testcase {
       %155 = stablehlo.shift_right_logical %iterArg_2, %154 : tensor<4xui32>
       %156 = stablehlo.or %151, %155 : tensor<4xui32>
       %157 = stablehlo.xor %149, %156 : tensor<4xui32>
-      %158 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %158 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %159 = stablehlo.reshape %158 : (tensor<1xui32>) -> tensor<ui32>
       %160 = stablehlo.add %149, %157 : tensor<4xui32>
       %161 = stablehlo.broadcast_in_dim %159, dims = [] : (tensor<ui32>) -> tensor<4xui32>
@@ -261,7 +261,7 @@ module @jit_testcase {
       %166 = stablehlo.shift_right_logical %157, %165 : tensor<4xui32>
       %167 = stablehlo.or %162, %166 : tensor<4xui32>
       %168 = stablehlo.xor %160, %167 : tensor<4xui32>
-      %169 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %169 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %170 = stablehlo.reshape %169 : (tensor<1xui32>) -> tensor<ui32>
       %171 = stablehlo.add %160, %168 : tensor<4xui32>
       %172 = stablehlo.broadcast_in_dim %170, dims = [] : (tensor<ui32>) -> tensor<4xui32>
@@ -272,7 +272,7 @@ module @jit_testcase {
       %177 = stablehlo.shift_right_logical %168, %176 : tensor<4xui32>
       %178 = stablehlo.or %173, %177 : tensor<4xui32>
       %179 = stablehlo.xor %171, %178 : tensor<4xui32>
-      %180 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %180 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %181 = stablehlo.reshape %180 : (tensor<1xui32>) -> tensor<ui32>
       %182 = stablehlo.add %171, %179 : tensor<4xui32>
       %183 = stablehlo.broadcast_in_dim %181, dims = [] : (tensor<ui32>) -> tensor<4xui32>

--- a/stablehlo/testdata/random_randint_shape_int8_5_4.mlir
+++ b/stablehlo/testdata/random_randint_shape_int8_5_4.mlir
@@ -27,12 +27,12 @@ module @jit_testcase {
     %19 = stablehlo.broadcast_in_dim %13, dims = [] : (tensor<i8>) -> tensor<1x1xi8>
     %20 = stablehlo.broadcast_in_dim %18, dims = [] : (tensor<i8>) -> tensor<1x1xi8>
     %21 = stablehlo.iota dim = 0 : tensor<4xui32>
-    %22 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %22 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %23 = stablehlo.reshape %22 : (tensor<1xui32>) -> tensor<ui32>
-    %24 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %24 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %25 = stablehlo.reshape %24 : (tensor<1xui32>) -> tensor<ui32>
-    %26 = "stablehlo.slice"(%21) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-    %27 = "stablehlo.slice"(%21) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+    %26 = "stablehlo.slice"(%21) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+    %27 = "stablehlo.slice"(%21) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
     %28 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %29 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %30 = stablehlo.xor %23, %25 : tensor<ui32>
@@ -52,7 +52,7 @@ module @jit_testcase {
     } do {
       %157 = stablehlo.constant dense<1> : tensor<i32>
       %158 = stablehlo.add %iterArg_0, %157 : tensor<i32>
-      %159 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %159 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %160 = stablehlo.reshape %159 : (tensor<1xui32>) -> tensor<ui32>
       %161 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<2xui32>
       %162 = stablehlo.broadcast_in_dim %160, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -63,7 +63,7 @@ module @jit_testcase {
       %167 = stablehlo.shift_right_logical %iterArg_2, %166 : tensor<2xui32>
       %168 = stablehlo.or %163, %167 : tensor<2xui32>
       %169 = stablehlo.xor %161, %168 : tensor<2xui32>
-      %170 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %170 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %171 = stablehlo.reshape %170 : (tensor<1xui32>) -> tensor<ui32>
       %172 = stablehlo.add %161, %169 : tensor<2xui32>
       %173 = stablehlo.broadcast_in_dim %171, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -74,7 +74,7 @@ module @jit_testcase {
       %178 = stablehlo.shift_right_logical %169, %177 : tensor<2xui32>
       %179 = stablehlo.or %174, %178 : tensor<2xui32>
       %180 = stablehlo.xor %172, %179 : tensor<2xui32>
-      %181 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %181 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %182 = stablehlo.reshape %181 : (tensor<1xui32>) -> tensor<ui32>
       %183 = stablehlo.add %172, %180 : tensor<2xui32>
       %184 = stablehlo.broadcast_in_dim %182, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -85,7 +85,7 @@ module @jit_testcase {
       %189 = stablehlo.shift_right_logical %180, %188 : tensor<2xui32>
       %190 = stablehlo.or %185, %189 : tensor<2xui32>
       %191 = stablehlo.xor %183, %190 : tensor<2xui32>
-      %192 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %192 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %193 = stablehlo.reshape %192 : (tensor<1xui32>) -> tensor<ui32>
       %194 = stablehlo.add %183, %191 : tensor<2xui32>
       %195 = stablehlo.broadcast_in_dim %193, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -111,19 +111,19 @@ module @jit_testcase {
     }
     %40 = stablehlo.concatenate %39#2, %39#3, dim = 0 : (tensor<2xui32>, tensor<2xui32>) -> tensor<4xui32>
     %41 = stablehlo.reshape %40 : (tensor<4xui32>) -> tensor<2x2xui32>
-    %42 = "stablehlo.slice"(%41) {limit_indices = dense<[1, 2]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+    %42 = "stablehlo.slice"(%41) {limit_indices = array<i64: 1, 2>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
     %43 = stablehlo.reshape %42 : (tensor<1x2xui32>) -> tensor<2xui32>
-    %44 = "stablehlo.slice"(%41) {limit_indices = dense<2> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
+    %44 = "stablehlo.slice"(%41) {limit_indices = array<i64: 2, 2>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<2x2xui32>) -> tensor<1x2xui32>
     %45 = stablehlo.reshape %44 : (tensor<1x2xui32>) -> tensor<2xui32>
     %46 = stablehlo.constant dense<0> : tensor<1xui32>
     %47 = stablehlo.iota dim = 0 : tensor<5xui32>
-    %48 = "stablehlo.slice"(%43) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %48 = "stablehlo.slice"(%43) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %49 = stablehlo.reshape %48 : (tensor<1xui32>) -> tensor<ui32>
-    %50 = "stablehlo.slice"(%43) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %50 = "stablehlo.slice"(%43) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %51 = stablehlo.reshape %50 : (tensor<1xui32>) -> tensor<ui32>
     %52 = stablehlo.concatenate %47, %46, dim = 0 : (tensor<5xui32>, tensor<1xui32>) -> tensor<6xui32>
-    %53 = "stablehlo.slice"(%52) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<6xui32>) -> tensor<3xui32>
-    %54 = "stablehlo.slice"(%52) {limit_indices = dense<6> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<6xui32>) -> tensor<3xui32>
+    %53 = "stablehlo.slice"(%52) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<6xui32>) -> tensor<3xui32>
+    %54 = "stablehlo.slice"(%52) {limit_indices = array<i64: 6>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<6xui32>) -> tensor<3xui32>
     %55 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %56 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %57 = stablehlo.xor %49, %51 : tensor<ui32>
@@ -143,7 +143,7 @@ module @jit_testcase {
     } do {
       %157 = stablehlo.constant dense<1> : tensor<i32>
       %158 = stablehlo.add %iterArg_0, %157 : tensor<i32>
-      %159 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %159 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %160 = stablehlo.reshape %159 : (tensor<1xui32>) -> tensor<ui32>
       %161 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<3xui32>
       %162 = stablehlo.broadcast_in_dim %160, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -154,7 +154,7 @@ module @jit_testcase {
       %167 = stablehlo.shift_right_logical %iterArg_2, %166 : tensor<3xui32>
       %168 = stablehlo.or %163, %167 : tensor<3xui32>
       %169 = stablehlo.xor %161, %168 : tensor<3xui32>
-      %170 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %170 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %171 = stablehlo.reshape %170 : (tensor<1xui32>) -> tensor<ui32>
       %172 = stablehlo.add %161, %169 : tensor<3xui32>
       %173 = stablehlo.broadcast_in_dim %171, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -165,7 +165,7 @@ module @jit_testcase {
       %178 = stablehlo.shift_right_logical %169, %177 : tensor<3xui32>
       %179 = stablehlo.or %174, %178 : tensor<3xui32>
       %180 = stablehlo.xor %172, %179 : tensor<3xui32>
-      %181 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %181 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %182 = stablehlo.reshape %181 : (tensor<1xui32>) -> tensor<ui32>
       %183 = stablehlo.add %172, %180 : tensor<3xui32>
       %184 = stablehlo.broadcast_in_dim %182, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -176,7 +176,7 @@ module @jit_testcase {
       %189 = stablehlo.shift_right_logical %180, %188 : tensor<3xui32>
       %190 = stablehlo.or %185, %189 : tensor<3xui32>
       %191 = stablehlo.xor %183, %190 : tensor<3xui32>
-      %192 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %192 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %193 = stablehlo.reshape %192 : (tensor<1xui32>) -> tensor<ui32>
       %194 = stablehlo.add %183, %191 : tensor<3xui32>
       %195 = stablehlo.broadcast_in_dim %193, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -221,13 +221,13 @@ module @jit_testcase {
     %85 = stablehlo.reshape %84 : (tensor<20xui8>) -> tensor<5x4xui8>
     %86 = stablehlo.constant dense<0> : tensor<1xui32>
     %87 = stablehlo.iota dim = 0 : tensor<5xui32>
-    %88 = "stablehlo.slice"(%45) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %88 = "stablehlo.slice"(%45) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %89 = stablehlo.reshape %88 : (tensor<1xui32>) -> tensor<ui32>
-    %90 = "stablehlo.slice"(%45) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %90 = "stablehlo.slice"(%45) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %91 = stablehlo.reshape %90 : (tensor<1xui32>) -> tensor<ui32>
     %92 = stablehlo.concatenate %87, %86, dim = 0 : (tensor<5xui32>, tensor<1xui32>) -> tensor<6xui32>
-    %93 = "stablehlo.slice"(%92) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<6xui32>) -> tensor<3xui32>
-    %94 = "stablehlo.slice"(%92) {limit_indices = dense<6> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<6xui32>) -> tensor<3xui32>
+    %93 = "stablehlo.slice"(%92) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<6xui32>) -> tensor<3xui32>
+    %94 = "stablehlo.slice"(%92) {limit_indices = array<i64: 6>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<6xui32>) -> tensor<3xui32>
     %95 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %96 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %97 = stablehlo.xor %89, %91 : tensor<ui32>
@@ -247,7 +247,7 @@ module @jit_testcase {
     } do {
       %157 = stablehlo.constant dense<1> : tensor<i32>
       %158 = stablehlo.add %iterArg_0, %157 : tensor<i32>
-      %159 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %159 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %160 = stablehlo.reshape %159 : (tensor<1xui32>) -> tensor<ui32>
       %161 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<3xui32>
       %162 = stablehlo.broadcast_in_dim %160, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -258,7 +258,7 @@ module @jit_testcase {
       %167 = stablehlo.shift_right_logical %iterArg_2, %166 : tensor<3xui32>
       %168 = stablehlo.or %163, %167 : tensor<3xui32>
       %169 = stablehlo.xor %161, %168 : tensor<3xui32>
-      %170 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %170 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %171 = stablehlo.reshape %170 : (tensor<1xui32>) -> tensor<ui32>
       %172 = stablehlo.add %161, %169 : tensor<3xui32>
       %173 = stablehlo.broadcast_in_dim %171, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -269,7 +269,7 @@ module @jit_testcase {
       %178 = stablehlo.shift_right_logical %169, %177 : tensor<3xui32>
       %179 = stablehlo.or %174, %178 : tensor<3xui32>
       %180 = stablehlo.xor %172, %179 : tensor<3xui32>
-      %181 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %181 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %182 = stablehlo.reshape %181 : (tensor<1xui32>) -> tensor<ui32>
       %183 = stablehlo.add %172, %180 : tensor<3xui32>
       %184 = stablehlo.broadcast_in_dim %182, dims = [] : (tensor<ui32>) -> tensor<3xui32>
@@ -280,7 +280,7 @@ module @jit_testcase {
       %189 = stablehlo.shift_right_logical %180, %188 : tensor<3xui32>
       %190 = stablehlo.or %185, %189 : tensor<3xui32>
       %191 = stablehlo.xor %183, %190 : tensor<3xui32>
-      %192 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %192 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %193 = stablehlo.reshape %192 : (tensor<1xui32>) -> tensor<ui32>
       %194 = stablehlo.add %183, %191 : tensor<3xui32>
       %195 = stablehlo.broadcast_in_dim %193, dims = [] : (tensor<ui32>) -> tensor<3xui32>

--- a/stablehlo/testdata/random_split_i_0.mlir
+++ b/stablehlo/testdata/random_split_i_0.mlir
@@ -21,12 +21,12 @@ module @jit_testcase {
   }
   func.func private @"<lambda>"(%arg0: tensor<2xui32>) -> tensor<2x2xui32> {
     %0 = stablehlo.iota dim = 0 : tensor<4xui32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %2 = stablehlo.reshape %1 : (tensor<1xui32>) -> tensor<ui32>
-    %3 = "stablehlo.slice"(%arg0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %3 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %4 = stablehlo.reshape %3 : (tensor<1xui32>) -> tensor<ui32>
-    %5 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-    %6 = "stablehlo.slice"(%0) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+    %5 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+    %6 = "stablehlo.slice"(%0) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
     %7 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %8 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %9 = stablehlo.xor %2, %4 : tensor<ui32>
@@ -46,7 +46,7 @@ module @jit_testcase {
     } do {
       %21 = stablehlo.constant dense<1> : tensor<i32>
       %22 = stablehlo.add %iterArg_0, %21 : tensor<i32>
-      %23 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %23 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %24 = stablehlo.reshape %23 : (tensor<1xui32>) -> tensor<ui32>
       %25 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<2xui32>
       %26 = stablehlo.broadcast_in_dim %24, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -57,7 +57,7 @@ module @jit_testcase {
       %31 = stablehlo.shift_right_logical %iterArg_2, %30 : tensor<2xui32>
       %32 = stablehlo.or %27, %31 : tensor<2xui32>
       %33 = stablehlo.xor %25, %32 : tensor<2xui32>
-      %34 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %34 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %35 = stablehlo.reshape %34 : (tensor<1xui32>) -> tensor<ui32>
       %36 = stablehlo.add %25, %33 : tensor<2xui32>
       %37 = stablehlo.broadcast_in_dim %35, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -68,7 +68,7 @@ module @jit_testcase {
       %42 = stablehlo.shift_right_logical %33, %41 : tensor<2xui32>
       %43 = stablehlo.or %38, %42 : tensor<2xui32>
       %44 = stablehlo.xor %36, %43 : tensor<2xui32>
-      %45 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %45 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %46 = stablehlo.reshape %45 : (tensor<1xui32>) -> tensor<ui32>
       %47 = stablehlo.add %36, %44 : tensor<2xui32>
       %48 = stablehlo.broadcast_in_dim %46, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -79,7 +79,7 @@ module @jit_testcase {
       %53 = stablehlo.shift_right_logical %44, %52 : tensor<2xui32>
       %54 = stablehlo.or %49, %53 : tensor<2xui32>
       %55 = stablehlo.xor %47, %54 : tensor<2xui32>
-      %56 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %56 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %57 = stablehlo.reshape %56 : (tensor<1xui32>) -> tensor<ui32>
       %58 = stablehlo.add %47, %55 : tensor<2xui32>
       %59 = stablehlo.broadcast_in_dim %57, dims = [] : (tensor<ui32>) -> tensor<2xui32>

--- a/stablehlo/testdata/random_split_i_1.mlir
+++ b/stablehlo/testdata/random_split_i_1.mlir
@@ -21,12 +21,12 @@ module @jit_testcase {
   }
   func.func private @"<lambda>"(%arg0: tensor<2xui32>) -> tensor<2x2xui32> {
     %0 = stablehlo.iota dim = 0 : tensor<4xui32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %2 = stablehlo.reshape %1 : (tensor<1xui32>) -> tensor<ui32>
-    %3 = "stablehlo.slice"(%arg0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %3 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %4 = stablehlo.reshape %3 : (tensor<1xui32>) -> tensor<ui32>
-    %5 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-    %6 = "stablehlo.slice"(%0) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+    %5 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+    %6 = "stablehlo.slice"(%0) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
     %7 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %8 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %9 = stablehlo.xor %2, %4 : tensor<ui32>
@@ -46,7 +46,7 @@ module @jit_testcase {
     } do {
       %21 = stablehlo.constant dense<1> : tensor<i32>
       %22 = stablehlo.add %iterArg_0, %21 : tensor<i32>
-      %23 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %23 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %24 = stablehlo.reshape %23 : (tensor<1xui32>) -> tensor<ui32>
       %25 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<2xui32>
       %26 = stablehlo.broadcast_in_dim %24, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -57,7 +57,7 @@ module @jit_testcase {
       %31 = stablehlo.shift_right_logical %iterArg_2, %30 : tensor<2xui32>
       %32 = stablehlo.or %27, %31 : tensor<2xui32>
       %33 = stablehlo.xor %25, %32 : tensor<2xui32>
-      %34 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %34 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %35 = stablehlo.reshape %34 : (tensor<1xui32>) -> tensor<ui32>
       %36 = stablehlo.add %25, %33 : tensor<2xui32>
       %37 = stablehlo.broadcast_in_dim %35, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -68,7 +68,7 @@ module @jit_testcase {
       %42 = stablehlo.shift_right_logical %33, %41 : tensor<2xui32>
       %43 = stablehlo.or %38, %42 : tensor<2xui32>
       %44 = stablehlo.xor %36, %43 : tensor<2xui32>
-      %45 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %45 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %46 = stablehlo.reshape %45 : (tensor<1xui32>) -> tensor<ui32>
       %47 = stablehlo.add %36, %44 : tensor<2xui32>
       %48 = stablehlo.broadcast_in_dim %46, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -79,7 +79,7 @@ module @jit_testcase {
       %53 = stablehlo.shift_right_logical %44, %52 : tensor<2xui32>
       %54 = stablehlo.or %49, %53 : tensor<2xui32>
       %55 = stablehlo.xor %47, %54 : tensor<2xui32>
-      %56 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %56 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %57 = stablehlo.reshape %56 : (tensor<1xui32>) -> tensor<ui32>
       %58 = stablehlo.add %47, %55 : tensor<2xui32>
       %59 = stablehlo.broadcast_in_dim %57, dims = [] : (tensor<ui32>) -> tensor<2xui32>

--- a/stablehlo/testdata/random_split_i_2.mlir
+++ b/stablehlo/testdata/random_split_i_2.mlir
@@ -21,12 +21,12 @@ module @jit_testcase {
   }
   func.func private @"<lambda>"(%arg0: tensor<2xui32>) -> tensor<2x2xui32> {
     %0 = stablehlo.iota dim = 0 : tensor<4xui32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %2 = stablehlo.reshape %1 : (tensor<1xui32>) -> tensor<ui32>
-    %3 = "stablehlo.slice"(%arg0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %3 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %4 = stablehlo.reshape %3 : (tensor<1xui32>) -> tensor<ui32>
-    %5 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-    %6 = "stablehlo.slice"(%0) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+    %5 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+    %6 = "stablehlo.slice"(%0) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
     %7 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %8 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %9 = stablehlo.xor %2, %4 : tensor<ui32>
@@ -46,7 +46,7 @@ module @jit_testcase {
     } do {
       %21 = stablehlo.constant dense<1> : tensor<i32>
       %22 = stablehlo.add %iterArg_0, %21 : tensor<i32>
-      %23 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %23 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %24 = stablehlo.reshape %23 : (tensor<1xui32>) -> tensor<ui32>
       %25 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<2xui32>
       %26 = stablehlo.broadcast_in_dim %24, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -57,7 +57,7 @@ module @jit_testcase {
       %31 = stablehlo.shift_right_logical %iterArg_2, %30 : tensor<2xui32>
       %32 = stablehlo.or %27, %31 : tensor<2xui32>
       %33 = stablehlo.xor %25, %32 : tensor<2xui32>
-      %34 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %34 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %35 = stablehlo.reshape %34 : (tensor<1xui32>) -> tensor<ui32>
       %36 = stablehlo.add %25, %33 : tensor<2xui32>
       %37 = stablehlo.broadcast_in_dim %35, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -68,7 +68,7 @@ module @jit_testcase {
       %42 = stablehlo.shift_right_logical %33, %41 : tensor<2xui32>
       %43 = stablehlo.or %38, %42 : tensor<2xui32>
       %44 = stablehlo.xor %36, %43 : tensor<2xui32>
-      %45 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %45 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %46 = stablehlo.reshape %45 : (tensor<1xui32>) -> tensor<ui32>
       %47 = stablehlo.add %36, %44 : tensor<2xui32>
       %48 = stablehlo.broadcast_in_dim %46, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -79,7 +79,7 @@ module @jit_testcase {
       %53 = stablehlo.shift_right_logical %44, %52 : tensor<2xui32>
       %54 = stablehlo.or %49, %53 : tensor<2xui32>
       %55 = stablehlo.xor %47, %54 : tensor<2xui32>
-      %56 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %56 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %57 = stablehlo.reshape %56 : (tensor<1xui32>) -> tensor<ui32>
       %58 = stablehlo.add %47, %55 : tensor<2xui32>
       %59 = stablehlo.broadcast_in_dim %57, dims = [] : (tensor<ui32>) -> tensor<2xui32>

--- a/stablehlo/testdata/random_split_i_3.mlir
+++ b/stablehlo/testdata/random_split_i_3.mlir
@@ -21,12 +21,12 @@ module @jit_testcase {
   }
   func.func private @"<lambda>"(%arg0: tensor<2xui32>) -> tensor<2x2xui32> {
     %0 = stablehlo.iota dim = 0 : tensor<4xui32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %2 = stablehlo.reshape %1 : (tensor<1xui32>) -> tensor<ui32>
-    %3 = "stablehlo.slice"(%arg0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %3 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %4 = stablehlo.reshape %3 : (tensor<1xui32>) -> tensor<ui32>
-    %5 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-    %6 = "stablehlo.slice"(%0) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+    %5 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+    %6 = "stablehlo.slice"(%0) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
     %7 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %8 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %9 = stablehlo.xor %2, %4 : tensor<ui32>
@@ -46,7 +46,7 @@ module @jit_testcase {
     } do {
       %21 = stablehlo.constant dense<1> : tensor<i32>
       %22 = stablehlo.add %iterArg_0, %21 : tensor<i32>
-      %23 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %23 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %24 = stablehlo.reshape %23 : (tensor<1xui32>) -> tensor<ui32>
       %25 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<2xui32>
       %26 = stablehlo.broadcast_in_dim %24, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -57,7 +57,7 @@ module @jit_testcase {
       %31 = stablehlo.shift_right_logical %iterArg_2, %30 : tensor<2xui32>
       %32 = stablehlo.or %27, %31 : tensor<2xui32>
       %33 = stablehlo.xor %25, %32 : tensor<2xui32>
-      %34 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %34 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %35 = stablehlo.reshape %34 : (tensor<1xui32>) -> tensor<ui32>
       %36 = stablehlo.add %25, %33 : tensor<2xui32>
       %37 = stablehlo.broadcast_in_dim %35, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -68,7 +68,7 @@ module @jit_testcase {
       %42 = stablehlo.shift_right_logical %33, %41 : tensor<2xui32>
       %43 = stablehlo.or %38, %42 : tensor<2xui32>
       %44 = stablehlo.xor %36, %43 : tensor<2xui32>
-      %45 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %45 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %46 = stablehlo.reshape %45 : (tensor<1xui32>) -> tensor<ui32>
       %47 = stablehlo.add %36, %44 : tensor<2xui32>
       %48 = stablehlo.broadcast_in_dim %46, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -79,7 +79,7 @@ module @jit_testcase {
       %53 = stablehlo.shift_right_logical %44, %52 : tensor<2xui32>
       %54 = stablehlo.or %49, %53 : tensor<2xui32>
       %55 = stablehlo.xor %47, %54 : tensor<2xui32>
-      %56 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %56 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %57 = stablehlo.reshape %56 : (tensor<1xui32>) -> tensor<ui32>
       %58 = stablehlo.add %47, %55 : tensor<2xui32>
       %59 = stablehlo.broadcast_in_dim %57, dims = [] : (tensor<ui32>) -> tensor<2xui32>

--- a/stablehlo/testdata/random_split_i_4.mlir
+++ b/stablehlo/testdata/random_split_i_4.mlir
@@ -21,12 +21,12 @@ module @jit_testcase {
   }
   func.func private @"<lambda>"(%arg0: tensor<2xui32>) -> tensor<2x2xui32> {
     %0 = stablehlo.iota dim = 0 : tensor<4xui32>
-    %1 = "stablehlo.slice"(%arg0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %1 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %2 = stablehlo.reshape %1 : (tensor<1xui32>) -> tensor<ui32>
-    %3 = "stablehlo.slice"(%arg0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %3 = "stablehlo.slice"(%arg0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %4 = stablehlo.reshape %3 : (tensor<1xui32>) -> tensor<ui32>
-    %5 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
-    %6 = "stablehlo.slice"(%0) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<2xui32>
+    %5 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
+    %6 = "stablehlo.slice"(%0) {limit_indices = array<i64: 4>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<2xui32>
     %7 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %8 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %9 = stablehlo.xor %2, %4 : tensor<ui32>
@@ -46,7 +46,7 @@ module @jit_testcase {
     } do {
       %21 = stablehlo.constant dense<1> : tensor<i32>
       %22 = stablehlo.add %iterArg_0, %21 : tensor<i32>
-      %23 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %23 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %24 = stablehlo.reshape %23 : (tensor<1xui32>) -> tensor<ui32>
       %25 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<2xui32>
       %26 = stablehlo.broadcast_in_dim %24, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -57,7 +57,7 @@ module @jit_testcase {
       %31 = stablehlo.shift_right_logical %iterArg_2, %30 : tensor<2xui32>
       %32 = stablehlo.or %27, %31 : tensor<2xui32>
       %33 = stablehlo.xor %25, %32 : tensor<2xui32>
-      %34 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %34 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %35 = stablehlo.reshape %34 : (tensor<1xui32>) -> tensor<ui32>
       %36 = stablehlo.add %25, %33 : tensor<2xui32>
       %37 = stablehlo.broadcast_in_dim %35, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -68,7 +68,7 @@ module @jit_testcase {
       %42 = stablehlo.shift_right_logical %33, %41 : tensor<2xui32>
       %43 = stablehlo.or %38, %42 : tensor<2xui32>
       %44 = stablehlo.xor %36, %43 : tensor<2xui32>
-      %45 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %45 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %46 = stablehlo.reshape %45 : (tensor<1xui32>) -> tensor<ui32>
       %47 = stablehlo.add %36, %44 : tensor<2xui32>
       %48 = stablehlo.broadcast_in_dim %46, dims = [] : (tensor<ui32>) -> tensor<2xui32>
@@ -79,7 +79,7 @@ module @jit_testcase {
       %53 = stablehlo.shift_right_logical %44, %52 : tensor<2xui32>
       %54 = stablehlo.or %49, %53 : tensor<2xui32>
       %55 = stablehlo.xor %47, %54 : tensor<2xui32>
-      %56 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %56 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %57 = stablehlo.reshape %56 : (tensor<1xui32>) -> tensor<ui32>
       %58 = stablehlo.add %47, %55 : tensor<2xui32>
       %59 = stablehlo.broadcast_in_dim %57, dims = [] : (tensor<ui32>) -> tensor<2xui32>

--- a/stablehlo/testdata/random_uniform_shape_bfloat16.mlir
+++ b/stablehlo/testdata/random_uniform_shape_bfloat16.mlir
@@ -9,13 +9,13 @@ module @jit_testcase {
     %1 = call @expected() : () -> tensor<bf16>
     %2 = stablehlo.constant dense<0> : tensor<1xui32>
     %3 = stablehlo.iota dim = 0 : tensor<1xui32>
-    %4 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %4 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %5 = stablehlo.reshape %4 : (tensor<1xui32>) -> tensor<ui32>
-    %6 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %6 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %7 = stablehlo.reshape %6 : (tensor<1xui32>) -> tensor<ui32>
     %8 = stablehlo.concatenate %3, %2, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-    %10 = "stablehlo.slice"(%8) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+    %10 = "stablehlo.slice"(%8) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %11 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %12 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %13 = stablehlo.xor %5, %7 : tensor<ui32>
@@ -35,7 +35,7 @@ module @jit_testcase {
     } do {
       %60 = stablehlo.constant dense<1> : tensor<i32>
       %61 = stablehlo.add %iterArg_0, %60 : tensor<i32>
-      %62 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %62 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %63 = stablehlo.reshape %62 : (tensor<1xui32>) -> tensor<ui32>
       %64 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<1xui32>
       %65 = stablehlo.broadcast_in_dim %63, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -46,7 +46,7 @@ module @jit_testcase {
       %70 = stablehlo.shift_right_logical %iterArg_2, %69 : tensor<1xui32>
       %71 = stablehlo.or %66, %70 : tensor<1xui32>
       %72 = stablehlo.xor %64, %71 : tensor<1xui32>
-      %73 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %73 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %74 = stablehlo.reshape %73 : (tensor<1xui32>) -> tensor<ui32>
       %75 = stablehlo.add %64, %72 : tensor<1xui32>
       %76 = stablehlo.broadcast_in_dim %74, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -57,7 +57,7 @@ module @jit_testcase {
       %81 = stablehlo.shift_right_logical %72, %80 : tensor<1xui32>
       %82 = stablehlo.or %77, %81 : tensor<1xui32>
       %83 = stablehlo.xor %75, %82 : tensor<1xui32>
-      %84 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %84 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %85 = stablehlo.reshape %84 : (tensor<1xui32>) -> tensor<ui32>
       %86 = stablehlo.add %75, %83 : tensor<1xui32>
       %87 = stablehlo.broadcast_in_dim %85, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -68,7 +68,7 @@ module @jit_testcase {
       %92 = stablehlo.shift_right_logical %83, %91 : tensor<1xui32>
       %93 = stablehlo.or %88, %92 : tensor<1xui32>
       %94 = stablehlo.xor %86, %93 : tensor<1xui32>
-      %95 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %95 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %96 = stablehlo.reshape %95 : (tensor<1xui32>) -> tensor<ui32>
       %97 = stablehlo.add %86, %94 : tensor<1xui32>
       %98 = stablehlo.broadcast_in_dim %96, dims = [] : (tensor<ui32>) -> tensor<1xui32>

--- a/stablehlo/testdata/random_uniform_shape_bfloat16_32.mlir
+++ b/stablehlo/testdata/random_uniform_shape_bfloat16_32.mlir
@@ -12,12 +12,12 @@ module @jit_testcase {
     %4 = stablehlo.constant dense<1.000000e+00> : tensor<bf16>
     %5 = stablehlo.broadcast_in_dim %4, dims = [] : (tensor<bf16>) -> tensor<1xbf16>
     %6 = stablehlo.iota dim = 0 : tensor<16xui32>
-    %7 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %7 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %8 = stablehlo.reshape %7 : (tensor<1xui32>) -> tensor<ui32>
-    %9 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %9 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %10 = stablehlo.reshape %9 : (tensor<1xui32>) -> tensor<ui32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<8> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<16xui32>) -> tensor<8xui32>
-    %12 = "stablehlo.slice"(%6) {limit_indices = dense<16> : tensor<1xi64>, start_indices = dense<8> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<16xui32>) -> tensor<8xui32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 8>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<16xui32>) -> tensor<8xui32>
+    %12 = "stablehlo.slice"(%6) {limit_indices = array<i64: 16>, start_indices = array<i64: 8>, strides = array<i64: 1>} : (tensor<16xui32>) -> tensor<8xui32>
     %13 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %14 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %15 = stablehlo.xor %8, %10 : tensor<ui32>
@@ -37,7 +37,7 @@ module @jit_testcase {
     } do {
       %58 = stablehlo.constant dense<1> : tensor<i32>
       %59 = stablehlo.add %iterArg_0, %58 : tensor<i32>
-      %60 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %60 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %61 = stablehlo.reshape %60 : (tensor<1xui32>) -> tensor<ui32>
       %62 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<8xui32>
       %63 = stablehlo.broadcast_in_dim %61, dims = [] : (tensor<ui32>) -> tensor<8xui32>
@@ -48,7 +48,7 @@ module @jit_testcase {
       %68 = stablehlo.shift_right_logical %iterArg_2, %67 : tensor<8xui32>
       %69 = stablehlo.or %64, %68 : tensor<8xui32>
       %70 = stablehlo.xor %62, %69 : tensor<8xui32>
-      %71 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %71 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %72 = stablehlo.reshape %71 : (tensor<1xui32>) -> tensor<ui32>
       %73 = stablehlo.add %62, %70 : tensor<8xui32>
       %74 = stablehlo.broadcast_in_dim %72, dims = [] : (tensor<ui32>) -> tensor<8xui32>
@@ -59,7 +59,7 @@ module @jit_testcase {
       %79 = stablehlo.shift_right_logical %70, %78 : tensor<8xui32>
       %80 = stablehlo.or %75, %79 : tensor<8xui32>
       %81 = stablehlo.xor %73, %80 : tensor<8xui32>
-      %82 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %82 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %83 = stablehlo.reshape %82 : (tensor<1xui32>) -> tensor<ui32>
       %84 = stablehlo.add %73, %81 : tensor<8xui32>
       %85 = stablehlo.broadcast_in_dim %83, dims = [] : (tensor<ui32>) -> tensor<8xui32>
@@ -70,7 +70,7 @@ module @jit_testcase {
       %90 = stablehlo.shift_right_logical %81, %89 : tensor<8xui32>
       %91 = stablehlo.or %86, %90 : tensor<8xui32>
       %92 = stablehlo.xor %84, %91 : tensor<8xui32>
-      %93 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %93 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %94 = stablehlo.reshape %93 : (tensor<1xui32>) -> tensor<ui32>
       %95 = stablehlo.add %84, %92 : tensor<8xui32>
       %96 = stablehlo.broadcast_in_dim %94, dims = [] : (tensor<ui32>) -> tensor<8xui32>

--- a/stablehlo/testdata/random_uniform_shape_bfloat16_5_4.mlir
+++ b/stablehlo/testdata/random_uniform_shape_bfloat16_5_4.mlir
@@ -12,12 +12,12 @@ module @jit_testcase {
     %4 = stablehlo.constant dense<1.000000e+00> : tensor<bf16>
     %5 = stablehlo.broadcast_in_dim %4, dims = [] : (tensor<bf16>) -> tensor<1x1xbf16>
     %6 = stablehlo.iota dim = 0 : tensor<10xui32>
-    %7 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %7 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %8 = stablehlo.reshape %7 : (tensor<1xui32>) -> tensor<ui32>
-    %9 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %9 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %10 = stablehlo.reshape %9 : (tensor<1xui32>) -> tensor<ui32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<5> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<10xui32>) -> tensor<5xui32>
-    %12 = "stablehlo.slice"(%6) {limit_indices = dense<10> : tensor<1xi64>, start_indices = dense<5> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<10xui32>) -> tensor<5xui32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 5>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<10xui32>) -> tensor<5xui32>
+    %12 = "stablehlo.slice"(%6) {limit_indices = array<i64: 10>, start_indices = array<i64: 5>, strides = array<i64: 1>} : (tensor<10xui32>) -> tensor<5xui32>
     %13 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %14 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %15 = stablehlo.xor %8, %10 : tensor<ui32>
@@ -37,7 +37,7 @@ module @jit_testcase {
     } do {
       %59 = stablehlo.constant dense<1> : tensor<i32>
       %60 = stablehlo.add %iterArg_0, %59 : tensor<i32>
-      %61 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %61 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %62 = stablehlo.reshape %61 : (tensor<1xui32>) -> tensor<ui32>
       %63 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<5xui32>
       %64 = stablehlo.broadcast_in_dim %62, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -48,7 +48,7 @@ module @jit_testcase {
       %69 = stablehlo.shift_right_logical %iterArg_2, %68 : tensor<5xui32>
       %70 = stablehlo.or %65, %69 : tensor<5xui32>
       %71 = stablehlo.xor %63, %70 : tensor<5xui32>
-      %72 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %72 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %73 = stablehlo.reshape %72 : (tensor<1xui32>) -> tensor<ui32>
       %74 = stablehlo.add %63, %71 : tensor<5xui32>
       %75 = stablehlo.broadcast_in_dim %73, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -59,7 +59,7 @@ module @jit_testcase {
       %80 = stablehlo.shift_right_logical %71, %79 : tensor<5xui32>
       %81 = stablehlo.or %76, %80 : tensor<5xui32>
       %82 = stablehlo.xor %74, %81 : tensor<5xui32>
-      %83 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %83 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %84 = stablehlo.reshape %83 : (tensor<1xui32>) -> tensor<ui32>
       %85 = stablehlo.add %74, %82 : tensor<5xui32>
       %86 = stablehlo.broadcast_in_dim %84, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -70,7 +70,7 @@ module @jit_testcase {
       %91 = stablehlo.shift_right_logical %82, %90 : tensor<5xui32>
       %92 = stablehlo.or %87, %91 : tensor<5xui32>
       %93 = stablehlo.xor %85, %92 : tensor<5xui32>
-      %94 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %94 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %95 = stablehlo.reshape %94 : (tensor<1xui32>) -> tensor<ui32>
       %96 = stablehlo.add %85, %93 : tensor<5xui32>
       %97 = stablehlo.broadcast_in_dim %95, dims = [] : (tensor<ui32>) -> tensor<5xui32>

--- a/stablehlo/testdata/random_uniform_shape_float16.mlir
+++ b/stablehlo/testdata/random_uniform_shape_float16.mlir
@@ -9,13 +9,13 @@ module @jit_testcase {
     %1 = call @expected() : () -> tensor<f16>
     %2 = stablehlo.constant dense<0> : tensor<1xui32>
     %3 = stablehlo.iota dim = 0 : tensor<1xui32>
-    %4 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %4 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %5 = stablehlo.reshape %4 : (tensor<1xui32>) -> tensor<ui32>
-    %6 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %6 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %7 = stablehlo.reshape %6 : (tensor<1xui32>) -> tensor<ui32>
     %8 = stablehlo.concatenate %3, %2, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-    %10 = "stablehlo.slice"(%8) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+    %10 = "stablehlo.slice"(%8) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %11 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %12 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %13 = stablehlo.xor %5, %7 : tensor<ui32>
@@ -35,7 +35,7 @@ module @jit_testcase {
     } do {
       %60 = stablehlo.constant dense<1> : tensor<i32>
       %61 = stablehlo.add %iterArg_0, %60 : tensor<i32>
-      %62 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %62 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %63 = stablehlo.reshape %62 : (tensor<1xui32>) -> tensor<ui32>
       %64 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<1xui32>
       %65 = stablehlo.broadcast_in_dim %63, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -46,7 +46,7 @@ module @jit_testcase {
       %70 = stablehlo.shift_right_logical %iterArg_2, %69 : tensor<1xui32>
       %71 = stablehlo.or %66, %70 : tensor<1xui32>
       %72 = stablehlo.xor %64, %71 : tensor<1xui32>
-      %73 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %73 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %74 = stablehlo.reshape %73 : (tensor<1xui32>) -> tensor<ui32>
       %75 = stablehlo.add %64, %72 : tensor<1xui32>
       %76 = stablehlo.broadcast_in_dim %74, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -57,7 +57,7 @@ module @jit_testcase {
       %81 = stablehlo.shift_right_logical %72, %80 : tensor<1xui32>
       %82 = stablehlo.or %77, %81 : tensor<1xui32>
       %83 = stablehlo.xor %75, %82 : tensor<1xui32>
-      %84 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %84 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %85 = stablehlo.reshape %84 : (tensor<1xui32>) -> tensor<ui32>
       %86 = stablehlo.add %75, %83 : tensor<1xui32>
       %87 = stablehlo.broadcast_in_dim %85, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -68,7 +68,7 @@ module @jit_testcase {
       %92 = stablehlo.shift_right_logical %83, %91 : tensor<1xui32>
       %93 = stablehlo.or %88, %92 : tensor<1xui32>
       %94 = stablehlo.xor %86, %93 : tensor<1xui32>
-      %95 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %95 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %96 = stablehlo.reshape %95 : (tensor<1xui32>) -> tensor<ui32>
       %97 = stablehlo.add %86, %94 : tensor<1xui32>
       %98 = stablehlo.broadcast_in_dim %96, dims = [] : (tensor<ui32>) -> tensor<1xui32>

--- a/stablehlo/testdata/random_uniform_shape_float16_32.mlir
+++ b/stablehlo/testdata/random_uniform_shape_float16_32.mlir
@@ -12,12 +12,12 @@ module @jit_testcase {
     %4 = stablehlo.constant dense<1.000000e+00> : tensor<f16>
     %5 = stablehlo.broadcast_in_dim %4, dims = [] : (tensor<f16>) -> tensor<1xf16>
     %6 = stablehlo.iota dim = 0 : tensor<16xui32>
-    %7 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %7 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %8 = stablehlo.reshape %7 : (tensor<1xui32>) -> tensor<ui32>
-    %9 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %9 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %10 = stablehlo.reshape %9 : (tensor<1xui32>) -> tensor<ui32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<8> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<16xui32>) -> tensor<8xui32>
-    %12 = "stablehlo.slice"(%6) {limit_indices = dense<16> : tensor<1xi64>, start_indices = dense<8> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<16xui32>) -> tensor<8xui32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 8>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<16xui32>) -> tensor<8xui32>
+    %12 = "stablehlo.slice"(%6) {limit_indices = array<i64: 16>, start_indices = array<i64: 8>, strides = array<i64: 1>} : (tensor<16xui32>) -> tensor<8xui32>
     %13 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %14 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %15 = stablehlo.xor %8, %10 : tensor<ui32>
@@ -37,7 +37,7 @@ module @jit_testcase {
     } do {
       %58 = stablehlo.constant dense<1> : tensor<i32>
       %59 = stablehlo.add %iterArg_0, %58 : tensor<i32>
-      %60 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %60 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %61 = stablehlo.reshape %60 : (tensor<1xui32>) -> tensor<ui32>
       %62 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<8xui32>
       %63 = stablehlo.broadcast_in_dim %61, dims = [] : (tensor<ui32>) -> tensor<8xui32>
@@ -48,7 +48,7 @@ module @jit_testcase {
       %68 = stablehlo.shift_right_logical %iterArg_2, %67 : tensor<8xui32>
       %69 = stablehlo.or %64, %68 : tensor<8xui32>
       %70 = stablehlo.xor %62, %69 : tensor<8xui32>
-      %71 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %71 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %72 = stablehlo.reshape %71 : (tensor<1xui32>) -> tensor<ui32>
       %73 = stablehlo.add %62, %70 : tensor<8xui32>
       %74 = stablehlo.broadcast_in_dim %72, dims = [] : (tensor<ui32>) -> tensor<8xui32>
@@ -59,7 +59,7 @@ module @jit_testcase {
       %79 = stablehlo.shift_right_logical %70, %78 : tensor<8xui32>
       %80 = stablehlo.or %75, %79 : tensor<8xui32>
       %81 = stablehlo.xor %73, %80 : tensor<8xui32>
-      %82 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %82 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %83 = stablehlo.reshape %82 : (tensor<1xui32>) -> tensor<ui32>
       %84 = stablehlo.add %73, %81 : tensor<8xui32>
       %85 = stablehlo.broadcast_in_dim %83, dims = [] : (tensor<ui32>) -> tensor<8xui32>
@@ -70,7 +70,7 @@ module @jit_testcase {
       %90 = stablehlo.shift_right_logical %81, %89 : tensor<8xui32>
       %91 = stablehlo.or %86, %90 : tensor<8xui32>
       %92 = stablehlo.xor %84, %91 : tensor<8xui32>
-      %93 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %93 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %94 = stablehlo.reshape %93 : (tensor<1xui32>) -> tensor<ui32>
       %95 = stablehlo.add %84, %92 : tensor<8xui32>
       %96 = stablehlo.broadcast_in_dim %94, dims = [] : (tensor<ui32>) -> tensor<8xui32>

--- a/stablehlo/testdata/random_uniform_shape_float16_5_4.mlir
+++ b/stablehlo/testdata/random_uniform_shape_float16_5_4.mlir
@@ -12,12 +12,12 @@ module @jit_testcase {
     %4 = stablehlo.constant dense<1.000000e+00> : tensor<f16>
     %5 = stablehlo.broadcast_in_dim %4, dims = [] : (tensor<f16>) -> tensor<1x1xf16>
     %6 = stablehlo.iota dim = 0 : tensor<10xui32>
-    %7 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %7 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %8 = stablehlo.reshape %7 : (tensor<1xui32>) -> tensor<ui32>
-    %9 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %9 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %10 = stablehlo.reshape %9 : (tensor<1xui32>) -> tensor<ui32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<5> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<10xui32>) -> tensor<5xui32>
-    %12 = "stablehlo.slice"(%6) {limit_indices = dense<10> : tensor<1xi64>, start_indices = dense<5> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<10xui32>) -> tensor<5xui32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 5>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<10xui32>) -> tensor<5xui32>
+    %12 = "stablehlo.slice"(%6) {limit_indices = array<i64: 10>, start_indices = array<i64: 5>, strides = array<i64: 1>} : (tensor<10xui32>) -> tensor<5xui32>
     %13 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %14 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %15 = stablehlo.xor %8, %10 : tensor<ui32>
@@ -37,7 +37,7 @@ module @jit_testcase {
     } do {
       %59 = stablehlo.constant dense<1> : tensor<i32>
       %60 = stablehlo.add %iterArg_0, %59 : tensor<i32>
-      %61 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %61 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %62 = stablehlo.reshape %61 : (tensor<1xui32>) -> tensor<ui32>
       %63 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<5xui32>
       %64 = stablehlo.broadcast_in_dim %62, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -48,7 +48,7 @@ module @jit_testcase {
       %69 = stablehlo.shift_right_logical %iterArg_2, %68 : tensor<5xui32>
       %70 = stablehlo.or %65, %69 : tensor<5xui32>
       %71 = stablehlo.xor %63, %70 : tensor<5xui32>
-      %72 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %72 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %73 = stablehlo.reshape %72 : (tensor<1xui32>) -> tensor<ui32>
       %74 = stablehlo.add %63, %71 : tensor<5xui32>
       %75 = stablehlo.broadcast_in_dim %73, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -59,7 +59,7 @@ module @jit_testcase {
       %80 = stablehlo.shift_right_logical %71, %79 : tensor<5xui32>
       %81 = stablehlo.or %76, %80 : tensor<5xui32>
       %82 = stablehlo.xor %74, %81 : tensor<5xui32>
-      %83 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %83 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %84 = stablehlo.reshape %83 : (tensor<1xui32>) -> tensor<ui32>
       %85 = stablehlo.add %74, %82 : tensor<5xui32>
       %86 = stablehlo.broadcast_in_dim %84, dims = [] : (tensor<ui32>) -> tensor<5xui32>
@@ -70,7 +70,7 @@ module @jit_testcase {
       %91 = stablehlo.shift_right_logical %82, %90 : tensor<5xui32>
       %92 = stablehlo.or %87, %91 : tensor<5xui32>
       %93 = stablehlo.xor %85, %92 : tensor<5xui32>
-      %94 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %94 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %95 = stablehlo.reshape %94 : (tensor<1xui32>) -> tensor<ui32>
       %96 = stablehlo.add %85, %93 : tensor<5xui32>
       %97 = stablehlo.broadcast_in_dim %95, dims = [] : (tensor<ui32>) -> tensor<5xui32>

--- a/stablehlo/testdata/random_uniform_shape_float32.mlir
+++ b/stablehlo/testdata/random_uniform_shape_float32.mlir
@@ -9,13 +9,13 @@ module @jit_testcase {
     %1 = call @expected() : () -> tensor<f32>
     %2 = stablehlo.constant dense<0> : tensor<1xui32>
     %3 = stablehlo.iota dim = 0 : tensor<1xui32>
-    %4 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %4 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %5 = stablehlo.reshape %4 : (tensor<1xui32>) -> tensor<ui32>
-    %6 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %6 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %7 = stablehlo.reshape %6 : (tensor<1xui32>) -> tensor<ui32>
     %8 = stablehlo.concatenate %3, %2, dim = 0 : (tensor<1xui32>, tensor<1xui32>) -> tensor<2xui32>
-    %9 = "stablehlo.slice"(%8) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
-    %10 = "stablehlo.slice"(%8) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %9 = "stablehlo.slice"(%8) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
+    %10 = "stablehlo.slice"(%8) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %11 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %12 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %13 = stablehlo.xor %5, %7 : tensor<ui32>
@@ -35,7 +35,7 @@ module @jit_testcase {
     } do {
       %45 = stablehlo.constant dense<1> : tensor<i32>
       %46 = stablehlo.add %iterArg_0, %45 : tensor<i32>
-      %47 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %47 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %48 = stablehlo.reshape %47 : (tensor<1xui32>) -> tensor<ui32>
       %49 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<1xui32>
       %50 = stablehlo.broadcast_in_dim %48, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -46,7 +46,7 @@ module @jit_testcase {
       %55 = stablehlo.shift_right_logical %iterArg_2, %54 : tensor<1xui32>
       %56 = stablehlo.or %51, %55 : tensor<1xui32>
       %57 = stablehlo.xor %49, %56 : tensor<1xui32>
-      %58 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %58 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %59 = stablehlo.reshape %58 : (tensor<1xui32>) -> tensor<ui32>
       %60 = stablehlo.add %49, %57 : tensor<1xui32>
       %61 = stablehlo.broadcast_in_dim %59, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -57,7 +57,7 @@ module @jit_testcase {
       %66 = stablehlo.shift_right_logical %57, %65 : tensor<1xui32>
       %67 = stablehlo.or %62, %66 : tensor<1xui32>
       %68 = stablehlo.xor %60, %67 : tensor<1xui32>
-      %69 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %69 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %70 = stablehlo.reshape %69 : (tensor<1xui32>) -> tensor<ui32>
       %71 = stablehlo.add %60, %68 : tensor<1xui32>
       %72 = stablehlo.broadcast_in_dim %70, dims = [] : (tensor<ui32>) -> tensor<1xui32>
@@ -68,7 +68,7 @@ module @jit_testcase {
       %77 = stablehlo.shift_right_logical %68, %76 : tensor<1xui32>
       %78 = stablehlo.or %73, %77 : tensor<1xui32>
       %79 = stablehlo.xor %71, %78 : tensor<1xui32>
-      %80 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %80 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %81 = stablehlo.reshape %80 : (tensor<1xui32>) -> tensor<ui32>
       %82 = stablehlo.add %71, %79 : tensor<1xui32>
       %83 = stablehlo.broadcast_in_dim %81, dims = [] : (tensor<ui32>) -> tensor<1xui32>

--- a/stablehlo/testdata/random_uniform_shape_float32_32.mlir
+++ b/stablehlo/testdata/random_uniform_shape_float32_32.mlir
@@ -12,12 +12,12 @@ module @jit_testcase {
     %4 = stablehlo.constant dense<1.000000e+00> : tensor<f32>
     %5 = stablehlo.broadcast_in_dim %4, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %6 = stablehlo.iota dim = 0 : tensor<32xui32>
-    %7 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %7 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %8 = stablehlo.reshape %7 : (tensor<1xui32>) -> tensor<ui32>
-    %9 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %9 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %10 = stablehlo.reshape %9 : (tensor<1xui32>) -> tensor<ui32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<16> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<32xui32>) -> tensor<16xui32>
-    %12 = "stablehlo.slice"(%6) {limit_indices = dense<32> : tensor<1xi64>, start_indices = dense<16> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<32xui32>) -> tensor<16xui32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 16>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<32xui32>) -> tensor<16xui32>
+    %12 = "stablehlo.slice"(%6) {limit_indices = array<i64: 32>, start_indices = array<i64: 16>, strides = array<i64: 1>} : (tensor<32xui32>) -> tensor<16xui32>
     %13 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %14 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %15 = stablehlo.xor %8, %10 : tensor<ui32>
@@ -37,7 +37,7 @@ module @jit_testcase {
     } do {
       %44 = stablehlo.constant dense<1> : tensor<i32>
       %45 = stablehlo.add %iterArg_0, %44 : tensor<i32>
-      %46 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %46 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %47 = stablehlo.reshape %46 : (tensor<1xui32>) -> tensor<ui32>
       %48 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<16xui32>
       %49 = stablehlo.broadcast_in_dim %47, dims = [] : (tensor<ui32>) -> tensor<16xui32>
@@ -48,7 +48,7 @@ module @jit_testcase {
       %54 = stablehlo.shift_right_logical %iterArg_2, %53 : tensor<16xui32>
       %55 = stablehlo.or %50, %54 : tensor<16xui32>
       %56 = stablehlo.xor %48, %55 : tensor<16xui32>
-      %57 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %57 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %58 = stablehlo.reshape %57 : (tensor<1xui32>) -> tensor<ui32>
       %59 = stablehlo.add %48, %56 : tensor<16xui32>
       %60 = stablehlo.broadcast_in_dim %58, dims = [] : (tensor<ui32>) -> tensor<16xui32>
@@ -59,7 +59,7 @@ module @jit_testcase {
       %65 = stablehlo.shift_right_logical %56, %64 : tensor<16xui32>
       %66 = stablehlo.or %61, %65 : tensor<16xui32>
       %67 = stablehlo.xor %59, %66 : tensor<16xui32>
-      %68 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %68 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %69 = stablehlo.reshape %68 : (tensor<1xui32>) -> tensor<ui32>
       %70 = stablehlo.add %59, %67 : tensor<16xui32>
       %71 = stablehlo.broadcast_in_dim %69, dims = [] : (tensor<ui32>) -> tensor<16xui32>
@@ -70,7 +70,7 @@ module @jit_testcase {
       %76 = stablehlo.shift_right_logical %67, %75 : tensor<16xui32>
       %77 = stablehlo.or %72, %76 : tensor<16xui32>
       %78 = stablehlo.xor %70, %77 : tensor<16xui32>
-      %79 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %79 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %80 = stablehlo.reshape %79 : (tensor<1xui32>) -> tensor<ui32>
       %81 = stablehlo.add %70, %78 : tensor<16xui32>
       %82 = stablehlo.broadcast_in_dim %80, dims = [] : (tensor<ui32>) -> tensor<16xui32>

--- a/stablehlo/testdata/random_uniform_shape_float32_5_4.mlir
+++ b/stablehlo/testdata/random_uniform_shape_float32_5_4.mlir
@@ -12,12 +12,12 @@ module @jit_testcase {
     %4 = stablehlo.constant dense<1.000000e+00> : tensor<f32>
     %5 = stablehlo.broadcast_in_dim %4, dims = [] : (tensor<f32>) -> tensor<1x1xf32>
     %6 = stablehlo.iota dim = 0 : tensor<20xui32>
-    %7 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %7 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %8 = stablehlo.reshape %7 : (tensor<1xui32>) -> tensor<ui32>
-    %9 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xui32>) -> tensor<1xui32>
+    %9 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<2xui32>) -> tensor<1xui32>
     %10 = stablehlo.reshape %9 : (tensor<1xui32>) -> tensor<ui32>
-    %11 = "stablehlo.slice"(%6) {limit_indices = dense<10> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<20xui32>) -> tensor<10xui32>
-    %12 = "stablehlo.slice"(%6) {limit_indices = dense<20> : tensor<1xi64>, start_indices = dense<10> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<20xui32>) -> tensor<10xui32>
+    %11 = "stablehlo.slice"(%6) {limit_indices = array<i64: 10>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<20xui32>) -> tensor<10xui32>
+    %12 = "stablehlo.slice"(%6) {limit_indices = array<i64: 20>, start_indices = array<i64: 10>, strides = array<i64: 1>} : (tensor<20xui32>) -> tensor<10xui32>
     %13 = stablehlo.constant dense<[13, 15, 26, 6]> : tensor<4xui32>
     %14 = stablehlo.constant dense<[17, 29, 16, 24]> : tensor<4xui32>
     %15 = stablehlo.xor %8, %10 : tensor<ui32>
@@ -37,7 +37,7 @@ module @jit_testcase {
     } do {
       %45 = stablehlo.constant dense<1> : tensor<i32>
       %46 = stablehlo.add %iterArg_0, %45 : tensor<i32>
-      %47 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %47 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %48 = stablehlo.reshape %47 : (tensor<1xui32>) -> tensor<ui32>
       %49 = stablehlo.add %iterArg_1, %iterArg_2 : tensor<10xui32>
       %50 = stablehlo.broadcast_in_dim %48, dims = [] : (tensor<ui32>) -> tensor<10xui32>
@@ -48,7 +48,7 @@ module @jit_testcase {
       %55 = stablehlo.shift_right_logical %iterArg_2, %54 : tensor<10xui32>
       %56 = stablehlo.or %51, %55 : tensor<10xui32>
       %57 = stablehlo.xor %49, %56 : tensor<10xui32>
-      %58 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %58 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %59 = stablehlo.reshape %58 : (tensor<1xui32>) -> tensor<ui32>
       %60 = stablehlo.add %49, %57 : tensor<10xui32>
       %61 = stablehlo.broadcast_in_dim %59, dims = [] : (tensor<ui32>) -> tensor<10xui32>
@@ -59,7 +59,7 @@ module @jit_testcase {
       %66 = stablehlo.shift_right_logical %57, %65 : tensor<10xui32>
       %67 = stablehlo.or %62, %66 : tensor<10xui32>
       %68 = stablehlo.xor %60, %67 : tensor<10xui32>
-      %69 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %69 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %70 = stablehlo.reshape %69 : (tensor<1xui32>) -> tensor<ui32>
       %71 = stablehlo.add %60, %68 : tensor<10xui32>
       %72 = stablehlo.broadcast_in_dim %70, dims = [] : (tensor<ui32>) -> tensor<10xui32>
@@ -70,7 +70,7 @@ module @jit_testcase {
       %77 = stablehlo.shift_right_logical %68, %76 : tensor<10xui32>
       %78 = stablehlo.or %73, %77 : tensor<10xui32>
       %79 = stablehlo.xor %71, %78 : tensor<10xui32>
-      %80 = "stablehlo.slice"(%iterArg_6) {limit_indices = dense<4> : tensor<1xi64>, start_indices = dense<3> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<4xui32>) -> tensor<1xui32>
+      %80 = "stablehlo.slice"(%iterArg_6) {limit_indices = array<i64: 4>, start_indices = array<i64: 3>, strides = array<i64: 1>} : (tensor<4xui32>) -> tensor<1xui32>
       %81 = stablehlo.reshape %80 : (tensor<1xui32>) -> tensor<ui32>
       %82 = stablehlo.add %71, %79 : tensor<10xui32>
       %83 = stablehlo.broadcast_in_dim %81, dims = [] : (tensor<ui32>) -> tensor<10xui32>

--- a/stablehlo/testdata/roll_axis_0_dynamic.mlir
+++ b/stablehlo/testdata/roll_axis_0_dynamic.mlir
@@ -10,7 +10,7 @@ module @jit_fun_flat_jax {
   }
   func.func private @_roll(%arg0: tensor<i64>, %arg1: tensor<?x4xf32>, %arg2: tensor<i64>) -> tensor<?x4xf32> {
     %0 = stablehlo.broadcast_in_dim %arg2, dims = [] : (tensor<i64>) -> tensor<1xi64>
-    %1 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi64>) -> tensor<1xi64>
+    %1 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi64>) -> tensor<1xi64>
     %2 = stablehlo.reshape %1 : (tensor<1xi64>) -> tensor<i64>
     %3 = stablehlo.convert %arg0 : (tensor<i64>) -> tensor<i32>
     %4 = stablehlo.convert %2 : (tensor<i64>) -> tensor<i32>

--- a/stablehlo/testdata/roll_axis_None_dynamic.mlir
+++ b/stablehlo/testdata/roll_axis_None_dynamic.mlir
@@ -24,7 +24,7 @@ module @jit_fun_flat_jax {
   }
   func.func private @_roll_0(%arg0: tensor<i64>, %arg1: tensor<?xf32>, %arg2: tensor<i64>) -> tensor<?xf32> {
     %0 = stablehlo.broadcast_in_dim %arg2, dims = [] : (tensor<i64>) -> tensor<1xi64>
-    %1 = "stablehlo.slice"(%0) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<1xi64>) -> tensor<1xi64>
+    %1 = "stablehlo.slice"(%0) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<1xi64>) -> tensor<1xi64>
     %2 = stablehlo.reshape %1 : (tensor<1xi64>) -> tensor<i64>
     %3 = stablehlo.constant dense<4> : tensor<i64>
     %4 = stablehlo.multiply %arg0, %3 : tensor<i64>

--- a/stablehlo/testdata/select_and_scatter_add_dtypes_shape_bfloat16_2_4_6__selectprim_ge_windowdimensions__2__2__2__windows5498388055904314537.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_dtypes_shape_bfloat16_2_4_6__selectprim_ge_windowdimensions__2__2__2__windows5498388055904314537.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.add %arg0, %arg1 : tensor<bf16>
       stablehlo.return %8 : tensor<bf16>
     }) {window_dimensions = dense<2> : tensor<3xi64>} : (tensor<2x4x6xbf16>, tensor<1x3x5xbf16>, tensor<bf16>) -> tensor<2x4x6xbf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 4, 6]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<2x4x6xbf16>) -> tensor<2x4x6xbf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 4, 6>, start_indices = array<i64: 0, 0, 0>, strides = array<i64: 1, 1, 1>} : (tensor<2x4x6xbf16>) -> tensor<2x4x6xbf16>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xbf16>, tensor<2x4x6xbf16>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/select_and_scatter_add_dtypes_shape_bool_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstrid3953935332736217868.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_dtypes_shape_bool_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstrid3953935332736217868.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.or %arg0, %arg1 : tensor<i1>
       stablehlo.return %8 : tensor<i1>
     }) {window_dimensions = dense<2> : tensor<3xi64>} : (tensor<2x4x6xi1>, tensor<1x3x5xi1>, tensor<i1>) -> tensor<2x4x6xi1>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 4, 6]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<2x4x6xi1>) -> tensor<2x4x6xi1>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 4, 6>, start_indices = array<i64: 0, 0, 0>, strides = array<i64: 1, 1, 1>} : (tensor<2x4x6xi1>) -> tensor<2x4x6xi1>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xi1>, tensor<2x4x6xi1>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/select_and_scatter_add_dtypes_shape_float16_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowst645862737998720881.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_dtypes_shape_float16_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowst645862737998720881.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.add %arg0, %arg1 : tensor<f16>
       stablehlo.return %8 : tensor<f16>
     }) {window_dimensions = dense<2> : tensor<3xi64>} : (tensor<2x4x6xf16>, tensor<1x3x5xf16>, tensor<f16>) -> tensor<2x4x6xf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 4, 6]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<2x4x6xf16>) -> tensor<2x4x6xf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 4, 6>, start_indices = array<i64: 0, 0, 0>, strides = array<i64: 1, 1, 1>} : (tensor<2x4x6xf16>) -> tensor<2x4x6xf16>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xf16>, tensor<2x4x6xf16>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/select_and_scatter_add_dtypes_shape_float32_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowst6350781848831556769.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_dtypes_shape_float32_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowst6350781848831556769.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.add %arg0, %arg1 : tensor<f32>
       stablehlo.return %8 : tensor<f32>
     }) {window_dimensions = dense<2> : tensor<3xi64>} : (tensor<2x4x6xf32>, tensor<1x3x5xf32>, tensor<f32>) -> tensor<2x4x6xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 4, 6]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<2x4x6xf32>) -> tensor<2x4x6xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 4, 6>, start_indices = array<i64: 0, 0, 0>, strides = array<i64: 1, 1, 1>} : (tensor<2x4x6xf32>) -> tensor<2x4x6xf32>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xf32>, tensor<2x4x6xf32>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/select_and_scatter_add_dtypes_shape_int16_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstri1180273328702244000.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_dtypes_shape_int16_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstri1180273328702244000.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.add %arg0, %arg1 : tensor<i16>
       stablehlo.return %8 : tensor<i16>
     }) {window_dimensions = dense<2> : tensor<3xi64>} : (tensor<2x4x6xi16>, tensor<1x3x5xi16>, tensor<i16>) -> tensor<2x4x6xi16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 4, 6]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<2x4x6xi16>) -> tensor<2x4x6xi16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 4, 6>, start_indices = array<i64: 0, 0, 0>, strides = array<i64: 1, 1, 1>} : (tensor<2x4x6xi16>) -> tensor<2x4x6xi16>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xi16>, tensor<2x4x6xi16>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/select_and_scatter_add_dtypes_shape_int32_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstri-799453658564734982.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_dtypes_shape_int32_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstri-799453658564734982.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.add %arg0, %arg1 : tensor<i32>
       stablehlo.return %8 : tensor<i32>
     }) {window_dimensions = dense<2> : tensor<3xi64>} : (tensor<2x4x6xi32>, tensor<1x3x5xi32>, tensor<i32>) -> tensor<2x4x6xi32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 4, 6]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<2x4x6xi32>) -> tensor<2x4x6xi32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 4, 6>, start_indices = array<i64: 0, 0, 0>, strides = array<i64: 1, 1, 1>} : (tensor<2x4x6xi32>) -> tensor<2x4x6xi32>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xi32>, tensor<2x4x6xi32>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/select_and_scatter_add_dtypes_shape_int8_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstrid-1158927479391781377.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_dtypes_shape_int8_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstrid-1158927479391781377.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.add %arg0, %arg1 : tensor<i8>
       stablehlo.return %8 : tensor<i8>
     }) {window_dimensions = dense<2> : tensor<3xi64>} : (tensor<2x4x6xi8>, tensor<1x3x5xi8>, tensor<i8>) -> tensor<2x4x6xi8>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 4, 6]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<2x4x6xi8>) -> tensor<2x4x6xi8>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 4, 6>, start_indices = array<i64: 0, 0, 0>, strides = array<i64: 1, 1, 1>} : (tensor<2x4x6xi8>) -> tensor<2x4x6xi8>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xi8>, tensor<2x4x6xi8>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/select_and_scatter_add_dtypes_shape_uint16_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstr2639417885255268371.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_dtypes_shape_uint16_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstr2639417885255268371.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.add %arg0, %arg1 : tensor<ui16>
       stablehlo.return %8 : tensor<ui16>
     }) {window_dimensions = dense<2> : tensor<3xi64>} : (tensor<2x4x6xui16>, tensor<1x3x5xui16>, tensor<ui16>) -> tensor<2x4x6xui16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 4, 6]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<2x4x6xui16>) -> tensor<2x4x6xui16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 4, 6>, start_indices = array<i64: 0, 0, 0>, strides = array<i64: 1, 1, 1>} : (tensor<2x4x6xui16>) -> tensor<2x4x6xui16>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xui16>, tensor<2x4x6xui16>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/select_and_scatter_add_dtypes_shape_uint32_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstr4996434443108277595.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_dtypes_shape_uint32_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstr4996434443108277595.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.add %arg0, %arg1 : tensor<ui32>
       stablehlo.return %8 : tensor<ui32>
     }) {window_dimensions = dense<2> : tensor<3xi64>} : (tensor<2x4x6xui32>, tensor<1x3x5xui32>, tensor<ui32>) -> tensor<2x4x6xui32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 4, 6]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<2x4x6xui32>) -> tensor<2x4x6xui32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 4, 6>, start_indices = array<i64: 0, 0, 0>, strides = array<i64: 1, 1, 1>} : (tensor<2x4x6xui32>) -> tensor<2x4x6xui32>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xui32>, tensor<2x4x6xui32>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/select_and_scatter_add_dtypes_shape_uint8_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstri3918878843829093576.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_dtypes_shape_uint8_2_4_6__selectprim_ge_windowdimensions__2__2__2__windowstri3918878843829093576.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.add %arg0, %arg1 : tensor<ui8>
       stablehlo.return %8 : tensor<ui8>
     }) {window_dimensions = dense<2> : tensor<3xi64>} : (tensor<2x4x6xui8>, tensor<1x3x5xui8>, tensor<ui8>) -> tensor<2x4x6xui8>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 4, 6]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<2x4x6xui8>) -> tensor<2x4x6xui8>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 4, 6>, start_indices = array<i64: 0, 0, 0>, strides = array<i64: 1, 1, 1>} : (tensor<2x4x6xui8>) -> tensor<2x4x6xui8>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xui8>, tensor<2x4x6xui8>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/select_and_scatter_add_padding_shape_float32_2_4_6__selectprim_ge_windowdimensions__2__2__2__windows7745011263169515186.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_padding_shape_float32_2_4_6__selectprim_ge_windowdimensions__2__2__2__windows7745011263169515186.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.add %arg0, %arg1 : tensor<f32>
       stablehlo.return %8 : tensor<f32>
     }) {window_dimensions = dense<2> : tensor<3xi64>} : (tensor<4x6x8xf32>, tensor<3x5x7xf32>, tensor<f32>) -> tensor<4x6x8xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[3, 5, 7]> : tensor<3xi64>, start_indices = dense<1> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<4x6x8xf32>) -> tensor<2x4x6xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 3, 5, 7>, start_indices = array<i64: 1, 1, 1>, strides = array<i64: 1, 1, 1>} : (tensor<4x6x8xf32>) -> tensor<2x4x6xf32>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xf32>, tensor<2x4x6xf32>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/select_and_scatter_add_select_prim_shape_float32_2_4_6__selectprim_le_windowdimensions__2__2__2__win3195252304676505603.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_select_prim_shape_float32_2_4_6__selectprim_le_windowdimensions__2__2__2__win3195252304676505603.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.add %arg0, %arg1 : tensor<f32>
       stablehlo.return %8 : tensor<f32>
     }) {window_dimensions = dense<2> : tensor<3xi64>} : (tensor<2x4x6xf32>, tensor<1x3x5xf32>, tensor<f32>) -> tensor<2x4x6xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 4, 6]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<2x4x6xf32>) -> tensor<2x4x6xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 4, 6>, start_indices = array<i64: 0, 0, 0>, strides = array<i64: 1, 1, 1>} : (tensor<2x4x6xf32>) -> tensor<2x4x6xf32>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xf32>, tensor<2x4x6xf32>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_bfloat16_2_4_6__selectprim_ge_windowdimensions__1__3__1__win7138983918417685208.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_bfloat16_2_4_6__selectprim_ge_windowdimensions__1__3__1__win7138983918417685208.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.add %arg0, %arg1 : tensor<bf16>
       stablehlo.return %8 : tensor<bf16>
     }) {window_dimensions = dense<[1, 3, 1]> : tensor<3xi64>, window_strides = dense<[1, 2, 1]> : tensor<3xi64>} : (tensor<2x4x6xbf16>, tensor<2x1x6xbf16>, tensor<bf16>) -> tensor<2x4x6xbf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 4, 6]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<2x4x6xbf16>) -> tensor<2x4x6xbf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 4, 6>, start_indices = array<i64: 0, 0, 0>, strides = array<i64: 1, 1, 1>} : (tensor<2x4x6xbf16>) -> tensor<2x4x6xbf16>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xbf16>, tensor<2x4x6xbf16>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_float16_2_4_6__selectprim_ge_windowdimensions__1__3__1__wind7040864175077487301.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_float16_2_4_6__selectprim_ge_windowdimensions__1__3__1__wind7040864175077487301.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.add %arg0, %arg1 : tensor<f16>
       stablehlo.return %8 : tensor<f16>
     }) {window_dimensions = dense<[1, 3, 1]> : tensor<3xi64>, window_strides = dense<[1, 2, 1]> : tensor<3xi64>} : (tensor<2x4x6xf16>, tensor<2x1x6xf16>, tensor<f16>) -> tensor<2x4x6xf16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 4, 6]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<2x4x6xf16>) -> tensor<2x4x6xf16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 4, 6>, start_indices = array<i64: 0, 0, 0>, strides = array<i64: 1, 1, 1>} : (tensor<2x4x6xf16>) -> tensor<2x4x6xf16>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xf16>, tensor<2x4x6xf16>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_float32_2_4_6__selectprim_ge_windowdimensions__1__3__1__wind-6867541439412093951.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_float32_2_4_6__selectprim_ge_windowdimensions__1__3__1__wind-6867541439412093951.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.add %arg0, %arg1 : tensor<f32>
       stablehlo.return %8 : tensor<f32>
     }) {window_dimensions = dense<[1, 3, 1]> : tensor<3xi64>, window_strides = dense<[1, 2, 1]> : tensor<3xi64>} : (tensor<2x4x6xf32>, tensor<2x1x6xf32>, tensor<f32>) -> tensor<2x4x6xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 4, 6]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<2x4x6xf32>) -> tensor<2x4x6xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 4, 6>, start_indices = array<i64: 0, 0, 0>, strides = array<i64: 1, 1, 1>} : (tensor<2x4x6xf32>) -> tensor<2x4x6xf32>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xf32>, tensor<2x4x6xf32>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_int16_2_4_6__selectprim_ge_windowdimensions__1__3__1__window-1515521222491375303.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_int16_2_4_6__selectprim_ge_windowdimensions__1__3__1__window-1515521222491375303.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.add %arg0, %arg1 : tensor<i16>
       stablehlo.return %8 : tensor<i16>
     }) {window_dimensions = dense<[1, 3, 1]> : tensor<3xi64>, window_strides = dense<[1, 2, 1]> : tensor<3xi64>} : (tensor<2x4x6xi16>, tensor<2x1x6xi16>, tensor<i16>) -> tensor<2x4x6xi16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 4, 6]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<2x4x6xi16>) -> tensor<2x4x6xi16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 4, 6>, start_indices = array<i64: 0, 0, 0>, strides = array<i64: 1, 1, 1>} : (tensor<2x4x6xi16>) -> tensor<2x4x6xi16>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xi16>, tensor<2x4x6xi16>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_int32_2_4_6__selectprim_ge_windowdimensions__1__3__1__window-8827730052770528042.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_int32_2_4_6__selectprim_ge_windowdimensions__1__3__1__window-8827730052770528042.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.add %arg0, %arg1 : tensor<i32>
       stablehlo.return %8 : tensor<i32>
     }) {window_dimensions = dense<[1, 3, 1]> : tensor<3xi64>, window_strides = dense<[1, 2, 1]> : tensor<3xi64>} : (tensor<2x4x6xi32>, tensor<2x1x6xi32>, tensor<i32>) -> tensor<2x4x6xi32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 4, 6]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<2x4x6xi32>) -> tensor<2x4x6xi32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 4, 6>, start_indices = array<i64: 0, 0, 0>, strides = array<i64: 1, 1, 1>} : (tensor<2x4x6xi32>) -> tensor<2x4x6xi32>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xi32>, tensor<2x4x6xi32>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_uint16_2_4_6__selectprim_ge_windowdimensions__1__3__1__windo2756544409025303514.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_uint16_2_4_6__selectprim_ge_windowdimensions__1__3__1__windo2756544409025303514.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.add %arg0, %arg1 : tensor<ui16>
       stablehlo.return %8 : tensor<ui16>
     }) {window_dimensions = dense<[1, 3, 1]> : tensor<3xi64>, window_strides = dense<[1, 2, 1]> : tensor<3xi64>} : (tensor<2x4x6xui16>, tensor<2x1x6xui16>, tensor<ui16>) -> tensor<2x4x6xui16>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 4, 6]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<2x4x6xui16>) -> tensor<2x4x6xui16>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 4, 6>, start_indices = array<i64: 0, 0, 0>, strides = array<i64: 1, 1, 1>} : (tensor<2x4x6xui16>) -> tensor<2x4x6xui16>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xui16>, tensor<2x4x6xui16>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_uint32_2_4_6__selectprim_ge_windowdimensions__1__3__1__windo-6304561722695857269.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_tpu_dtypes_shape_uint32_2_4_6__selectprim_ge_windowdimensions__1__3__1__windo-6304561722695857269.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.add %arg0, %arg1 : tensor<ui32>
       stablehlo.return %8 : tensor<ui32>
     }) {window_dimensions = dense<[1, 3, 1]> : tensor<3xi64>, window_strides = dense<[1, 2, 1]> : tensor<3xi64>} : (tensor<2x4x6xui32>, tensor<2x1x6xui32>, tensor<ui32>) -> tensor<2x4x6xui32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 4, 6]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<2x4x6xui32>) -> tensor<2x4x6xui32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 4, 6>, start_indices = array<i64: 0, 0, 0>, strides = array<i64: 1, 1, 1>} : (tensor<2x4x6xui32>) -> tensor<2x4x6xui32>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xui32>, tensor<2x4x6xui32>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/select_and_scatter_add_window_dimensions_shape_float32_2_4_6__selectprim_ge_windowdimensions__1__2__2730457018571670567.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_window_dimensions_shape_float32_2_4_6__selectprim_ge_windowdimensions__1__2__2730457018571670567.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.add %arg0, %arg1 : tensor<f32>
       stablehlo.return %8 : tensor<f32>
     }) {window_dimensions = dense<[1, 2, 3]> : tensor<3xi64>} : (tensor<2x4x6xf32>, tensor<2x3x4xf32>, tensor<f32>) -> tensor<2x4x6xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 4, 6]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<2x4x6xf32>) -> tensor<2x4x6xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 4, 6>, start_indices = array<i64: 0, 0, 0>, strides = array<i64: 1, 1, 1>} : (tensor<2x4x6xf32>) -> tensor<2x4x6xf32>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xf32>, tensor<2x4x6xf32>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/select_and_scatter_add_window_strides_shape_float32_2_4_6__selectprim_ge_windowdimensions__2__2__2__-3819633790000483811.mlir
+++ b/stablehlo/testdata/select_and_scatter_add_window_strides_shape_float32_2_4_6__selectprim_ge_windowdimensions__2__2__2__-3819633790000483811.mlir
@@ -19,7 +19,7 @@ module @jit_testcase {
       %8 = stablehlo.add %arg0, %arg1 : tensor<f32>
       stablehlo.return %8 : tensor<f32>
     }) {window_dimensions = dense<2> : tensor<3xi64>, window_strides = dense<[1, 2, 3]> : tensor<3xi64>} : (tensor<2x4x6xf32>, tensor<1x2x2xf32>, tensor<f32>) -> tensor<2x4x6xf32>
-    %6 = "stablehlo.slice"(%5) {limit_indices = dense<[2, 4, 6]> : tensor<3xi64>, start_indices = dense<0> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<2x4x6xf32>) -> tensor<2x4x6xf32>
+    %6 = "stablehlo.slice"(%5) {limit_indices = array<i64: 2, 4, 6>, start_indices = array<i64: 0, 0, 0>, strides = array<i64: 1, 1, 1>} : (tensor<2x4x6xf32>) -> tensor<2x4x6xf32>
     %7 = stablehlo.custom_call @check.eq(%6, %1) : (tensor<2x4x6xf32>, tensor<2x4x6xf32>) -> tensor<i1>
     return %7 : tensor<i1>
   }

--- a/stablehlo/testdata/slice_dtypes_a_bfloat16_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_bfloat16_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0 = call @inputs() : () -> tensor<3xbf16>
     %1 = call @expected() : () -> tensor<1xbf16>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xbf16>) -> tensor<1xbf16>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xbf16>) -> tensor<1xbf16>
     %3 = stablehlo.custom_call @check.eq(%2, %1) : (tensor<1xbf16>, tensor<1xbf16>) -> tensor<i1>
     return %3 : tensor<i1>
   }

--- a/stablehlo/testdata/slice_dtypes_a_bool_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_bool_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0 = call @inputs() : () -> tensor<3xi1>
     %1 = call @expected() : () -> tensor<1xi1>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xi1>) -> tensor<1xi1>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xi1>) -> tensor<1xi1>
     %3 = stablehlo.custom_call @check.eq(%2, %1) : (tensor<1xi1>, tensor<1xi1>) -> tensor<i1>
     return %3 : tensor<i1>
   }

--- a/stablehlo/testdata/slice_dtypes_a_complex64_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_complex64_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0 = call @inputs() : () -> tensor<3xcomplex<f32>>
     %1 = call @expected() : () -> tensor<1xcomplex<f32>>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xcomplex<f32>>) -> tensor<1xcomplex<f32>>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xcomplex<f32>>) -> tensor<1xcomplex<f32>>
     %3 = stablehlo.custom_call @check.eq(%2, %1) : (tensor<1xcomplex<f32>>, tensor<1xcomplex<f32>>) -> tensor<i1>
     return %3 : tensor<i1>
   }

--- a/stablehlo/testdata/slice_dtypes_a_float16_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_float16_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0 = call @inputs() : () -> tensor<3xf16>
     %1 = call @expected() : () -> tensor<1xf16>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf16>) -> tensor<1xf16>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xf16>) -> tensor<1xf16>
     %3 = stablehlo.custom_call @check.eq(%2, %1) : (tensor<1xf16>, tensor<1xf16>) -> tensor<i1>
     return %3 : tensor<i1>
   }

--- a/stablehlo/testdata/slice_dtypes_a_float32_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_float32_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0 = call @inputs() : () -> tensor<3xf32>
     %1 = call @expected() : () -> tensor<1xf32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %3 = stablehlo.custom_call @check.eq(%2, %1) : (tensor<1xf32>, tensor<1xf32>) -> tensor<i1>
     return %3 : tensor<i1>
   }

--- a/stablehlo/testdata/slice_dtypes_a_int16_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_int16_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0 = call @inputs() : () -> tensor<3xi16>
     %1 = call @expected() : () -> tensor<1xi16>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xi16>) -> tensor<1xi16>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xi16>) -> tensor<1xi16>
     %3 = stablehlo.custom_call @check.eq(%2, %1) : (tensor<1xi16>, tensor<1xi16>) -> tensor<i1>
     return %3 : tensor<i1>
   }

--- a/stablehlo/testdata/slice_dtypes_a_int32_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_int32_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0 = call @inputs() : () -> tensor<3xi32>
     %1 = call @expected() : () -> tensor<1xi32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xi32>) -> tensor<1xi32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xi32>) -> tensor<1xi32>
     %3 = stablehlo.custom_call @check.eq(%2, %1) : (tensor<1xi32>, tensor<1xi32>) -> tensor<i1>
     return %3 : tensor<i1>
   }

--- a/stablehlo/testdata/slice_dtypes_a_int8_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_int8_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0 = call @inputs() : () -> tensor<3xi8>
     %1 = call @expected() : () -> tensor<1xi8>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xi8>) -> tensor<1xi8>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xi8>) -> tensor<1xi8>
     %3 = stablehlo.custom_call @check.eq(%2, %1) : (tensor<1xi8>, tensor<1xi8>) -> tensor<i1>
     return %3 : tensor<i1>
   }

--- a/stablehlo/testdata/slice_dtypes_a_uint16_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_uint16_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0 = call @inputs() : () -> tensor<3xui16>
     %1 = call @expected() : () -> tensor<1xui16>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xui16>) -> tensor<1xui16>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xui16>) -> tensor<1xui16>
     %3 = stablehlo.custom_call @check.eq(%2, %1) : (tensor<1xui16>, tensor<1xui16>) -> tensor<i1>
     return %3 : tensor<i1>
   }

--- a/stablehlo/testdata/slice_dtypes_a_uint32_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_uint32_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0 = call @inputs() : () -> tensor<3xui32>
     %1 = call @expected() : () -> tensor<1xui32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xui32>) -> tensor<1xui32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xui32>) -> tensor<1xui32>
     %3 = stablehlo.custom_call @check.eq(%2, %1) : (tensor<1xui32>, tensor<1xui32>) -> tensor<i1>
     return %3 : tensor<i1>
   }

--- a/stablehlo/testdata/slice_dtypes_a_uint8_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_dtypes_a_uint8_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0 = call @inputs() : () -> tensor<3xui8>
     %1 = call @expected() : () -> tensor<1xui8>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xui8>) -> tensor<1xui8>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xui8>) -> tensor<1xui8>
     %3 = stablehlo.custom_call @check.eq(%2, %1) : (tensor<1xui8>, tensor<1xui8>) -> tensor<i1>
     return %3 : tensor<i1>
   }

--- a/stablehlo/testdata/slice_shapes_a_float32_3__start_indices__1___limit_indices__2___strides_None.mlir
+++ b/stablehlo/testdata/slice_shapes_a_float32_3__start_indices__1___limit_indices__2___strides_None.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0 = call @inputs() : () -> tensor<3xf32>
     %1 = call @expected() : () -> tensor<1xf32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %3 = stablehlo.custom_call @check.eq(%2, %1) : (tensor<1xf32>, tensor<1xf32>) -> tensor<i1>
     return %3 : tensor<i1>
   }

--- a/stablehlo/testdata/slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__2__1__strides__1__1.mlir
+++ b/stablehlo/testdata/slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__2__1__strides__1__1.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0 = call @inputs() : () -> tensor<5x3xf32>
     %1 = call @expected() : () -> tensor<1x0xf32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<[2, 1]> : tensor<2xi64>, start_indices = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<5x3xf32>) -> tensor<1x0xf32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 2, 1>, start_indices = array<i64: 1, 1>, strides = array<i64: 1, 1>} : (tensor<5x3xf32>) -> tensor<1x0xf32>
     %3 = stablehlo.custom_call @check.eq(%2, %1) : (tensor<1x0xf32>, tensor<1x0xf32>) -> tensor<i1>
     return %3 : tensor<i1>
   }

--- a/stablehlo/testdata/slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__3__1__strides_None.mlir
+++ b/stablehlo/testdata/slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__3__1__strides_None.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0 = call @inputs() : () -> tensor<5x3xf32>
     %1 = call @expected() : () -> tensor<2x0xf32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<[3, 1]> : tensor<2xi64>, start_indices = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<5x3xf32>) -> tensor<2x0xf32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 3, 1>, start_indices = array<i64: 1, 1>, strides = array<i64: 1, 1>} : (tensor<5x3xf32>) -> tensor<2x0xf32>
     %3 = stablehlo.custom_call @check.eq(%2, %1) : (tensor<2x0xf32>, tensor<2x0xf32>) -> tensor<i1>
     return %3 : tensor<i1>
   }

--- a/stablehlo/testdata/slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__3__2__strides_None.mlir
+++ b/stablehlo/testdata/slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__3__2__strides_None.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0 = call @inputs() : () -> tensor<5x3xf32>
     %1 = call @expected() : () -> tensor<2x1xf32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<[3, 2]> : tensor<2xi64>, start_indices = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<5x3xf32>) -> tensor<2x1xf32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 3, 2>, start_indices = array<i64: 1, 1>, strides = array<i64: 1, 1>} : (tensor<5x3xf32>) -> tensor<2x1xf32>
     %3 = stablehlo.custom_call @check.eq(%2, %1) : (tensor<2x1xf32>, tensor<2x1xf32>) -> tensor<i1>
     return %3 : tensor<i1>
   }

--- a/stablehlo/testdata/slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__5__3__strides__2__1.mlir
+++ b/stablehlo/testdata/slice_shapes_a_float32_5_3__start_indices__1__1__limit_indices__5__3__strides__2__1.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0 = call @inputs() : () -> tensor<5x3xf32>
     %1 = call @expected() : () -> tensor<2x2xf32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<[5, 3]> : tensor<2xi64>, start_indices = dense<1> : tensor<2xi64>, strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<5x3xf32>) -> tensor<2x2xf32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 5, 3>, start_indices = array<i64: 1, 1>, strides = array<i64: 2, 1>} : (tensor<5x3xf32>) -> tensor<2x2xf32>
     %3 = stablehlo.custom_call @check.eq(%2, %1) : (tensor<2x2xf32>, tensor<2x2xf32>) -> tensor<i1>
     return %3 : tensor<i1>
   }

--- a/stablehlo/testdata/slice_shapes_a_float32_5__start_indices__1___limit_indices__5___strides__2.mlir
+++ b/stablehlo/testdata/slice_shapes_a_float32_5__start_indices__1___limit_indices__5___strides__2.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0 = call @inputs() : () -> tensor<5xf32>
     %1 = call @expected() : () -> tensor<2xf32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<5> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<2> : tensor<1xi64>} : (tensor<5xf32>) -> tensor<2xf32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 5>, start_indices = array<i64: 1>, strides = array<i64: 2>} : (tensor<5xf32>) -> tensor<2xf32>
     %3 = stablehlo.custom_call @check.eq(%2, %1) : (tensor<2xf32>, tensor<2xf32>) -> tensor<i1>
     return %3 : tensor<i1>
   }

--- a/stablehlo/testdata/slice_shapes_a_float32_7_5_3__start_indices__4__0__1__limit_indices__7__1__3__strides_None.mlir
+++ b/stablehlo/testdata/slice_shapes_a_float32_7_5_3__start_indices__4__0__1__limit_indices__7__1__3__strides_None.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0 = call @inputs() : () -> tensor<7x5x3xf32>
     %1 = call @expected() : () -> tensor<3x1x2xf32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<[7, 1, 3]> : tensor<3xi64>, start_indices = dense<[4, 0, 1]> : tensor<3xi64>, strides = dense<1> : tensor<3xi64>} : (tensor<7x5x3xf32>) -> tensor<3x1x2xf32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 7, 1, 3>, start_indices = array<i64: 4, 0, 1>, strides = array<i64: 1, 1, 1>} : (tensor<7x5x3xf32>) -> tensor<3x1x2xf32>
     %3 = stablehlo.custom_call @check.eq(%2, %1) : (tensor<3x1x2xf32>, tensor<3x1x2xf32>) -> tensor<i1>
     return %3 : tensor<i1>
   }

--- a/stablehlo/testdata/slice_shapes_a_float32_7__start_indices__4___limit_indices__7___strides_None.mlir
+++ b/stablehlo/testdata/slice_shapes_a_float32_7__start_indices__4___limit_indices__7___strides_None.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0 = call @inputs() : () -> tensor<7xf32>
     %1 = call @expected() : () -> tensor<3xf32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<7> : tensor<1xi64>, start_indices = dense<4> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<7xf32>) -> tensor<3xf32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 7>, start_indices = array<i64: 4>, strides = array<i64: 1>} : (tensor<7xf32>) -> tensor<3xf32>
     %3 = stablehlo.custom_call @check.eq(%2, %1) : (tensor<3xf32>, tensor<3xf32>) -> tensor<i1>
     return %3 : tensor<i1>
   }

--- a/stablehlo/testdata/slice_shapes_a_float32_8__start_indices__1___limit_indices__6___strides__2.mlir
+++ b/stablehlo/testdata/slice_shapes_a_float32_8__start_indices__1___limit_indices__6___strides__2.mlir
@@ -7,7 +7,7 @@ module @jit_testcase {
   func.func public @main() -> tensor<i1> {
     %0 = call @inputs() : () -> tensor<8xf32>
     %1 = call @expected() : () -> tensor<3xf32>
-    %2 = "stablehlo.slice"(%0) {limit_indices = dense<6> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<2> : tensor<1xi64>} : (tensor<8xf32>) -> tensor<3xf32>
+    %2 = "stablehlo.slice"(%0) {limit_indices = array<i64: 6>, start_indices = array<i64: 1>, strides = array<i64: 2>} : (tensor<8xf32>) -> tensor<3xf32>
     %3 = stablehlo.custom_call @check.eq(%2, %1) : (tensor<3xf32>, tensor<3xf32>) -> tensor<i1>
     return %3 : tensor<i1>
   }

--- a/stablehlo/testdata/tridiagonal_solve_shape_float32_3.mlir
+++ b/stablehlo/testdata/tridiagonal_solve_shape_float32_3.mlir
@@ -14,23 +14,23 @@ module @jit_testcase {
     %6 = stablehlo.dynamic_slice %0#1, %5, sizes = [1] : (tensor<3xf32>, tensor<i32>) -> tensor<1xf32>
     %7 = stablehlo.reshape %6 : (tensor<1xf32>) -> tensor<f32>
     %8 = stablehlo.divide %4, %7 : tensor<f32>
-    %9 = "stablehlo.slice"(%0#1) {limit_indices = dense<0> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<0xf32>
-    %10 = "stablehlo.slice"(%0#1) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<3xf32>
-    %11 = "stablehlo.slice"(%0#2) {limit_indices = dense<0> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<0xf32>
-    %12 = "stablehlo.slice"(%0#2) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<3xf32>
-    %13 = "stablehlo.slice"(%0#0) {limit_indices = dense<0> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<0xf32>
-    %14 = "stablehlo.slice"(%0#0) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<3xf32>
+    %9 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 0>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<0xf32>
+    %10 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<3xf32>
+    %11 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 0>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<0xf32>
+    %12 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<3xf32>
+    %13 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 0>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<0xf32>
+    %14 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<3xf32>
     %15 = stablehlo.reshape %9 : (tensor<0xf32>) -> tensor<0x32xf32>
     %16 = stablehlo.reshape %11 : (tensor<0xf32>) -> tensor<0x32xf32>
     %17 = stablehlo.reshape %13 : (tensor<0xf32>) -> tensor<0x32xf32>
     %18 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %19 = stablehlo.broadcast_in_dim %18, dims = [] : (tensor<f32>) -> tensor<0x32xf32>
     %20 = stablehlo.reshape %19 : (tensor<0x32xf32>) -> tensor<0xf32>
-    %21 = "stablehlo.slice"(%10) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %21 = "stablehlo.slice"(%10) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %22 = stablehlo.reshape %21 : (tensor<1xf32>) -> tensor<f32>
-    %23 = "stablehlo.slice"(%12) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %23 = "stablehlo.slice"(%12) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %24 = stablehlo.reshape %23 : (tensor<1xf32>) -> tensor<f32>
-    %25 = "stablehlo.slice"(%14) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %25 = "stablehlo.slice"(%14) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %26 = stablehlo.reshape %25 : (tensor<1xf32>) -> tensor<f32>
     %27 = stablehlo.multiply %26, %8 : tensor<f32>
     %28 = stablehlo.subtract %22, %27 : tensor<f32>
@@ -38,11 +38,11 @@ module @jit_testcase {
     %30 = stablehlo.multiply %26, %8 : tensor<f32>
     %31 = stablehlo.subtract %22, %30 : tensor<f32>
     %32 = stablehlo.divide %24, %31 : tensor<f32>
-    %33 = "stablehlo.slice"(%10) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %33 = "stablehlo.slice"(%10) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %34 = stablehlo.reshape %33 : (tensor<1xf32>) -> tensor<f32>
-    %35 = "stablehlo.slice"(%12) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %35 = "stablehlo.slice"(%12) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %36 = stablehlo.reshape %35 : (tensor<1xf32>) -> tensor<f32>
-    %37 = "stablehlo.slice"(%14) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %37 = "stablehlo.slice"(%14) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %38 = stablehlo.reshape %37 : (tensor<1xf32>) -> tensor<f32>
     %39 = stablehlo.multiply %38, %29 : tensor<f32>
     %40 = stablehlo.subtract %34, %39 : tensor<f32>
@@ -50,11 +50,11 @@ module @jit_testcase {
     %42 = stablehlo.multiply %38, %29 : tensor<f32>
     %43 = stablehlo.subtract %34, %42 : tensor<f32>
     %44 = stablehlo.divide %36, %43 : tensor<f32>
-    %45 = "stablehlo.slice"(%10) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %45 = "stablehlo.slice"(%10) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %46 = stablehlo.reshape %45 : (tensor<1xf32>) -> tensor<f32>
-    %47 = "stablehlo.slice"(%12) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %47 = "stablehlo.slice"(%12) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %48 = stablehlo.reshape %47 : (tensor<1xf32>) -> tensor<f32>
-    %49 = "stablehlo.slice"(%14) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %49 = "stablehlo.slice"(%14) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %50 = stablehlo.reshape %49 : (tensor<1xf32>) -> tensor<f32>
     %51 = stablehlo.multiply %50, %41 : tensor<f32>
     %52 = stablehlo.subtract %46, %51 : tensor<f32>
@@ -82,14 +82,14 @@ module @jit_testcase {
     %74 = stablehlo.broadcast_in_dim %73, dims = [] : (tensor<i32>) -> tensor<1xi32>
     %75 = "stablehlo.gather"(%61, %74) {dimension_numbers = #stablehlo.gather<offset_dims = [0], start_index_map = [0]>, indices_are_sorted = true, slice_sizes = dense<2> : tensor<1xi64>} : (tensor<3xf32>, tensor<1xi32>) -> tensor<2xf32>
     %76 = call @append(%72, %75) : (tensor<1xf32>, tensor<2xf32>) -> tensor<3xf32>
-    %77 = "stablehlo.slice"(%0#3) {limit_indices = dense<[0, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>) -> tensor<0x1xf32>
-    %78 = "stablehlo.slice"(%0#3) {limit_indices = dense<[3, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>) -> tensor<3x1xf32>
-    %79 = "stablehlo.slice"(%0#1) {limit_indices = dense<0> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<0xf32>
-    %80 = "stablehlo.slice"(%0#1) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<3xf32>
-    %81 = "stablehlo.slice"(%76) {limit_indices = dense<0> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<0xf32>
-    %82 = "stablehlo.slice"(%76) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<3xf32>
-    %83 = "stablehlo.slice"(%0#0) {limit_indices = dense<0> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<0xf32>
-    %84 = "stablehlo.slice"(%0#0) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<3xf32>
+    %77 = "stablehlo.slice"(%0#3) {limit_indices = array<i64: 0, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<3x1xf32>) -> tensor<0x1xf32>
+    %78 = "stablehlo.slice"(%0#3) {limit_indices = array<i64: 3, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<3x1xf32>) -> tensor<3x1xf32>
+    %79 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 0>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<0xf32>
+    %80 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<3xf32>
+    %81 = "stablehlo.slice"(%76) {limit_indices = array<i64: 0>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<0xf32>
+    %82 = "stablehlo.slice"(%76) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<3xf32>
+    %83 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 0>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<0xf32>
+    %84 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<3xf32>
     %85 = stablehlo.reshape %77 : (tensor<0x1xf32>) -> tensor<0x32x1xf32>
     %86 = stablehlo.reshape %79 : (tensor<0xf32>) -> tensor<0x32xf32>
     %87 = stablehlo.reshape %81 : (tensor<0xf32>) -> tensor<0x32xf32>
@@ -97,13 +97,13 @@ module @jit_testcase {
     %89 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %90 = stablehlo.broadcast_in_dim %89, dims = [] : (tensor<f32>) -> tensor<0x32x1xf32>
     %91 = stablehlo.reshape %90 : (tensor<0x32x1xf32>) -> tensor<0x1xf32>
-    %92 = "stablehlo.slice"(%78) {limit_indices = dense<1> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
+    %92 = "stablehlo.slice"(%78) {limit_indices = array<i64: 1, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
     %93 = stablehlo.reshape %92 : (tensor<1x1xf32>) -> tensor<1xf32>
-    %94 = "stablehlo.slice"(%80) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %94 = "stablehlo.slice"(%80) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %95 = stablehlo.reshape %94 : (tensor<1xf32>) -> tensor<f32>
-    %96 = "stablehlo.slice"(%82) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %96 = "stablehlo.slice"(%82) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %97 = stablehlo.reshape %96 : (tensor<1xf32>) -> tensor<f32>
-    %98 = "stablehlo.slice"(%84) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %98 = "stablehlo.slice"(%84) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %99 = stablehlo.reshape %98 : (tensor<1xf32>) -> tensor<f32>
     %100 = stablehlo.broadcast_in_dim %99, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %101 = stablehlo.multiply %100, %70 : tensor<1xf32>
@@ -119,13 +119,13 @@ module @jit_testcase {
     %111 = stablehlo.subtract %95, %110 : tensor<f32>
     %112 = stablehlo.broadcast_in_dim %111, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %113 = stablehlo.divide %109, %112 : tensor<1xf32>
-    %114 = "stablehlo.slice"(%78) {limit_indices = dense<[2, 1]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
+    %114 = "stablehlo.slice"(%78) {limit_indices = array<i64: 2, 1>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
     %115 = stablehlo.reshape %114 : (tensor<1x1xf32>) -> tensor<1xf32>
-    %116 = "stablehlo.slice"(%80) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %116 = "stablehlo.slice"(%80) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %117 = stablehlo.reshape %116 : (tensor<1xf32>) -> tensor<f32>
-    %118 = "stablehlo.slice"(%82) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %118 = "stablehlo.slice"(%82) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %119 = stablehlo.reshape %118 : (tensor<1xf32>) -> tensor<f32>
-    %120 = "stablehlo.slice"(%84) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %120 = "stablehlo.slice"(%84) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %121 = stablehlo.reshape %120 : (tensor<1xf32>) -> tensor<f32>
     %122 = stablehlo.broadcast_in_dim %121, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %123 = stablehlo.multiply %122, %106 : tensor<1xf32>
@@ -141,13 +141,13 @@ module @jit_testcase {
     %133 = stablehlo.subtract %117, %132 : tensor<f32>
     %134 = stablehlo.broadcast_in_dim %133, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %135 = stablehlo.divide %131, %134 : tensor<1xf32>
-    %136 = "stablehlo.slice"(%78) {limit_indices = dense<[3, 1]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
+    %136 = "stablehlo.slice"(%78) {limit_indices = array<i64: 3, 1>, start_indices = array<i64: 2, 0>, strides = array<i64: 1, 1>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
     %137 = stablehlo.reshape %136 : (tensor<1x1xf32>) -> tensor<1xf32>
-    %138 = "stablehlo.slice"(%80) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %138 = "stablehlo.slice"(%80) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %139 = stablehlo.reshape %138 : (tensor<1xf32>) -> tensor<f32>
-    %140 = "stablehlo.slice"(%82) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %140 = "stablehlo.slice"(%82) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %141 = stablehlo.reshape %140 : (tensor<1xf32>) -> tensor<f32>
-    %142 = "stablehlo.slice"(%84) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %142 = "stablehlo.slice"(%84) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %143 = stablehlo.reshape %142 : (tensor<1xf32>) -> tensor<f32>
     %144 = stablehlo.broadcast_in_dim %143, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %145 = stablehlo.multiply %144, %128 : tensor<1xf32>
@@ -176,18 +176,18 @@ module @jit_testcase {
     %168 = "stablehlo.gather"(%162, %167) {dimension_numbers = #stablehlo.gather<offset_dims = [0], collapsed_slice_dims = [0], start_index_map = [0]>, indices_are_sorted = true, slice_sizes = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>, tensor<1xi32>) -> tensor<1xf32>
     %169 = stablehlo.reverse %162, dims = [0] : tensor<3x1xf32>
     %170 = stablehlo.reverse %61, dims = [0] : tensor<3xf32>
-    %171 = "stablehlo.slice"(%169) {limit_indices = dense<[0, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>) -> tensor<0x1xf32>
-    %172 = "stablehlo.slice"(%169) {limit_indices = dense<[3, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>) -> tensor<3x1xf32>
-    %173 = "stablehlo.slice"(%170) {limit_indices = dense<0> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<0xf32>
-    %174 = "stablehlo.slice"(%170) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<3xf32>
+    %171 = "stablehlo.slice"(%169) {limit_indices = array<i64: 0, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<3x1xf32>) -> tensor<0x1xf32>
+    %172 = "stablehlo.slice"(%169) {limit_indices = array<i64: 3, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<3x1xf32>) -> tensor<3x1xf32>
+    %173 = "stablehlo.slice"(%170) {limit_indices = array<i64: 0>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<0xf32>
+    %174 = "stablehlo.slice"(%170) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<3xf32>
     %175 = stablehlo.reshape %171 : (tensor<0x1xf32>) -> tensor<0x32x1xf32>
     %176 = stablehlo.reshape %173 : (tensor<0xf32>) -> tensor<0x32xf32>
     %177 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %178 = stablehlo.broadcast_in_dim %177, dims = [] : (tensor<f32>) -> tensor<0x32x1xf32>
     %179 = stablehlo.reshape %178 : (tensor<0x32x1xf32>) -> tensor<0x1xf32>
-    %180 = "stablehlo.slice"(%172) {limit_indices = dense<1> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
+    %180 = "stablehlo.slice"(%172) {limit_indices = array<i64: 1, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
     %181 = stablehlo.reshape %180 : (tensor<1x1xf32>) -> tensor<1xf32>
-    %182 = "stablehlo.slice"(%174) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %182 = "stablehlo.slice"(%174) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %183 = stablehlo.reshape %182 : (tensor<1xf32>) -> tensor<f32>
     %184 = stablehlo.broadcast_in_dim %183, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %185 = stablehlo.multiply %184, %168 : tensor<1xf32>
@@ -195,9 +195,9 @@ module @jit_testcase {
     %187 = stablehlo.broadcast_in_dim %183, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %188 = stablehlo.multiply %187, %168 : tensor<1xf32>
     %189 = stablehlo.subtract %181, %188 : tensor<1xf32>
-    %190 = "stablehlo.slice"(%172) {limit_indices = dense<[2, 1]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
+    %190 = "stablehlo.slice"(%172) {limit_indices = array<i64: 2, 1>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
     %191 = stablehlo.reshape %190 : (tensor<1x1xf32>) -> tensor<1xf32>
-    %192 = "stablehlo.slice"(%174) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %192 = "stablehlo.slice"(%174) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %193 = stablehlo.reshape %192 : (tensor<1xf32>) -> tensor<f32>
     %194 = stablehlo.broadcast_in_dim %193, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %195 = stablehlo.multiply %194, %186 : tensor<1xf32>
@@ -205,9 +205,9 @@ module @jit_testcase {
     %197 = stablehlo.broadcast_in_dim %193, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %198 = stablehlo.multiply %197, %186 : tensor<1xf32>
     %199 = stablehlo.subtract %191, %198 : tensor<1xf32>
-    %200 = "stablehlo.slice"(%172) {limit_indices = dense<[3, 1]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
+    %200 = "stablehlo.slice"(%172) {limit_indices = array<i64: 3, 1>, start_indices = array<i64: 2, 0>, strides = array<i64: 1, 1>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
     %201 = stablehlo.reshape %200 : (tensor<1x1xf32>) -> tensor<1xf32>
-    %202 = "stablehlo.slice"(%174) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %202 = "stablehlo.slice"(%174) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %203 = stablehlo.reshape %202 : (tensor<1xf32>) -> tensor<f32>
     %204 = stablehlo.broadcast_in_dim %203, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %205 = stablehlo.multiply %204, %196 : tensor<1xf32>

--- a/stablehlo/testdata/tridiagonal_solve_shape_float64_3.mlir
+++ b/stablehlo/testdata/tridiagonal_solve_shape_float64_3.mlir
@@ -14,23 +14,23 @@ module @jit_testcase {
     %6 = stablehlo.dynamic_slice %0#1, %5, sizes = [1] : (tensor<3xf32>, tensor<i32>) -> tensor<1xf32>
     %7 = stablehlo.reshape %6 : (tensor<1xf32>) -> tensor<f32>
     %8 = stablehlo.divide %4, %7 : tensor<f32>
-    %9 = "stablehlo.slice"(%0#1) {limit_indices = dense<0> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<0xf32>
-    %10 = "stablehlo.slice"(%0#1) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<3xf32>
-    %11 = "stablehlo.slice"(%0#2) {limit_indices = dense<0> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<0xf32>
-    %12 = "stablehlo.slice"(%0#2) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<3xf32>
-    %13 = "stablehlo.slice"(%0#0) {limit_indices = dense<0> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<0xf32>
-    %14 = "stablehlo.slice"(%0#0) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<3xf32>
+    %9 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 0>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<0xf32>
+    %10 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<3xf32>
+    %11 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 0>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<0xf32>
+    %12 = "stablehlo.slice"(%0#2) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<3xf32>
+    %13 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 0>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<0xf32>
+    %14 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<3xf32>
     %15 = stablehlo.reshape %9 : (tensor<0xf32>) -> tensor<0x32xf32>
     %16 = stablehlo.reshape %11 : (tensor<0xf32>) -> tensor<0x32xf32>
     %17 = stablehlo.reshape %13 : (tensor<0xf32>) -> tensor<0x32xf32>
     %18 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %19 = stablehlo.broadcast_in_dim %18, dims = [] : (tensor<f32>) -> tensor<0x32xf32>
     %20 = stablehlo.reshape %19 : (tensor<0x32xf32>) -> tensor<0xf32>
-    %21 = "stablehlo.slice"(%10) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %21 = "stablehlo.slice"(%10) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %22 = stablehlo.reshape %21 : (tensor<1xf32>) -> tensor<f32>
-    %23 = "stablehlo.slice"(%12) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %23 = "stablehlo.slice"(%12) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %24 = stablehlo.reshape %23 : (tensor<1xf32>) -> tensor<f32>
-    %25 = "stablehlo.slice"(%14) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %25 = "stablehlo.slice"(%14) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %26 = stablehlo.reshape %25 : (tensor<1xf32>) -> tensor<f32>
     %27 = stablehlo.multiply %26, %8 : tensor<f32>
     %28 = stablehlo.subtract %22, %27 : tensor<f32>
@@ -38,11 +38,11 @@ module @jit_testcase {
     %30 = stablehlo.multiply %26, %8 : tensor<f32>
     %31 = stablehlo.subtract %22, %30 : tensor<f32>
     %32 = stablehlo.divide %24, %31 : tensor<f32>
-    %33 = "stablehlo.slice"(%10) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %33 = "stablehlo.slice"(%10) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %34 = stablehlo.reshape %33 : (tensor<1xf32>) -> tensor<f32>
-    %35 = "stablehlo.slice"(%12) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %35 = "stablehlo.slice"(%12) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %36 = stablehlo.reshape %35 : (tensor<1xf32>) -> tensor<f32>
-    %37 = "stablehlo.slice"(%14) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %37 = "stablehlo.slice"(%14) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %38 = stablehlo.reshape %37 : (tensor<1xf32>) -> tensor<f32>
     %39 = stablehlo.multiply %38, %29 : tensor<f32>
     %40 = stablehlo.subtract %34, %39 : tensor<f32>
@@ -50,11 +50,11 @@ module @jit_testcase {
     %42 = stablehlo.multiply %38, %29 : tensor<f32>
     %43 = stablehlo.subtract %34, %42 : tensor<f32>
     %44 = stablehlo.divide %36, %43 : tensor<f32>
-    %45 = "stablehlo.slice"(%10) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %45 = "stablehlo.slice"(%10) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %46 = stablehlo.reshape %45 : (tensor<1xf32>) -> tensor<f32>
-    %47 = "stablehlo.slice"(%12) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %47 = "stablehlo.slice"(%12) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %48 = stablehlo.reshape %47 : (tensor<1xf32>) -> tensor<f32>
-    %49 = "stablehlo.slice"(%14) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %49 = "stablehlo.slice"(%14) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %50 = stablehlo.reshape %49 : (tensor<1xf32>) -> tensor<f32>
     %51 = stablehlo.multiply %50, %41 : tensor<f32>
     %52 = stablehlo.subtract %46, %51 : tensor<f32>
@@ -82,14 +82,14 @@ module @jit_testcase {
     %74 = stablehlo.broadcast_in_dim %73, dims = [] : (tensor<i32>) -> tensor<1xi32>
     %75 = "stablehlo.gather"(%61, %74) {dimension_numbers = #stablehlo.gather<offset_dims = [0], start_index_map = [0]>, indices_are_sorted = true, slice_sizes = dense<2> : tensor<1xi64>} : (tensor<3xf32>, tensor<1xi32>) -> tensor<2xf32>
     %76 = call @append(%72, %75) : (tensor<1xf32>, tensor<2xf32>) -> tensor<3xf32>
-    %77 = "stablehlo.slice"(%0#3) {limit_indices = dense<[0, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>) -> tensor<0x1xf32>
-    %78 = "stablehlo.slice"(%0#3) {limit_indices = dense<[3, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>) -> tensor<3x1xf32>
-    %79 = "stablehlo.slice"(%0#1) {limit_indices = dense<0> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<0xf32>
-    %80 = "stablehlo.slice"(%0#1) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<3xf32>
-    %81 = "stablehlo.slice"(%76) {limit_indices = dense<0> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<0xf32>
-    %82 = "stablehlo.slice"(%76) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<3xf32>
-    %83 = "stablehlo.slice"(%0#0) {limit_indices = dense<0> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<0xf32>
-    %84 = "stablehlo.slice"(%0#0) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<3xf32>
+    %77 = "stablehlo.slice"(%0#3) {limit_indices = array<i64: 0, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<3x1xf32>) -> tensor<0x1xf32>
+    %78 = "stablehlo.slice"(%0#3) {limit_indices = array<i64: 3, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<3x1xf32>) -> tensor<3x1xf32>
+    %79 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 0>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<0xf32>
+    %80 = "stablehlo.slice"(%0#1) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<3xf32>
+    %81 = "stablehlo.slice"(%76) {limit_indices = array<i64: 0>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<0xf32>
+    %82 = "stablehlo.slice"(%76) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<3xf32>
+    %83 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 0>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<0xf32>
+    %84 = "stablehlo.slice"(%0#0) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<3xf32>
     %85 = stablehlo.reshape %77 : (tensor<0x1xf32>) -> tensor<0x32x1xf32>
     %86 = stablehlo.reshape %79 : (tensor<0xf32>) -> tensor<0x32xf32>
     %87 = stablehlo.reshape %81 : (tensor<0xf32>) -> tensor<0x32xf32>
@@ -97,13 +97,13 @@ module @jit_testcase {
     %89 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %90 = stablehlo.broadcast_in_dim %89, dims = [] : (tensor<f32>) -> tensor<0x32x1xf32>
     %91 = stablehlo.reshape %90 : (tensor<0x32x1xf32>) -> tensor<0x1xf32>
-    %92 = "stablehlo.slice"(%78) {limit_indices = dense<1> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
+    %92 = "stablehlo.slice"(%78) {limit_indices = array<i64: 1, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
     %93 = stablehlo.reshape %92 : (tensor<1x1xf32>) -> tensor<1xf32>
-    %94 = "stablehlo.slice"(%80) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %94 = "stablehlo.slice"(%80) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %95 = stablehlo.reshape %94 : (tensor<1xf32>) -> tensor<f32>
-    %96 = "stablehlo.slice"(%82) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %96 = "stablehlo.slice"(%82) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %97 = stablehlo.reshape %96 : (tensor<1xf32>) -> tensor<f32>
-    %98 = "stablehlo.slice"(%84) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %98 = "stablehlo.slice"(%84) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %99 = stablehlo.reshape %98 : (tensor<1xf32>) -> tensor<f32>
     %100 = stablehlo.broadcast_in_dim %99, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %101 = stablehlo.multiply %100, %70 : tensor<1xf32>
@@ -119,13 +119,13 @@ module @jit_testcase {
     %111 = stablehlo.subtract %95, %110 : tensor<f32>
     %112 = stablehlo.broadcast_in_dim %111, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %113 = stablehlo.divide %109, %112 : tensor<1xf32>
-    %114 = "stablehlo.slice"(%78) {limit_indices = dense<[2, 1]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
+    %114 = "stablehlo.slice"(%78) {limit_indices = array<i64: 2, 1>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
     %115 = stablehlo.reshape %114 : (tensor<1x1xf32>) -> tensor<1xf32>
-    %116 = "stablehlo.slice"(%80) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %116 = "stablehlo.slice"(%80) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %117 = stablehlo.reshape %116 : (tensor<1xf32>) -> tensor<f32>
-    %118 = "stablehlo.slice"(%82) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %118 = "stablehlo.slice"(%82) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %119 = stablehlo.reshape %118 : (tensor<1xf32>) -> tensor<f32>
-    %120 = "stablehlo.slice"(%84) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %120 = "stablehlo.slice"(%84) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %121 = stablehlo.reshape %120 : (tensor<1xf32>) -> tensor<f32>
     %122 = stablehlo.broadcast_in_dim %121, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %123 = stablehlo.multiply %122, %106 : tensor<1xf32>
@@ -141,13 +141,13 @@ module @jit_testcase {
     %133 = stablehlo.subtract %117, %132 : tensor<f32>
     %134 = stablehlo.broadcast_in_dim %133, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %135 = stablehlo.divide %131, %134 : tensor<1xf32>
-    %136 = "stablehlo.slice"(%78) {limit_indices = dense<[3, 1]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
+    %136 = "stablehlo.slice"(%78) {limit_indices = array<i64: 3, 1>, start_indices = array<i64: 2, 0>, strides = array<i64: 1, 1>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
     %137 = stablehlo.reshape %136 : (tensor<1x1xf32>) -> tensor<1xf32>
-    %138 = "stablehlo.slice"(%80) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %138 = "stablehlo.slice"(%80) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %139 = stablehlo.reshape %138 : (tensor<1xf32>) -> tensor<f32>
-    %140 = "stablehlo.slice"(%82) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %140 = "stablehlo.slice"(%82) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %141 = stablehlo.reshape %140 : (tensor<1xf32>) -> tensor<f32>
-    %142 = "stablehlo.slice"(%84) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %142 = "stablehlo.slice"(%84) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %143 = stablehlo.reshape %142 : (tensor<1xf32>) -> tensor<f32>
     %144 = stablehlo.broadcast_in_dim %143, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %145 = stablehlo.multiply %144, %128 : tensor<1xf32>
@@ -176,18 +176,18 @@ module @jit_testcase {
     %168 = "stablehlo.gather"(%162, %167) {dimension_numbers = #stablehlo.gather<offset_dims = [0], collapsed_slice_dims = [0], start_index_map = [0]>, indices_are_sorted = true, slice_sizes = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>, tensor<1xi32>) -> tensor<1xf32>
     %169 = stablehlo.reverse %162, dims = [0] : tensor<3x1xf32>
     %170 = stablehlo.reverse %61, dims = [0] : tensor<3xf32>
-    %171 = "stablehlo.slice"(%169) {limit_indices = dense<[0, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>) -> tensor<0x1xf32>
-    %172 = "stablehlo.slice"(%169) {limit_indices = dense<[3, 1]> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>) -> tensor<3x1xf32>
-    %173 = "stablehlo.slice"(%170) {limit_indices = dense<0> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<0xf32>
-    %174 = "stablehlo.slice"(%170) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<3xf32>
+    %171 = "stablehlo.slice"(%169) {limit_indices = array<i64: 0, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<3x1xf32>) -> tensor<0x1xf32>
+    %172 = "stablehlo.slice"(%169) {limit_indices = array<i64: 3, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<3x1xf32>) -> tensor<3x1xf32>
+    %173 = "stablehlo.slice"(%170) {limit_indices = array<i64: 0>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<0xf32>
+    %174 = "stablehlo.slice"(%170) {limit_indices = array<i64: 3>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<3xf32>
     %175 = stablehlo.reshape %171 : (tensor<0x1xf32>) -> tensor<0x32x1xf32>
     %176 = stablehlo.reshape %173 : (tensor<0xf32>) -> tensor<0x32xf32>
     %177 = stablehlo.constant dense<0.000000e+00> : tensor<f32>
     %178 = stablehlo.broadcast_in_dim %177, dims = [] : (tensor<f32>) -> tensor<0x32x1xf32>
     %179 = stablehlo.reshape %178 : (tensor<0x32x1xf32>) -> tensor<0x1xf32>
-    %180 = "stablehlo.slice"(%172) {limit_indices = dense<1> : tensor<2xi64>, start_indices = dense<0> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
+    %180 = "stablehlo.slice"(%172) {limit_indices = array<i64: 1, 1>, start_indices = array<i64: 0, 0>, strides = array<i64: 1, 1>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
     %181 = stablehlo.reshape %180 : (tensor<1x1xf32>) -> tensor<1xf32>
-    %182 = "stablehlo.slice"(%174) {limit_indices = dense<1> : tensor<1xi64>, start_indices = dense<0> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %182 = "stablehlo.slice"(%174) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %183 = stablehlo.reshape %182 : (tensor<1xf32>) -> tensor<f32>
     %184 = stablehlo.broadcast_in_dim %183, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %185 = stablehlo.multiply %184, %168 : tensor<1xf32>
@@ -195,9 +195,9 @@ module @jit_testcase {
     %187 = stablehlo.broadcast_in_dim %183, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %188 = stablehlo.multiply %187, %168 : tensor<1xf32>
     %189 = stablehlo.subtract %181, %188 : tensor<1xf32>
-    %190 = "stablehlo.slice"(%172) {limit_indices = dense<[2, 1]> : tensor<2xi64>, start_indices = dense<[1, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
+    %190 = "stablehlo.slice"(%172) {limit_indices = array<i64: 2, 1>, start_indices = array<i64: 1, 0>, strides = array<i64: 1, 1>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
     %191 = stablehlo.reshape %190 : (tensor<1x1xf32>) -> tensor<1xf32>
-    %192 = "stablehlo.slice"(%174) {limit_indices = dense<2> : tensor<1xi64>, start_indices = dense<1> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %192 = "stablehlo.slice"(%174) {limit_indices = array<i64: 2>, start_indices = array<i64: 1>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %193 = stablehlo.reshape %192 : (tensor<1xf32>) -> tensor<f32>
     %194 = stablehlo.broadcast_in_dim %193, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %195 = stablehlo.multiply %194, %186 : tensor<1xf32>
@@ -205,9 +205,9 @@ module @jit_testcase {
     %197 = stablehlo.broadcast_in_dim %193, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %198 = stablehlo.multiply %197, %186 : tensor<1xf32>
     %199 = stablehlo.subtract %191, %198 : tensor<1xf32>
-    %200 = "stablehlo.slice"(%172) {limit_indices = dense<[3, 1]> : tensor<2xi64>, start_indices = dense<[2, 0]> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
+    %200 = "stablehlo.slice"(%172) {limit_indices = array<i64: 3, 1>, start_indices = array<i64: 2, 0>, strides = array<i64: 1, 1>} : (tensor<3x1xf32>) -> tensor<1x1xf32>
     %201 = stablehlo.reshape %200 : (tensor<1x1xf32>) -> tensor<1xf32>
-    %202 = "stablehlo.slice"(%174) {limit_indices = dense<3> : tensor<1xi64>, start_indices = dense<2> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<3xf32>) -> tensor<1xf32>
+    %202 = "stablehlo.slice"(%174) {limit_indices = array<i64: 3>, start_indices = array<i64: 2>, strides = array<i64: 1>} : (tensor<3xf32>) -> tensor<1xf32>
     %203 = stablehlo.reshape %202 : (tensor<1xf32>) -> tensor<f32>
     %204 = stablehlo.broadcast_in_dim %203, dims = [] : (tensor<f32>) -> tensor<1xf32>
     %205 = stablehlo.multiply %204, %196 : tensor<1xf32>

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -81,9 +81,9 @@ func.func @dynamic_slice(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tens
 // CHECK-LABEL: @pad
 func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xindex> {
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
-    edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
-    interior_padding = dense<[0, 0, 1]> : tensor<3xi64>
+    edge_padding_high = array<i64: 1, 1, 0>,
+    edge_padding_low = array<i64: 0, 1, 2>,
+    interior_padding = array<i64: 0, 0, 1>
   } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
   // CHECK: types0 = tensor<2x4x7xf16>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<2x4x7xf16>) -> tensor<2x4x7xindex>
@@ -1190,9 +1190,9 @@ func.func @slice_with_index_larger_than_bound_dim(%arg0: tensor<3x?x?xi32, #stab
 // CHECK-LABEL: @pad_with_bounds
 func.func @pad_with_bounds(%arg0: tensor<3x?x?xf16, #stablehlo.bounds<?, 3, ?>>, %arg1: tensor<f16>) -> tensor<*xindex> {
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_low = dense<[2, 2, 0]> : tensor<3xi64>,
-    edge_padding_high = dense<[0, 0, 0]> : tensor<3xi64>,
-    interior_padding = dense<[1, 1, 1]> : tensor<3xi64>
+    edge_padding_low = array<i64: 2, 2, 0>,
+    edge_padding_high = array<i64: 0, 0, 0>,
+    interior_padding = array<i64: 1, 1, 1>
   } : (tensor<3x?x?xf16, #stablehlo.bounds<?, 3, ?>>, tensor<f16>) -> tensor<*xf16>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf16>) -> tensor<*xindex>
   // CHECK: types0 = tensor<7x?x?xf16, #stablehlo.bounds<?, 7, ?>>
@@ -1205,9 +1205,9 @@ func.func @pad_with_negative_inferred_bounds(%arg0: tensor<3x?x?xf16, #stablehlo
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{Padding result in negative bound for dimension 1}}
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_low = dense<[2, -10, 0]> : tensor<3xi64>,
-    edge_padding_high = dense<[0, 0, 0]> : tensor<3xi64>,
-    interior_padding = dense<[1, 1, 1]> : tensor<3xi64>
+    edge_padding_low = array<i64: 2, -10, 0>,
+    edge_padding_high = array<i64: 0, 0, 0>,
+    interior_padding = array<i64: 1, 1, 1>
   } : (tensor<3x?x?xf16, #stablehlo.bounds<?, 3, ?>>, tensor<f16>) -> tensor<*xf16>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf16>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
@@ -1473,9 +1473,9 @@ func.func @pad(%arg0: tensor<?x48x48x32xf32>) -> tensor<4xindex> {
   // CHECK: return %[[RES]] : tensor<4xindex>
   %0 = "stablehlo.constant"() {value = dense<0.000000e+00> : tensor<f32>} : () -> tensor<f32>
   %result = "stablehlo.pad"(%arg0, %0) {
-    edge_padding_high = dense<[0, 0, 0, 16]> : tensor<4xi64>,
-    edge_padding_low = dense<0> : tensor<4xi64>,
-    interior_padding = dense<0> : tensor<4xi64>
+    edge_padding_high = array<i64: 0, 0, 0, 16>,
+    edge_padding_low = array<i64: 0, 0, 0, 0>,
+    interior_padding = array<i64: 0, 0, 0, 0>
   } : (tensor<?x48x48x32xf32>, tensor<f32>) -> tensor<?x48x48x48xf32>
   %1 = "hlo_test_infer.reify_return_type_shapes"(%result) : (tensor<?x48x48x48xf32>) -> tensor<4xindex>
   func.return %1 : tensor<4xindex>

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -229,7 +229,7 @@ func.func @rng_uniform(%a: tensor<f32>, %b: tensor<f32>) -> tensor<2x3x5xindex> 
 
 // CHECK-LABEL: func @slice
 func.func @slice(%arg0: tensor<3x4xi32>) -> tensor<1x2xindex> {
-  %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 0]> : tensor<2xi64>, limit_indices = dense<[2, 4]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<3x4xi32>) -> tensor<1x2xi32>
+  %0 = "stablehlo.slice"(%arg0) {start_indices = array<i64: 1, 0>, limit_indices = array<i64: 2, 4>, strides = array<i64: 1, 2>} : (tensor<3x4xi32>) -> tensor<1x2xi32>
   // CHECK: types0 = tensor<1x2xi32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1x2xi32>) -> tensor<1x2xindex>
   func.return %1 : tensor<1x2xindex>
@@ -1169,7 +1169,7 @@ func.func @transpose_with_bounds(%arg0: tensor<?x2x?x4xi32, #stablehlo.bounds<1,
 
 // CHECK-LABEL: func @slice_with_bounds
 func.func @slice_with_bounds(%arg0: tensor<3x?x?xi32, #stablehlo.bounds<?, 4, ?>>) -> tensor<*xindex> {
-  %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 0, 0]> : tensor<3xi64>, limit_indices = dense<[2, 4, 4]> : tensor<3xi64>, strides = dense<[1, 2, 2]> : tensor<3xi64>} : (tensor<3x?x?xi32, #stablehlo.bounds<?, 4, ?>>) -> tensor<*xi32>
+  %0 = "stablehlo.slice"(%arg0) {start_indices = array<i64: 1, 0, 0>, limit_indices = array<i64: 2, 4, 4>, strides = array<i64: 1, 2, 2>} : (tensor<3x?x?xi32, #stablehlo.bounds<?, 4, ?>>) -> tensor<*xi32>
   // CHECK: types0 = tensor<1x2x2xi32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xi32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
@@ -1180,7 +1180,7 @@ func.func @slice_with_bounds(%arg0: tensor<3x?x?xi32, #stablehlo.bounds<?, 4, ?>
 func.func @slice_with_index_larger_than_bound_dim(%arg0: tensor<3x?x?xi32, #stablehlo.bounds<?, 4, ?>>) -> tensor<*xindex> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{limit index 5 is larger than dimension bound 4 in dimension 1}}
-  %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 0, 0]> : tensor<3xi64>, limit_indices = dense<[2, 5, 4]> : tensor<3xi64>, strides = dense<[1, 2, 2]> : tensor<3xi64>} : (tensor<3x?x?xi32, #stablehlo.bounds<?, 4, ?>>) -> tensor<*xi32>
+  %0 = "stablehlo.slice"(%arg0) {start_indices = array<i64: 1, 0, 0>, limit_indices = array<i64: 2, 5, 4>, strides = array<i64: 1, 2, 2>} : (tensor<3x?x?xi32, #stablehlo.bounds<?, 4, ?>>) -> tensor<*xi32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xi32>) -> tensor<*xindex>
   func.return %1 : tensor<*xindex>
 }

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -259,7 +259,7 @@ func.func @uniform_dequantize_c2(%arg: tensor<16x16x!quant.uniform<i8:f32, 34.0:
 
 // CHECK-LABEL: func @fft
 func.func @fft(%arg0: tensor<3x9xcomplex<f32>>) -> tensor<3x9xindex> {
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type FFT> } : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 9>, fft_type = #stablehlo<fft_type FFT> } : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
   // CHECK: types0 = tensor<3x9xcomplex<f32>>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xindex>
   func.return %1 : tensor<3x9xindex>
@@ -1766,7 +1766,7 @@ func.func @triangular_solve_bounds(
 // CHECK-LABEL: func @fft_bound
 func.func @fft_bound(%arg0: tensor<?x9xcomplex<f32>, #stablehlo.bounds<3, ?>>) -> tensor<*xindex> {
   %0 = "stablehlo.fft"(%arg0) {
-    fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type FFT>
+    fft_length = array<i64: 9>, fft_type = #stablehlo<fft_type FFT>
   } : (tensor<?x9xcomplex<f32>, #stablehlo.bounds<3, ?>>) -> tensor<*xcomplex<f32>>
   // CHECK: types0 = tensor<?x9xcomplex<f32>, #stablehlo.bounds<3, ?>>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xcomplex<f32>>) -> tensor<*xindex>
@@ -1778,7 +1778,7 @@ func.func @fft_bound(%arg0: tensor<?x9xcomplex<f32>, #stablehlo.bounds<3, ?>>) -
 // CHECK-LABEL: func @rfft_with_bound
 func.func @rfft_with_bound(%arg0: tensor<3x?x?xf32, #stablehlo.bounds<?, 3, 10>>) -> tensor<*xindex> {
   %0 = "stablehlo.fft"(%arg0) {
-    fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type RFFT>
+    fft_length = array<i64: 9>, fft_type = #stablehlo<fft_type RFFT>
   } : (tensor<3x?x?xf32, #stablehlo.bounds<?, 3, 10>>) -> tensor<*xcomplex<f32>>
   // CHECK: types0 = tensor<3x?x5xcomplex<f32>, #stablehlo.bounds<?, 3, ?>>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xcomplex<f32>>) -> tensor<*xindex>
@@ -1790,7 +1790,7 @@ func.func @rfft_with_bound(%arg0: tensor<3x?x?xf32, #stablehlo.bounds<?, 3, 10>>
 // CHECK-LABEL: func @irfft_with_bound
 func.func @irfft_with_bound(%arg0: tensor<3x?x?xcomplex<f32>, #stablehlo.bounds<?, 3, 17>>) -> tensor<*xindex> {
   %0 = "stablehlo.fft"(%arg0) {
-    fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type IRFFT>
+    fft_length = array<i64: 9>, fft_type = #stablehlo<fft_type IRFFT>
   } : (tensor<3x?x?xcomplex<f32>, #stablehlo.bounds<?, 3, 17>>) -> tensor<*xf32>
   // CHECK: types0 = tensor<3x?x9xf32, #stablehlo.bounds<?, 3, ?>>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xf32>) -> tensor<*xindex>

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -49,7 +49,7 @@ func.func @select(%pred : tensor<i1>, %a : tensor<?x2x3xf32>, %b : tensor<1x?x3x
 
 // CHECK-LABEL: @broadcast
 func.func @broadcast(%a : tensor<3xi32>) -> tensor<1x2x3xindex> {
-  %0 = "stablehlo.broadcast"(%a) {broadcast_sizes = dense<[1, 2]> : tensor<2xi64>}
+  %0 = "stablehlo.broadcast"(%a) {broadcast_sizes = array<i64: 1, 2>}
       : (tensor<3xi32>) -> tensor<1x2x3xi32>
   // CHECK: types0 = tensor<1x2x3xi32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1x2x3xi32>) -> tensor<1x2x3xindex>
@@ -61,7 +61,7 @@ func.func @broadcast(%a : tensor<3xi32>) -> tensor<1x2x3xindex> {
 func.func @broadcast(%a : tensor<3xi32>) -> tensor<1x2x3xi32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{Broadcast with negative dimension size -2}}
-  %0 = "stablehlo.broadcast"(%a) {broadcast_sizes = dense<[1, -2]> : tensor<2xi64>}
+  %0 = "stablehlo.broadcast"(%a) {broadcast_sizes = array<i64: 1, -2>}
       : (tensor<3xi32>) -> tensor<1x2x3xi32>
   func.return %0 : tensor<1x2x3xi32>
 }
@@ -1636,7 +1636,7 @@ func.func @broadcast(%arg0: tensor<?xi32>) -> tensor<3xindex> {
   // CHECK: %[[DIM:.*]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?xi32>
   // CHECK: %[[RES:.*]] = tensor.from_elements %[[C1]], %[[C2]], %[[DIM]] : tensor<3xindex>
   // CHECK: return %[[RES]] : tensor<3xindex>
-  %result = "stablehlo.broadcast"(%arg0) {broadcast_sizes = dense<[1, 2]> : tensor<2xi64>} : (tensor<?xi32>) -> tensor<1x2x?xi32>
+  %result = "stablehlo.broadcast"(%arg0) {broadcast_sizes = array<i64: 1, 2>} : (tensor<?xi32>) -> tensor<1x2x?xi32>
   %1 = "hlo_test_infer.reify_return_type_shapes"(%result): (tensor<1x2x?xi32>) -> tensor<3xindex>
   func.return %1: tensor<3xindex>
 }

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -1147,7 +1147,7 @@ func.func @add_bounds_unranked(
 
 // CHECK-LABEL: func @transpose
 func.func @transpose(%arg0: tensor<1x2x3x4xi32>) -> tensor<*xindex> {
-  %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<1x2x3x4xi32>) -> tensor<*xi32>
+  %0 = "stablehlo.transpose"(%arg0) {permutation = array<i64: 1, 0, 3, 2>} : (tensor<1x2x3x4xi32>) -> tensor<*xi32>
 
   // CHECK: types0 = tensor<2x1x4x3xi32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xi32>) -> tensor<*xindex>
@@ -1158,7 +1158,7 @@ func.func @transpose(%arg0: tensor<1x2x3x4xi32>) -> tensor<*xindex> {
 
 // CHECK-LABEL: func @transpose_with_bounds
 func.func @transpose_with_bounds(%arg0: tensor<?x2x?x4xi32, #stablehlo.bounds<1, ?, 3, ?>>) -> tensor<*xindex> {
-  %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<?x2x?x4xi32, #stablehlo.bounds<1, ?, 3, ?>>) -> tensor<*xi32>
+  %0 = "stablehlo.transpose"(%arg0) {permutation = array<i64: 1, 0, 3, 2>} : (tensor<?x2x?x4xi32, #stablehlo.bounds<1, ?, 3, ?>>) -> tensor<*xi32>
 
   // CHECK: types0 = tensor<2x?x4x?xi32, #stablehlo.bounds<?, 1, ?, 3>>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<*xi32>) -> tensor<*xindex>
@@ -1656,7 +1656,7 @@ func.func @transpose(%arg0: tensor<?x?x?x?xi32>) -> tensor<4xindex> {
   // CHECK: %[[DIM2:.*]] = tensor.dim %[[ARG0]], %[[C3]] : tensor<?x?x?x?xi32>
   // CHECK: %[[RES:.*]] = tensor.from_elements %[[DIM0]], %[[DIM]], %[[DIM2]], %[[DIM1]] : tensor<4xindex>
   // CHECK: return %[[RES]] : tensor<4xindex>
-  %result = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<?x?x?x?xi32>) -> tensor<?x?x?x?xi32>
+  %result = "stablehlo.transpose"(%arg0) {permutation = array<i64: 1, 0, 3, 2>} : (tensor<?x?x?x?xi32>) -> tensor<?x?x?x?xi32>
   %1 = "hlo_test_infer.reify_return_type_shapes"(%result): (tensor<?x?x?x?xi32>) -> tensor<4xindex>
   func.return %1: tensor<4xindex>
 }

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -70,7 +70,7 @@ func.func @broadcast(%a : tensor<3xi32>) -> tensor<1x2x3xi32> {
 
 // CHECK-LABEL: @dynamic_slice
 func.func @dynamic_slice(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xindex> {
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
+  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = array<i64: 1, 4>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
   // CHECK: types0 = tensor<1x4xi32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1x4xi32>) -> tensor<1x4xindex>
   func.return %1 : tensor<1x4xindex>

--- a/stablehlo/tests/interpret_dynamic_slice.mlir
+++ b/stablehlo/tests/interpret_dynamic_slice.mlir
@@ -7,7 +7,7 @@ func.func @dynamic_slice() {
   %start_indices0 = stablehlo.constant dense<3> : tensor<i64>
   %start_indices1 = stablehlo.constant dense<3> : tensor<i64>
   %result = "stablehlo.dynamic_slice"(%operand, %start_indices0, %start_indices1) {
-    slice_sizes = dense<[3, 3]> : tensor<2xi64>
+    slice_sizes = array<i64: 3, 3>
   } : (tensor<3x3xi64>, tensor<i64>, tensor<i64>) -> tensor<3x3xi64>
   check.expect_eq_const %result, dense<[[1, 1, 1], [1, 1, 1], [1, 1, 1]]> : tensor<3x3xi64>
   func.return

--- a/stablehlo/tests/interpret_reverse.mlir
+++ b/stablehlo/tests/interpret_reverse.mlir
@@ -3,7 +3,7 @@
 func.func @reverse() {
   %operand = stablehlo.constant dense<[[1, 2], [3, 4], [5, 6]]> : tensor<3x2xi64>
   %result = "stablehlo.reverse"(%operand) {
-    dimensions = dense<[1, 0]> : tensor<2xi64>
+    dimensions = array<i64: 1, 0>
   } : (tensor<3x2xi64>) -> tensor<3x2xi64>
   check.expect_eq_const %result, dense<[[6, 5], [4, 3], [2, 1]]> : tensor<3x2xi64>
   func.return

--- a/stablehlo/tests/interpret_slice.mlir
+++ b/stablehlo/tests/interpret_slice.mlir
@@ -5,9 +5,9 @@ func.func @slice_op() {
                                        [0, 0, 0, 0, 0, 0],
                                        [0, 0, 1, 0, 0, 1]]> : tensor<3x6xi64>
   %result = "stablehlo.slice"(%operand) {
-    start_indices = dense<[0, 2]> : tensor<2xi64>,
-    limit_indices = dense<[3, 6]> : tensor<2xi64>,
-    strides = dense<[2, 3]> : tensor<2xi64>
+    start_indices = array<i64: 0, 2>,
+    limit_indices = array<i64: 3, 6>,
+    strides = array<i64: 2, 3>
   } : (tensor<3x6xi64>) -> tensor<2x2xi64>
   check.expect_eq_const %result, dense<[[1, 1], [1, 1]]> : tensor<2x2xi64>
   func.return

--- a/stablehlo/tests/interpret_transpose.mlir
+++ b/stablehlo/tests/interpret_transpose.mlir
@@ -2,7 +2,7 @@
 
 func.func @transpose_op_test_si32() {
   %0 = stablehlo.constant dense<[[[1,2],[3,4],[5,6]], [[7,8],[9,10],[11,12]]]> : tensor<2x3x2xi32>
-  %1 = "stablehlo.transpose"(%0) {permutation = dense<[1,0,2]> : tensor<3xi64>} : (tensor<2x3x2xi32>) -> tensor<3x2x2xi32>
+  %1 = "stablehlo.transpose"(%0) {permutation = array<i64: 1,0,2>} : (tensor<2x3x2xi32>) -> tensor<3x2x2xi32>
   check.expect_eq_const %1, dense<[[[1, 2], [7, 8]], [[3, 4], [9, 10]], [[5, 6], [11, 12]]]> : tensor<3x2x2xi32>
   func.return
 }
@@ -11,7 +11,7 @@ func.func @transpose_op_test_si32() {
 
 func.func @transpose_op_test_si32() {
   %0 = stablehlo.constant dense<[[[1,2],[3,4],[5,6]], [[7,8],[9,10],[11,12]]]> : tensor<2x3x2xi32>
-  %1 = "stablehlo.transpose"(%0) {permutation = dense<[2,1,0]> : tensor<3xi64>} : (tensor<2x3x2xi32>) -> tensor<2x3x2xi32>
+  %1 = "stablehlo.transpose"(%0) {permutation = array<i64: 2,1,0>} : (tensor<2x3x2xi32>) -> tensor<2x3x2xi32>
   check.expect_eq_const %1, dense<[[[1, 7], [3, 9], [5, 11]], [[2, 8], [4, 10], [6, 12]]]> : tensor<2x3x2xi32>
   func.return
 }
@@ -20,8 +20,8 @@ func.func @transpose_op_test_si32() {
 
 func.func @transpose_op_test_si32() {
   %0 = stablehlo.constant dense<[[[1,2],[3,4],[5,6]], [[7,8],[9,10],[11,12]]]> : tensor<2x3x2xi32>
-  %1 = "stablehlo.transpose"(%0) {permutation = dense<[2,1,0]> : tensor<3xi64>} : (tensor<2x3x2xi32>) -> tensor<2x3x2xi32>
-  %2 = "stablehlo.transpose"(%1) {permutation = dense<[2,1,0]> : tensor<3xi64>} : (tensor<2x3x2xi32>) -> tensor<2x3x2xi32>
+  %1 = "stablehlo.transpose"(%0) {permutation = array<i64: 2,1,0>} : (tensor<2x3x2xi32>) -> tensor<2x3x2xi32>
+  %2 = "stablehlo.transpose"(%1) {permutation = array<i64: 2,1,0>} : (tensor<2x3x2xi32>) -> tensor<2x3x2xi32>
   check.expect_eq_const %2, dense<[[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]]> : tensor<2x3x2xi32>
   func.return
 }

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -5089,9 +5089,9 @@ func.func @conv_i4(%arg0: tensor<64x8x8x8xi4>, %arg1: tensor<4x4x8x32xi4>) -> te
 // CHECK-LABEL: func @pad
 func.func @pad(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
-    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
-    interior_padding = dense<[0, 0, 1]> : tensor<3xi64>
+    edge_padding_low = array<i64: 0, 1, 2>,
+    edge_padding_high = array<i64: 1, 1, 0>,
+    interior_padding = array<i64: 0, 0, 1>
   } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
   func.return %0 : tensor<2x4x7xf16>
 }
@@ -5103,9 +5103,9 @@ func.func @pad_c2(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7x
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{edge_padding_low length (2) must match operand rank (3)}}
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_low = dense<[0, 1]> : tensor<2xi64>,
-    edge_padding_high = dense<[1, 1]> : tensor<2xi64>,
-    interior_padding = dense<[0, 0]> : tensor<2xi64>
+    edge_padding_low = array<i64: 0, 1>,
+    edge_padding_high = array<i64: 1, 1>,
+    interior_padding = array<i64: 0, 0>
   } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
   func.return %0 : tensor<2x4x7xf16>
 }
@@ -5116,9 +5116,9 @@ func.func @pad_c3(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x3x
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{Interior padding cannot be negative: -1}}
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
-    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
-    interior_padding = dense<[0, 0, -1]> : tensor<3xi64>
+    edge_padding_low = array<i64: 0, 1, 2>,
+    edge_padding_high = array<i64: 1, 1, 0>,
+    interior_padding = array<i64: 0, 0, -1>
   } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x3xf16>
   func.return %0 : tensor<2x4x3xf16>
 }
@@ -5129,9 +5129,9 @@ func.func @pad_c4(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7x
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{Padding result in negative size for dimension 2}}
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_low = dense<[0, 1, -4]> : tensor<3xi64>,
-    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
-    interior_padding = dense<[0, 0, 0]> : tensor<3xi64>
+    edge_padding_low = array<i64: 0, 1, -4>,
+    edge_padding_high = array<i64: 1, 1, 0>,
+    interior_padding = array<i64: 0, 0, 0>
   } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
   func.return %0 : tensor<2x4x7xf16>
 }
@@ -5142,9 +5142,9 @@ func.func @pad_c4(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<8x8x8x
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{'stablehlo.pad' op inferred type(s) 'tensor<2x4x7xf16>' are incompatible with return type(s) of operation 'tensor<8x8x8xf16>'}}
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
-    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
-    interior_padding = dense<[0, 0, 1]> : tensor<3xi64>
+    edge_padding_low = array<i64: 0, 1, 2>,
+    edge_padding_high = array<i64: 1, 1, 0>,
+    interior_padding = array<i64: 0, 0, 1>
   } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<8x8x8xf16>
   func.return %0 : tensor<8x8x8xf16>
 }
@@ -5155,9 +5155,9 @@ func.func @pad_c4(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<8x8x8x
 func.func @pad_dynamic(%arg0: tensor<?x48x48x32xf32>) -> tensor<?x48x48x48xf32> {
   %0 = "stablehlo.constant"() {value = dense<0.000000e+00> : tensor<f32>} : () -> tensor<f32>
   %1 = "stablehlo.pad"(%arg0, %0) {
-    edge_padding_low = dense<0> : tensor<4xi64>,
-    edge_padding_high = dense<[0, 0, 0, 16]> : tensor<4xi64>,
-    interior_padding = dense<0> : tensor<4xi64>
+    edge_padding_low = array<i64: 0, 0, 0, 0>,
+    edge_padding_high = array<i64: 0, 0, 0, 16>,
+    interior_padding = array<i64: 0, 0, 0, 0>
   } : (tensor<?x48x48x32xf32>, tensor<f32>) -> tensor<?x48x48x48xf32>
   func.return %1 : tensor<?x48x48x48xf32>
 }
@@ -5168,9 +5168,9 @@ func.func @pad_i2(%arg0: tensor<1x2x3xf16>, %arg1: tensor<2xf16>) -> tensor<2x4x
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{padding value type should be a rank-0 tensor, is rank 1}}
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_low = dense<[0, 1, 2]> : tensor<3xi64>,
-    edge_padding_high = dense<[1, 1, 0]> : tensor<3xi64>,
-    interior_padding = dense<[0, 0, 1]> : tensor<3xi64>
+    edge_padding_low = array<i64: 0, 1, 2>,
+    edge_padding_high = array<i64: 1, 1, 0>,
+    interior_padding = array<i64: 0, 0, 1>
   } : (tensor<1x2x3xf16>, tensor<2xf16>) -> tensor<2x4x7xf16>
   func.return %0 : tensor<2x4x7xf16>
 }
@@ -5179,11 +5179,11 @@ func.func @pad_i2(%arg0: tensor<1x2x3xf16>, %arg1: tensor<2xf16>) -> tensor<2x4x
 
 func.func @pad_i3(%arg0: tensor<1x2x3xf16>, %arg1: tensor<f16>) -> tensor<2x4x7xf16> {
   // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{edge_padding_low has rank 0 instead of required rank 1}}
+  // expected-error@+1 {{edge_padding_low length (1) must match operand rank (3)}}
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_low = dense<1> : tensor<i64>,
-    edge_padding_high = dense<1> : tensor<i64>,
-    interior_padding = dense<1> : tensor<i64>
+    edge_padding_low = array<i64: 1>,
+    edge_padding_high = array<i64: 1>,
+    interior_padding = array<i64: 1>
   } : (tensor<1x2x3xf16>, tensor<f16>) -> tensor<2x4x7xf16>
   func.return %0 : tensor<2x4x7xf16>
 }

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -824,16 +824,7 @@ func.func @all_gather_i3(%arg0: tensor<8x2xf32>) -> tensor<8x8xf32> {
 
 // CHECK-LABEL: func @broadcast
 func.func @broadcast(%arg0: tensor<3xi32>) -> tensor<1x2x3xi32> {
-  %0 = "stablehlo.broadcast"(%arg0) {broadcast_sizes = dense<[1, 2]> : tensor<2xi64>} : (tensor<3xi32>) -> tensor<1x2x3xi32>
-  func.return %0 : tensor<1x2x3xi32>
-}
-
-// -----
-
-func.func @broadcast_bad_sizes_rank(%arg0: tensor<3xi32>) -> tensor<1x2x3xi32> {
-  // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{broadcast_sizes has rank 2 instead of rank 1}}
-  %0 = "stablehlo.broadcast"(%arg0) {broadcast_sizes = dense<[[1, 2]]> : tensor<1x2xi64>} : (tensor<3xi32>) -> tensor<1x2x3xi32>
+  %0 = "stablehlo.broadcast"(%arg0) {broadcast_sizes = array<i64: 1, 2>} : (tensor<3xi32>) -> tensor<1x2x3xi32>
   func.return %0 : tensor<1x2x3xi32>
 }
 
@@ -842,7 +833,7 @@ func.func @broadcast_bad_sizes_rank(%arg0: tensor<3xi32>) -> tensor<1x2x3xi32> {
 func.func @broadcast_bad_result_rank(%arg0: tensor<3xi32>) -> tensor<1x2x3xi32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{'stablehlo.broadcast' op inferred type(s) 'tensor<2x3xi32>' are incompatible with return type(s) of operation 'tensor<1x2x3xi32>'}}
-  %0 = "stablehlo.broadcast"(%arg0) {broadcast_sizes = dense<[2]> : tensor<1xi64>} : (tensor<3xi32>) -> tensor<1x2x3xi32>
+  %0 = "stablehlo.broadcast"(%arg0) {broadcast_sizes = array<i64: 2>} : (tensor<3xi32>) -> tensor<1x2x3xi32>
   func.return %0 : tensor<1x2x3xi32>
 }
 
@@ -851,7 +842,7 @@ func.func @broadcast_bad_result_rank(%arg0: tensor<3xi32>) -> tensor<1x2x3xi32> 
 func.func @broadcast_bad_first_part_result_shape(%arg0: tensor<3xi32>) -> tensor<1x3xi32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{'stablehlo.broadcast' op inferred type(s) 'tensor<2x3xi32>' are incompatible with return type(s) of operation 'tensor<1x3xi32>'}}
-  %0 = "stablehlo.broadcast"(%arg0) {broadcast_sizes = dense<[2]> : tensor<1xi64>} : (tensor<3xi32>) -> tensor<1x3xi32>
+  %0 = "stablehlo.broadcast"(%arg0) {broadcast_sizes = array<i64: 2>} : (tensor<3xi32>) -> tensor<1x3xi32>
   func.return %0 : tensor<1x3xi32>
 }
 
@@ -860,7 +851,7 @@ func.func @broadcast_bad_first_part_result_shape(%arg0: tensor<3xi32>) -> tensor
 func.func @broadcast_bad_second_part_result_shape(%arg0: tensor<3xi32>) -> tensor<2x1xi32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{'stablehlo.broadcast' op inferred type(s) 'tensor<2x3xi32>' are incompatible with return type(s) of operation 'tensor<2x1xi32>'}}
-  %0 = "stablehlo.broadcast"(%arg0) {broadcast_sizes = dense<[2]> : tensor<1xi64>} : (tensor<3xi32>) -> tensor<2x1xi32>
+  %0 = "stablehlo.broadcast"(%arg0) {broadcast_sizes = array<i64: 2>} : (tensor<3xi32>) -> tensor<2x1xi32>
   func.return %0 : tensor<2x1xi32>
 }
 

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -4786,7 +4786,7 @@ func.func @error_batch_norm_grad_c5(%input: tensor<2x2x2x2xf32>, %scale: tensor<
 
 // CHECK-LABEL: @fft
 func.func @fft(%arg0: tensor<3x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>> {
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type FFT> } : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 9>, fft_type = #stablehlo<fft_type FFT> } : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
   func.return %0 : tensor<3x9xcomplex<f32>>
 }
 
@@ -4794,7 +4794,7 @@ func.func @fft(%arg0: tensor<3x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>> {
 
 // CHECK-LABEL: @ifft
 func.func @ifft(%arg0: tensor<3x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>> {
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type IFFT> } : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 9>, fft_type = #stablehlo<fft_type IFFT> } : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>>
   func.return %0 : tensor<3x9xcomplex<f32>>
 }
 
@@ -4802,7 +4802,7 @@ func.func @ifft(%arg0: tensor<3x9xcomplex<f32>>) -> tensor<3x9xcomplex<f32>> {
 
 // CHECK-LABEL: @rfft
 func.func @rfft(%arg0: tensor<3x9xf32>) -> tensor<3x5xcomplex<f32>> {
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type RFFT> } : (tensor<3x9xf32>) -> tensor<3x5xcomplex<f32>>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 9>, fft_type = #stablehlo<fft_type RFFT> } : (tensor<3x9xf32>) -> tensor<3x5xcomplex<f32>>
   func.return %0 : tensor<3x5xcomplex<f32>>
 }
 
@@ -4810,7 +4810,7 @@ func.func @rfft(%arg0: tensor<3x9xf32>) -> tensor<3x5xcomplex<f32>> {
 
 // CHECK-LABEL: @irfft
 func.func @irfft(%arg0: tensor<3x9xcomplex<f32>>) -> tensor<3x16xf32> {
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<16> : tensor<1xi64>, fft_type = #stablehlo<fft_type IRFFT> } : (tensor<3x9xcomplex<f32>>) -> tensor<3x16xf32>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 16>, fft_type = #stablehlo<fft_type IRFFT> } : (tensor<3x9xcomplex<f32>>) -> tensor<3x16xf32>
   func.return %0 : tensor<3x16xf32>
 }
 
@@ -4818,7 +4818,7 @@ func.func @irfft(%arg0: tensor<3x9xcomplex<f32>>) -> tensor<3x16xf32> {
 
 // CHECK-LABEL: @rfft_unranked
 func.func @rfft_unranked(%arg0: tensor<*xf32>) -> tensor<*xcomplex<f32>> {
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type RFFT> } : (tensor<*xf32>) -> tensor<*xcomplex<f32>>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 9>, fft_type = #stablehlo<fft_type RFFT> } : (tensor<*xf32>) -> tensor<*xcomplex<f32>>
   func.return %0 : tensor<*xcomplex<f32>>
 }
 
@@ -4827,7 +4827,7 @@ func.func @rfft_unranked(%arg0: tensor<*xf32>) -> tensor<*xcomplex<f32>> {
 func.func @rfft_not_float32or64(%arg0: tensor<3x9xf16>) -> tensor<3x5xcomplex<f32>> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{RFFT requires f32 or f64 input type, but is given 'f16'.}}
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type RFFT> } : (tensor<3x9xf16>) -> tensor<3x5xcomplex<f32>>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 9>, fft_type = #stablehlo<fft_type RFFT> } : (tensor<3x9xf16>) -> tensor<3x5xcomplex<f32>>
   func.return %0 : tensor<3x5xcomplex<f32>>
 }
 
@@ -4836,7 +4836,7 @@ func.func @rfft_not_float32or64(%arg0: tensor<3x9xf16>) -> tensor<3x5xcomplex<f3
 func.func @fft_invalid_rank(%arg0: tensor<3x9xf32>) -> tensor<3x9xcomplex<f32>> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{rank must be between 1 and 3, but got 4.}}
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<9> : tensor<4xi64>, fft_type = #stablehlo<fft_type RFFT> } : (tensor<3x9xf32>) -> tensor<3x9xcomplex<f32>>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 9, 9, 9, 9>, fft_type = #stablehlo<fft_type RFFT> } : (tensor<3x9xf32>) -> tensor<3x9xcomplex<f32>>
   func.return %0 : tensor<3x9xcomplex<f32>>
 }
 
@@ -4845,7 +4845,7 @@ func.func @fft_invalid_rank(%arg0: tensor<3x9xf32>) -> tensor<3x9xcomplex<f32>> 
 func.func @fft_rank_mismatch(%arg0: tensor<3x9xf32>) -> tensor<3x9xcomplex<f32>> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{operand rank must not be less than fft rank of 3 for operand of type 'tensor<3x9xf32>'}}
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<9> : tensor<3xi64>, fft_type = #stablehlo<fft_type RFFT> } : (tensor<3x9xf32>) -> tensor<3x9xcomplex<f32>>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 9, 9, 9>, fft_type = #stablehlo<fft_type RFFT> } : (tensor<3x9xf32>) -> tensor<3x9xcomplex<f32>>
   func.return %0 : tensor<3x9xcomplex<f32>>
 }
 
@@ -4854,7 +4854,7 @@ func.func @fft_rank_mismatch(%arg0: tensor<3x9xf32>) -> tensor<3x9xcomplex<f32>>
 func.func @rfft_invalid_dim(%arg0: tensor<3x9xf32>) -> tensor<3x9xcomplex<f32>> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{RFFT requires innermost dimensions to be compatible with fft_length. Got: 3, 9 but wanted 9, 9.}}
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<9> : tensor<2xi64>, fft_type = #stablehlo<fft_type RFFT> } : (tensor<3x9xf32>) -> tensor<3x9xcomplex<f32>>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 9, 9>, fft_type = #stablehlo<fft_type RFFT> } : (tensor<3x9xf32>) -> tensor<3x9xcomplex<f32>>
   func.return %0 : tensor<3x9xcomplex<f32>>
 }
 
@@ -4863,7 +4863,7 @@ func.func @rfft_invalid_dim(%arg0: tensor<3x9xf32>) -> tensor<3x9xcomplex<f32>> 
 func.func @irfft_invalid_dim(%arg0: tensor<3x9xcomplex<f32>>) -> tensor<3x9xf32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{IRFFT requires non-final dimensions to be compatible with fft_length. Got: 3, 9 but wanted 9, 9, and 3 != 9.}}
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<9> : tensor<2xi64>, fft_type = #stablehlo<fft_type IRFFT> } : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xf32>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 9, 9>, fft_type = #stablehlo<fft_type IRFFT> } : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xf32>
   func.return %0 : tensor<3x9xf32>
 }
 
@@ -4872,7 +4872,7 @@ func.func @irfft_invalid_dim(%arg0: tensor<3x9xcomplex<f32>>) -> tensor<3x9xf32>
 func.func @irfft_invalid_dim(%arg0: tensor<3x9xcomplex<f32>>) -> tensor<3x9xf32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{IRFFT requires innermost dimension to be compatible with fft_length[-1]/2+1. Got: 9 but fft_length is 9.}}
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type IRFFT> } : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xf32>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 9>, fft_type = #stablehlo<fft_type IRFFT> } : (tensor<3x9xcomplex<f32>>) -> tensor<3x9xf32>
   func.return %0 : tensor<3x9xf32>
 }
 
@@ -4881,7 +4881,7 @@ func.func @irfft_invalid_dim(%arg0: tensor<3x9xcomplex<f32>>) -> tensor<3x9xf32>
 func.func @irfft_invalid_elt(%arg0: tensor<3x9xf32>) -> tensor<3x9xcomplex<f32>> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{FFT/IFFT/IRFFT take a complex tensor as input, but is given 'tensor<3x9xf32>'}}
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<16> : tensor<1xi64>, fft_type = #stablehlo<fft_type IRFFT> } : (tensor<3x9xf32>) -> tensor<3x9xcomplex<f32>>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 16>, fft_type = #stablehlo<fft_type IRFFT> } : (tensor<3x9xf32>) -> tensor<3x9xcomplex<f32>>
   func.return %0 : tensor<3x9xcomplex<f32>>
 }
 
@@ -4890,7 +4890,7 @@ func.func @irfft_invalid_elt(%arg0: tensor<3x9xf32>) -> tensor<3x9xcomplex<f32>>
 func.func @irfft_invalid_ret_elt(%arg0: tensor<3x9xcomplex<f32>>) -> tensor<3x16xcomplex<f32>> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{inferred type(s) 'tensor<3x16xf32>' are incompatible with return type(s) of operation 'tensor<3x16xcomplex<f32>>'}}
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<16> : tensor<1xi64>, fft_type = #stablehlo<fft_type IRFFT> } : (tensor<3x9xcomplex<f32>>) -> tensor<3x16xcomplex<f32>>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 16>, fft_type = #stablehlo<fft_type IRFFT> } : (tensor<3x9xcomplex<f32>>) -> tensor<3x16xcomplex<f32>>
   func.return %0 : tensor<3x16xcomplex<f32>>
 }
 
@@ -4899,7 +4899,7 @@ func.func @irfft_invalid_ret_elt(%arg0: tensor<3x9xcomplex<f32>>) -> tensor<3x16
 func.func @rfft_invalid_ret_elt(%arg0: tensor<3x9xf32>) -> tensor<3x9xf32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{inferred type(s) 'tensor<3x5xcomplex<f32>>' are incompatible with return type(s) of operation 'tensor<3x9xf32>'}}
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type RFFT> } : (tensor<3x9xf32>) -> tensor<3x9xf32>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 9>, fft_type = #stablehlo<fft_type RFFT> } : (tensor<3x9xf32>) -> tensor<3x9xf32>
   func.return %0 : tensor<3x9xf32>
 }
 
@@ -4907,7 +4907,7 @@ func.func @rfft_invalid_ret_elt(%arg0: tensor<3x9xf32>) -> tensor<3x9xf32> {
 
 // CHECK-LABEL: @rfft_dynamic
 func.func @rfft_dynamic(%arg0: tensor<?x?xf32>) -> tensor<?x?xcomplex<f32>> {
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type RFFT> } : (tensor<?x?xf32>) -> tensor<?x?xcomplex<f32>>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 9>, fft_type = #stablehlo<fft_type RFFT> } : (tensor<?x?xf32>) -> tensor<?x?xcomplex<f32>>
   func.return %0 : tensor<?x?xcomplex<f32>>
 }
 
@@ -4916,7 +4916,7 @@ func.func @rfft_dynamic(%arg0: tensor<?x?xf32>) -> tensor<?x?xcomplex<f32>> {
 func.func @rfft_dynamic_incompatible_dims(%arg0: tensor<3x10xf32>) -> tensor<?x?xcomplex<f32>> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{RFFT requires innermost dimensions to be compatible with fft_length. Got: 3, 10 but wanted 9.}}
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type RFFT> } : (tensor<3x10xf32>) -> tensor<?x?xcomplex<f32>>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 9>, fft_type = #stablehlo<fft_type RFFT> } : (tensor<3x10xf32>) -> tensor<?x?xcomplex<f32>>
   func.return %0 : tensor<?x?xcomplex<f32>>
 }
 
@@ -4924,7 +4924,7 @@ func.func @rfft_dynamic_incompatible_dims(%arg0: tensor<3x10xf32>) -> tensor<?x?
 
 // CHECK-LABEL: @irfft_dynamic
 func.func @irfft_dynamic(%arg0: tensor<?x?xcomplex<f32>>) -> tensor<?x?xf32> {
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<16> : tensor<1xi64>, fft_type = #stablehlo<fft_type IRFFT> } : (tensor<?x?xcomplex<f32>>) -> tensor<?x?xf32>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 16>, fft_type = #stablehlo<fft_type IRFFT> } : (tensor<?x?xcomplex<f32>>) -> tensor<?x?xf32>
   func.return %0 : tensor<?x?xf32>
 }
 
@@ -4933,7 +4933,7 @@ func.func @irfft_dynamic(%arg0: tensor<?x?xcomplex<f32>>) -> tensor<?x?xf32> {
 func.func @irfft_dynamic_incompatible_non_final_dims(%arg0: tensor<?x3x15xcomplex<f32>>) -> tensor<?x?x?xf32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{IRFFT requires non-final dimensions to be compatible with fft_length. Got: -9223372036854775808, 3, 15 but wanted 4, 16, and 3 != 4}}
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<[4, 16]> : tensor<2xi64>, fft_type = #stablehlo<fft_type IRFFT> } : (tensor<?x3x15xcomplex<f32>>) -> tensor<?x?x?xf32>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 4, 16>, fft_type = #stablehlo<fft_type IRFFT> } : (tensor<?x3x15xcomplex<f32>>) -> tensor<?x?x?xf32>
   func.return %0 : tensor<?x?x?xf32>
 }
 
@@ -4942,7 +4942,7 @@ func.func @irfft_dynamic_incompatible_non_final_dims(%arg0: tensor<?x3x15xcomple
 func.func @irfft_dynamic_incompatible_final_dim(%arg0: tensor<?x8xcomplex<f32>>) -> tensor<?x?xf32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{IRFFT requires innermost dimension to be compatible with fft_length[-1]/2+1. Got: 8 but fft_length is 16.}}
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<16> : tensor<1xi64>, fft_type = #stablehlo<fft_type IRFFT> } : (tensor<?x8xcomplex<f32>>) -> tensor<?x?xf32>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 16>, fft_type = #stablehlo<fft_type IRFFT> } : (tensor<?x8xcomplex<f32>>) -> tensor<?x?xf32>
   func.return %0 : tensor<?x?xf32>
 }
 
@@ -4950,7 +4950,7 @@ func.func @irfft_dynamic_incompatible_final_dim(%arg0: tensor<?x8xcomplex<f32>>)
 
 // CHECK-LABEL: @irfft_dynamic
 func.func @irfft_dynamic(%arg0: tensor<?x?xcomplex<f32>>) -> tensor<?x?xf32> {
-  %0 = "stablehlo.fft"(%arg0) { fft_length = dense<16> : tensor<1xi64>, fft_type = #stablehlo<fft_type IRFFT> } : (tensor<?x?xcomplex<f32>>) -> tensor<?x?xf32>
+  %0 = "stablehlo.fft"(%arg0) { fft_length = array<i64: 16>, fft_type = #stablehlo<fft_type IRFFT> } : (tensor<?x?xcomplex<f32>>) -> tensor<?x?xf32>
   func.return %0 : tensor<?x?xf32>
 }
 

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2924,7 +2924,7 @@ func.func @reshape_invalid_shapes(%operand: tensor<2x4xf32>) -> tensor<3x3xf32> 
 // CHECK-LABEL: func @reverse
 func.func @reverse(%operand: tensor<3x2xi32>) -> tensor<3x2xi32> {
   %0 = "stablehlo.reverse"(%operand) {
-    dimensions = dense<[0, 1]> : tensor<2xi64>
+    dimensions = array<i64: 0, 1>
   } : (tensor<3x2xi32>) -> tensor<3x2xi32>
   func.return %0 : tensor<3x2xi32>
 }
@@ -2934,7 +2934,7 @@ func.func @reverse(%operand: tensor<3x2xi32>) -> tensor<3x2xi32> {
 func.func @reverse_c2(%operand: tensor<3x2xi32>) -> tensor<3x2xi32> {
   // expected-error @+1 {{dimensions should be unique. Got: 0, 0}}
   %0 = "stablehlo.reverse"(%operand) {
-    dimensions = dense<[0, 0]> : tensor<2xi64>
+    dimensions = array<i64: 0, 0>
   } : (tensor<3x2xi32>) -> tensor<3x2xi32>
   func.return %0 : tensor<3x2xi32>
 }
@@ -2944,7 +2944,7 @@ func.func @reverse_c2(%operand: tensor<3x2xi32>) -> tensor<3x2xi32> {
 func.func @reverse_c3(%operand: tensor<*xi32>) -> tensor<*xi32> {
   // expected-error @+1 {{all dimensions should be non-negative. Got dimension: -1.}}
   %0 = "stablehlo.reverse"(%operand) {
-    dimensions = dense<-1> : tensor<1xi64>
+    dimensions = array<i64: -1>
   } : (tensor<*xi32>) -> tensor<*xi32>
   func.return %0 : tensor<*xi32>
 }
@@ -2954,7 +2954,7 @@ func.func @reverse_c3(%operand: tensor<*xi32>) -> tensor<*xi32> {
 func.func @reverse_c3(%operand: tensor<3x2xi32>) -> tensor<3x2xi32> {
   // expected-error @+1 {{all dimensions should be non-negative. Got dimension: -1.}}
   %0 = "stablehlo.reverse"(%operand) {
-    dimensions = dense<-1> : tensor<1xi64>
+    dimensions = array<i64: -1>
   } : (tensor<3x2xi32>) -> tensor<3x2xi32>
   func.return %0 : tensor<3x2xi32>
 }
@@ -2964,17 +2964,7 @@ func.func @reverse_c3(%operand: tensor<3x2xi32>) -> tensor<3x2xi32> {
 func.func @reverse_c3(%operand: tensor<3x2xi32>) -> tensor<3x2xi32> {
   // expected-error @+1 {{all dimensions should be between [0, 2). Got dimension: 2.}}
   %0 = "stablehlo.reverse"(%operand) {
-    dimensions = dense<2> : tensor<1xi64>
-  } : (tensor<3x2xi32>) -> tensor<3x2xi32>
-  func.return %0 : tensor<3x2xi32>
-}
-
-// -----
-
-func.func @reverse_i2(%operand: tensor<3x2xi32>) -> tensor<3x2xi32> {
-  // expected-error @+1 {{dimensions has rank 0 instead of required rank 1.}}
-  %0 = "stablehlo.reverse"(%operand) {
-    dimensions = dense<2> : tensor<i64>
+    dimensions = array<i64: 2>
   } : (tensor<3x2xi32>) -> tensor<3x2xi32>
   func.return %0 : tensor<3x2xi32>
 }

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2520,21 +2520,21 @@ func.func @dynamic_update_slice_dynamic_sizes(%operand: tensor<?x4xi64>, %update
 
 // CHECK-LABEL: func @transpose
 func.func @transpose(%arg0: tensor<1x2x3x4xi32>) -> tensor<2x1x4x3xi32> {
-  %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<1x2x3x4xi32>) -> tensor<2x1x4x3xi32>
+  %0 = "stablehlo.transpose"(%arg0) {permutation = array<i64: 1, 0, 3, 2>} : (tensor<1x2x3x4xi32>) -> tensor<2x1x4x3xi32>
   func.return %0: tensor<2x1x4x3xi32>
 }
 
 // -----
 
 func.func @transpose_ranked(%arg0: tensor<?x?x?x?xi32>) ->  tensor<?x?x?x?xi32> {
-  %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<?x?x?x?xi32>) -> tensor<?x?x?x?xi32>
+  %0 = "stablehlo.transpose"(%arg0) {permutation = array<i64: 1, 0, 3, 2>} : (tensor<?x?x?x?xi32>) -> tensor<?x?x?x?xi32>
   func.return %0: tensor<?x?x?x?xi32>
 }
 
 // -----
 
 func.func @transpose_unranked(%arg0: tensor<*xi32>) ->  tensor<*xi32> {
-  %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<*xi32>) -> tensor<*xi32>
+  %0 = "stablehlo.transpose"(%arg0) {permutation = array<i64: 1, 0, 3, 2>} : (tensor<*xi32>) -> tensor<*xi32>
   func.return %0: tensor<*xi32>
 }
 
@@ -2548,19 +2548,10 @@ func.func @transpose_missing_permutation(%arg0: tensor<1x2x3x4xi32>) -> tensor<2
 
 // -----
 
-func.func @transpose_bad_permutations_rank(%arg0: tensor<1x2x3x4xi32>) ->  tensor<2x1x4x3xi32> {
-  // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{permutation has rank 2 instead of rank 1}}
-  %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[[1]]> : tensor<1x1xi64>} : (tensor<1x2x3x4xi32>) -> tensor<2x1x4x3xi32>
-  func.return %0: tensor<2x1x4x3xi32>
-}
-
-// -----
-
 func.func @transpose_bad_permutations_size(%arg0: tensor<1x2x3x4xi32>) ->  tensor<2x1x4x3xi32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{TransposeOp operand rank 4 does not match permutation size 1}}
-  %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[1]> : tensor<1xi64>} : (tensor<1x2x3x4xi32>) -> tensor<2x1x4x3xi32>
+  %0 = "stablehlo.transpose"(%arg0) {permutation = array<i64: 1>} : (tensor<1x2x3x4xi32>) -> tensor<2x1x4x3xi32>
   func.return %0: tensor<2x1x4x3xi32>
 }
 
@@ -2568,8 +2559,8 @@ func.func @transpose_bad_permutations_size(%arg0: tensor<1x2x3x4xi32>) ->  tenso
 
 func.func @transpose_bad_permutation(%arg0: tensor<1x2x3x4xi32>) ->  tensor<2x1x4x3xi32> {
   // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{attribute permutation must be a permutation of [0, 1, 2, 3] but got dense<[1, 0, 3, 9]> : tensor<4xi64>}}
-  %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 9]> : tensor<4xi64>} : (tensor<1x2x3x4xi32>) -> tensor<2x1x4x3xi32>
+  // expected-error@+1 {{attribute permutation must be a permutation of [0, 1, 2, 3] but got 1, 0, 3, 9}}
+  %0 = "stablehlo.transpose"(%arg0) {permutation = array<i64: 1, 0, 3, 9>} : (tensor<1x2x3x4xi32>) -> tensor<2x1x4x3xi32>
   func.return %0: tensor<2x1x4x3xi32>
 }
 
@@ -2578,7 +2569,7 @@ func.func @transpose_bad_permutation(%arg0: tensor<1x2x3x4xi32>) ->  tensor<2x1x
 func.func @transpose_operand_result_rank_mismatch(%arg0: tensor<1x2x3x4xi32>) ->  tensor<2xi32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{op inferred type(s) 'tensor<2x1x4x3xi32>' are incompatible with return type(s) of operation 'tensor<2xi32>'}}
-  %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<1x2x3x4xi32>) -> tensor<2xi32>
+  %0 = "stablehlo.transpose"(%arg0) {permutation = array<i64: 1, 0, 3, 2>} : (tensor<1x2x3x4xi32>) -> tensor<2xi32>
   func.return %0: tensor<2xi32>
 }
 
@@ -2587,7 +2578,7 @@ func.func @transpose_operand_result_rank_mismatch(%arg0: tensor<1x2x3x4xi32>) ->
 func.func @transpose_operand_result_permutation_mismatch(%arg0: tensor<1x?x3x?xi32>) ->  tensor<?x2x?x?xi32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{op inferred type(s) 'tensor<?x1x?x3xi32>' are incompatible with return type(s) of operation 'tensor<?x2x?x?xi32>}}
-  %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<1x?x3x?xi32>) -> tensor<?x2x?x?xi32>
+  %0 = "stablehlo.transpose"(%arg0) {permutation = array<i64: 1, 0, 3, 2>} : (tensor<1x?x3x?xi32>) -> tensor<?x2x?x?xi32>
   func.return %0: tensor<?x2x?x?xi32>
 }
 
@@ -5395,7 +5386,7 @@ func.func @per_axis_quantized_ops(%arg0: tensor<1x2x2x!quant.uniform<i8<-128:127
   %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[0,1,3]> : tensor<3xi64>} : (tensor<1x2x2x!quant.uniform<i8<-128:127>:f32:2, {0.1:-30, 0.5:-20}>>) -> tensor<1x2x3x2x!quant.uniform<i8<-128:127>:f32:3, {0.1:-30, 0.5:-20}>>
   %1 = "stablehlo.broadcast_in_dim"(%arg1) {broadcast_dimensions = dense<[0,1,2]> : tensor<3xi64>} : (tensor<1x2x2x!quant.uniform<i8<-128:127>:f32:0, {0.1:-30}>>) -> tensor<2x2x2x!quant.uniform<i8<-128:127>:f32:0, {0.1:-30, 0.1:-30}>>
   %2 = stablehlo.reshape %arg0 : (tensor<1x2x2x!quant.uniform<i8<-128:127>:f32:2, {0.1:-30, 0.5:-20}>>) -> tensor<2x2x!quant.uniform<i8<-128:127>:f32:1, {0.1:-30, 0.5:-20}>>
-  %3 = "stablehlo.transpose"(%arg0) {permutation = dense<[0,2,1]> : tensor<3xi64>}: (tensor<1x2x2x!quant.uniform<i8<-128:127>:f32:2, {0.1:-30, 0.5:-20}>>) -> tensor<1x2x2x!quant.uniform<i8<-128:127>:f32:1, {0.1:-30, 0.5:-20}>>
+  %3 = "stablehlo.transpose"(%arg0) {permutation = array<i64: 0, 2, 1>}: (tensor<1x2x2x!quant.uniform<i8<-128:127>:f32:2, {0.1:-30, 0.5:-20}>>) -> tensor<1x2x2x!quant.uniform<i8<-128:127>:f32:1, {0.1:-30, 0.5:-20}>>
   func.return
 }
 

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2218,7 +2218,7 @@ func.func @select_c2(%arg0: tensor<i1>, %arg1: tensor<2x3xf32>, %arg2: tensor<2x
 
 // CHECK-LABEL: func @slice
 func.func @slice(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
-  %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 0]> : tensor<2xi64>, limit_indices = dense<[2, 4]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<3x4xi32>) -> tensor<1x2xi32>
+  %0 = "stablehlo.slice"(%arg0) {start_indices = array<i64: 1, 0>, limit_indices = array<i64: 2, 4>, strides = array<i64: 1, 2>} : (tensor<3x4xi32>) -> tensor<1x2xi32>
   func.return %0 : tensor<1x2xi32>
 }
 
@@ -2228,9 +2228,9 @@ func.func @slice_c2(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{the number of elements in start_indices (3) does not match the rank of the operand (2)}}
   %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<[1, 0, 0]> : tensor<3xi64>,
-    limit_indices = dense<[2, 4, 0]> : tensor<3xi64>,
-    strides = dense<[1, 2, 0]> : tensor<3xi64>
+    start_indices = array<i64: 1, 0, 0>,
+    limit_indices = array<i64: 2, 4, 0>,
+    strides = array<i64: 1, 2, 0>
   } : (tensor<3x4xi32>) -> tensor<1x2xi32>
   func.return %0 : tensor<1x2xi32>
 }
@@ -2241,9 +2241,9 @@ func.func @slice_c3(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{negative start index -1 in dimension 0}}
   %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<[-1, 0]> : tensor<2xi64>,
-    limit_indices = dense<[2, 4]> : tensor<2xi64>,
-    strides = dense<[1, 2]> : tensor<2xi64>
+    start_indices = array<i64: -1, 0>,
+    limit_indices = array<i64: 2, 4>,
+    strides = array<i64: 1, 2>
   } : (tensor<3x4xi32>) -> tensor<1x2xi32>
   func.return %0 : tensor<1x2xi32>
 }
@@ -2254,9 +2254,9 @@ func.func @slice_c3(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{limit index 5 is larger than dimension size 4 in dimension 1}}
   %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<[1, 0]> : tensor<2xi64>,
-    limit_indices = dense<[2, 5]> : tensor<2xi64>,
-    strides = dense<[1, 2]> : tensor<2xi64>
+    start_indices = array<i64: 1, 0>,
+    limit_indices = array<i64: 2, 5>,
+    strides = array<i64: 1, 2>
   } : (tensor<3x4xi32>) -> tensor<1x2xi32>
   func.return %0 : tensor<1x2xi32>
 }
@@ -2267,9 +2267,9 @@ func.func @slice_c3(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{start index 3 is larger than limit index 2 in dimension 1}}
   %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<[1, 3]> : tensor<2xi64>,
-    limit_indices = dense<[2, 2]> : tensor<2xi64>,
-    strides = dense<[1, 2]> : tensor<2xi64>
+    start_indices = array<i64: 1, 3>,
+    limit_indices = array<i64: 2, 2>,
+    strides = array<i64: 1, 2>
   } : (tensor<3x4xi32>) -> tensor<1x2xi32>
   func.return %0 : tensor<1x2xi32>
 }
@@ -2280,9 +2280,9 @@ func.func @slice_c4(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{stride must be positive but got 0 in dimension 0}}
   %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<[1, 0]> : tensor<2xi64>,
-    limit_indices = dense<[2, 4]> : tensor<2xi64>,
-    strides = dense<[0, 2]> : tensor<2xi64>
+    start_indices = array<i64: 1, 0>,
+    limit_indices = array<i64: 2, 4>,
+    strides = array<i64: 0, 2>
   } : (tensor<3x4xi32>) -> tensor<1x2xi32>
   func.return %0 : tensor<1x2xi32>
 }
@@ -2292,24 +2292,11 @@ func.func @slice_c4(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
 // CHECK-LABEL: func @slice_dynamic_dim
 func.func @slice_dynamic_dim(%arg0: tensor<3x?xi32>) -> tensor<1x?xi32> {
   %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<[1, 1]> : tensor<2xi64>,
-    limit_indices = dense<[2, 2]> : tensor<2xi64>,
-    strides = dense<[1, 1]> : tensor<2xi64>
+    start_indices = array<i64: 1, 1>,
+    limit_indices = array<i64: 2, 2>,
+    strides = array<i64: 1, 1>
   } : (tensor<3x?xi32>) -> tensor<1x?xi32>
   func.return %0 : tensor<1x?xi32>
-}
-
-// -----
-
-func.func @slice_i2(%arg0: tensor<3x4xi32>) -> tensor<1x2xi32> {
-  // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{start_indices has rank 2 instead of required rank 1}}
-  %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<[[1, 0]]> : tensor<1x2xi64>,
-    limit_indices = dense<[[2, 4]]> : tensor<1x2xi64>,
-    strides = dense<[[1, 2]]> : tensor<1x2xi64>
-  } : (tensor<3x4xi32>) -> tensor<1x2xi32>
-  func.return %0 : tensor<1x2xi32>
 }
 
 // -----
@@ -2339,7 +2326,7 @@ func.func @send_c1(%arg0: tensor<2x2xi64>, %arg1: !stablehlo.token) -> !stablehl
 
 // CHECK-LABEL: func @slice_unranked
 func.func @slice_unranked(%arg0: tensor<*xi32>) -> tensor<*xi32> {
-  %0 = "stablehlo.slice"(%arg0) {start_indices = dense<[1, 0]> : tensor<2xi64>, limit_indices = dense<[2, 4]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<*xi32>) -> tensor<*xi32>
+  %0 = "stablehlo.slice"(%arg0) {start_indices = array<i64: 1, 0>, limit_indices = array<i64: 2, 4>, strides = array<i64: 1, 2>} : (tensor<*xi32>) -> tensor<*xi32>
   func.return %0 : tensor<*xi32>
 }
 

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2347,7 +2347,7 @@ func.func @slice_unranked(%arg0: tensor<*xi32>) -> tensor<*xi32> {
 
 // CHECK-LABEL: func @dynamic_slice
 func.func @dynamic_slice(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xi32> {
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
+  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = array<i64: 1, 4>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
   func.return %0 : tensor<1x4xi32>
 }
 
@@ -2356,7 +2356,7 @@ func.func @dynamic_slice(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tens
 func.func @dynamic_slice_c2(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xi32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{has mismatched number of slice sizes (1) and number of start indices (2)}}
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[4]> : tensor<1xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
+  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = array<i64: 4>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
   func.return %0 : tensor<1x4xi32>
 }
 
@@ -2365,7 +2365,7 @@ func.func @dynamic_slice_c2(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: t
 func.func @dynamic_slice_c2(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>) -> tensor<1x4xi32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{has mismatched number of start indices (1) and the rank of operand (2)}}
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1) {slice_sizes = dense<[1]> : tensor<1xi64>} : (tensor<3x4xi32>, tensor<i64>) -> tensor<1x4xi32>
+  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1) {slice_sizes = array<i64: 1>} : (tensor<3x4xi32>, tensor<i64>) -> tensor<1x4xi32>
   func.return %0 : tensor<1x4xi32>
 }
 
@@ -2374,7 +2374,7 @@ func.func @dynamic_slice_c2(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>) -> tenso
 func.func @dynamic_slice_c3(%arg0: tensor<3x4xi32>, %arg1: tensor<i32>, %arg2: tensor<i64>) -> tensor<1x4xi32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{start indices must have same element type}}
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i32>, tensor<i64>) -> tensor<1x4xi32>
+  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = array<i64: 1, 4>} : (tensor<3x4xi32>, tensor<i32>, tensor<i64>) -> tensor<1x4xi32>
   func.return %0 : tensor<1x4xi32>
 }
 
@@ -2383,7 +2383,7 @@ func.func @dynamic_slice_c3(%arg0: tensor<3x4xi32>, %arg1: tensor<i32>, %arg2: t
 func.func @dynamic_slice_c4(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xi32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{has negative size index to dynamic slice: -1}}
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[-1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
+  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = array<i64: -1, 4>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
   func.return %0 : tensor<1x4xi32>
 }
 
@@ -2392,7 +2392,7 @@ func.func @dynamic_slice_c4(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: t
 func.func @dynamic_slice_c4(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xi32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{has slice size 10 greater than dimension size 4 in dimension 1 of operand}}
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 10]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
+  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = array<i64: 1, 10>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
   func.return %0 : tensor<1x4xi32>
 }
 
@@ -2401,7 +2401,7 @@ func.func @dynamic_slice_c4(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: t
 func.func @dynamic_slice_c5(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<2x4xi32> {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{inferred type(s) 'tensor<1x4xi32>' are incompatible with return type(s) of operation 'tensor<2x4xi32>'}}
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<2x4xi32>
+  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = array<i64: 1, 4>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<2x4xi32>
   func.return %0 : tensor<2x4xi32>
 }
 
@@ -2409,16 +2409,7 @@ func.func @dynamic_slice_c5(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: t
 
 // CHECK-LABEL: func @dynamic_slice_dynamic_dim
 func.func @dynamic_slice_dynamic_dim(%arg0: tensor<?x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xi32> {
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<?x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
-  func.return %0 : tensor<1x4xi32>
-}
-
-// -----
-
-func.func @dynamic_slice_i3(%arg0: tensor<3x4xi32>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<1x4xi32> {
-  // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{slice_sizes should be rank 1, but got rank 0.}}
-  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = dense<1> : tensor<i64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
+  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {slice_sizes = array<i64: 1, 4>} : (tensor<?x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
   func.return %0 : tensor<1x4xi32>
 }
 

--- a/stablehlo/tests/ops_stablehlo_roundtrip.mlir
+++ b/stablehlo/tests/ops_stablehlo_roundtrip.mlir
@@ -574,7 +574,7 @@ func.func @test_reshape(%arg0: tensor<2xf32>) -> tensor<1x2xf32> {
 
 func.func @test_reverse(%arg0 : tensor<10x11x12x13xf32>) -> tensor<10x11x12x13xf32> {
   %result = "stablehlo.reverse"(%arg0) {
-    dimensions = dense<[1,2]> : tensor<2xi64>
+    dimensions = array<i64: 1,2>
   } : (tensor<10x11x12x13xf32>) -> tensor<10x11x12x13xf32>
   func.return %result : tensor<10x11x12x13xf32>
 }

--- a/stablehlo/tests/ops_stablehlo_roundtrip.mlir
+++ b/stablehlo/tests/ops_stablehlo_roundtrip.mlir
@@ -357,7 +357,7 @@ func.func @test_einsum(%arg0: tensor<3x4xi32>, %arg1: tensor<4x5xi32>) -> tensor
 }
 
 func.func @test_fft(%arg0: tensor<3x9xf32>) -> tensor<3x5xcomplex<f32>> {
-  %0 = "stablehlo.fft"(%arg0) {fft_length = dense<9> : tensor<1xi64>, fft_type = #stablehlo<fft_type RFFT>} : (tensor<3x9xf32>) -> tensor<3x5xcomplex<f32>>
+  %0 = "stablehlo.fft"(%arg0) {fft_length = array<i64: 9>, fft_type = #stablehlo<fft_type RFFT>} : (tensor<3x9xf32>) -> tensor<3x5xcomplex<f32>>
   func.return %0 : tensor<3x5xcomplex<f32>>
 }
 

--- a/stablehlo/tests/ops_stablehlo_roundtrip.mlir
+++ b/stablehlo/tests/ops_stablehlo_roundtrip.mlir
@@ -448,7 +448,7 @@ func.func @test_outfeed3(%token: !stablehlo.token) -> !stablehlo.token {
 }
 
 func.func @test_pad(%arg: tensor<4x6xf32>, %pad: tensor<f32>) -> tensor<13x19xf32> {
-  %0 = "stablehlo.pad"(%arg, %pad) {edge_padding_high = dense<[4,5]> : tensor<2xi64>, edge_padding_low = dense<[2,3]> : tensor<2xi64>, interior_padding = dense<1> : tensor<2xi64>} : (tensor<4x6xf32>, tensor<f32>) -> tensor<13x19xf32>
+  %0 = "stablehlo.pad"(%arg, %pad) {edge_padding_high = array<i64: 4,5>, edge_padding_low = array<i64: 2,3>, interior_padding = array<i64: 1, 1>} : (tensor<4x6xf32>, tensor<f32>) -> tensor<13x19xf32>
   func.return %0 : tensor<13x19xf32>
 }
 

--- a/stablehlo/tests/ops_stablehlo_roundtrip.mlir
+++ b/stablehlo/tests/ops_stablehlo_roundtrip.mlir
@@ -718,7 +718,7 @@ func.func @test_sort2(%input0: tensor<16x16xf32>) {
 }
 
 func.func @test_transpose(%arg0: tensor<1x2x3x4xi32>) -> tensor<2x1x4x3xi32> {
-  %0 = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0, 3, 2]> : tensor<4xi64>} : (tensor<1x2x3x4xi32>) -> tensor<2x1x4x3xi32>
+  %0 = "stablehlo.transpose"(%arg0) {permutation = array<i64: 1, 0, 3, 2>} : (tensor<1x2x3x4xi32>) -> tensor<2x1x4x3xi32>
   func.return %0 : tensor<2x1x4x3xi32>
 }
 

--- a/stablehlo/tests/ops_stablehlo_roundtrip.mlir
+++ b/stablehlo/tests/ops_stablehlo_roundtrip.mlir
@@ -109,7 +109,7 @@ func.func @test_bitcast_convert(%arg0: tensor<2xi32>) -> tensor<2xf32> {
 }
 
 func.func @test_broadcast(%arg0: tensor<4xi32>) -> tensor<1x2x3x4xi32> {
-      %0 = "stablehlo.broadcast"(%arg0) {broadcast_sizes = dense<[1,2,3]> : tensor<3xi64>} : (tensor<4xi32>) -> tensor<1x2x3x4xi32>
+      %0 = "stablehlo.broadcast"(%arg0) {broadcast_sizes = array<i64: 1,2,3>} : (tensor<4xi32>) -> tensor<1x2x3x4xi32>
   func.return %0 : tensor<1x2x3x4xi32>
 }
 

--- a/stablehlo/tests/ops_stablehlo_roundtrip.mlir
+++ b/stablehlo/tests/ops_stablehlo_roundtrip.mlir
@@ -695,7 +695,7 @@ func.func @test_shift(%arg0: tensor<4xi32>, %arg1: tensor<4xi32>) -> (tensor<4xi
 }
 
 func.func @test_slice(%arg: tensor<3x4xi32>) -> tensor<1x2xi32> {
-  %0 = "stablehlo.slice"(%arg) {start_indices = dense<[1, 0]> : tensor<2xi64>, limit_indices = dense<[2, 4]> : tensor<2xi64>, strides = dense<[1, 2]> : tensor<2xi64>} : (tensor<3x4xi32>) -> tensor<1x2xi32>
+  %0 = "stablehlo.slice"(%arg) {start_indices = array<i64: 1, 0>, limit_indices = array<i64: 2, 4>, strides = array<i64: 1, 2>} : (tensor<3x4xi32>) -> tensor<1x2xi32>
   func.return %0 : tensor<1x2xi32>
 }
 

--- a/stablehlo/tests/ops_stablehlo_roundtrip.mlir
+++ b/stablehlo/tests/ops_stablehlo_roundtrip.mlir
@@ -346,7 +346,7 @@ func.func @test_dot_general(%arg0: tensor<2x2x2xi8>, %arg1: tensor<2x2x3xi8>) ->
 }
 
 func.func @test_dynamic_slice(%arg: tensor<3x4xi32>, %start1: tensor<i64>, %start2: tensor<i64>) -> tensor<1x4xi32> {
-  %0 = "stablehlo.dynamic_slice"(%arg, %start1, %start2) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
+  %0 = "stablehlo.dynamic_slice"(%arg, %start1, %start2) {slice_sizes = array<i64: 1, 4>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
   func.return %0 : tensor<1x4xi32>
 }
 

--- a/stablehlo/tests/print_stablehlo.mlir
+++ b/stablehlo/tests/print_stablehlo.mlir
@@ -289,7 +289,7 @@ func.func @dimension_attr(%arg0 : tensor<1x2xf32>, %arg1 : tensor<3xi32>, %arg2 
   %2 = "stablehlo.reverse"(%arg0) {dimensions = array<i64: 0, 1>} : (tensor<1x2xf32>) -> tensor<1x2xf32>
   %3 = "stablehlo.transpose"(%arg0) {permutation = array<i64: 1, 0>} : (tensor<1x2xf32>) -> tensor<2x1xf32>
   %4 = "stablehlo.dynamic_slice"(%arg2, %arg3, %arg3) {slice_sizes = array<i64: 1, 4>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
-  %5 = "stablehlo.pad"(%arg4, %arg5) { edge_padding_high = dense<4> : tensor<1xi64>, edge_padding_low = dense<4> : tensor<1xi64>, interior_padding = dense<0> : tensor<1xi64>} : (tensor<8xf32>, tensor<f32>) -> tensor<16xf32>
+  %5 = "stablehlo.pad"(%arg4, %arg5) { edge_padding_high = array<i64: 4>, edge_padding_low = array<i64: 4>, interior_padding = array<i64: 0>} : (tensor<8xf32>, tensor<f32>) -> tensor<16xf32>
   "stablehlo.return"() : () -> ()
 }
 

--- a/stablehlo/tests/print_stablehlo.mlir
+++ b/stablehlo/tests/print_stablehlo.mlir
@@ -287,7 +287,7 @@ func.func @dimension_attr(%arg0 : tensor<1x2xf32>, %arg1 : tensor<3xi32>, %arg2 
   %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[0, 1]> : tensor<2xi64>} : (tensor<1x2xf32>) -> tensor<1x2x3xf32>
   %1 = "stablehlo.broadcast"(%arg1) {broadcast_sizes = dense<[1, 2]> : tensor<2xi64>} : (tensor<3xi32>) -> tensor<1x2x3xi32>
   %2 = "stablehlo.reverse"(%arg0) {dimensions = dense<[0, 1]> : tensor<2xi64>} : (tensor<1x2xf32>) -> tensor<1x2xf32>
-  %3 = "stablehlo.transpose"(%arg0) {permutation = dense<[1, 0]> : tensor<2xi64>} : (tensor<1x2xf32>) -> tensor<2x1xf32>
+  %3 = "stablehlo.transpose"(%arg0) {permutation = array<i64: 1, 0>} : (tensor<1x2xf32>) -> tensor<2x1xf32>
   %4 = "stablehlo.dynamic_slice"(%arg2, %arg3, %arg3) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
   %5 = "stablehlo.pad"(%arg4, %arg5) { edge_padding_high = dense<4> : tensor<1xi64>, edge_padding_low = dense<4> : tensor<1xi64>, interior_padding = dense<0> : tensor<1xi64>} : (tensor<8xf32>, tensor<f32>) -> tensor<16xf32>
   "stablehlo.return"() : () -> ()

--- a/stablehlo/tests/print_stablehlo.mlir
+++ b/stablehlo/tests/print_stablehlo.mlir
@@ -288,7 +288,7 @@ func.func @dimension_attr(%arg0 : tensor<1x2xf32>, %arg1 : tensor<3xi32>, %arg2 
   %1 = "stablehlo.broadcast"(%arg1) {broadcast_sizes = array<i64: 1, 2>} : (tensor<3xi32>) -> tensor<1x2x3xi32>
   %2 = "stablehlo.reverse"(%arg0) {dimensions = array<i64: 0, 1>} : (tensor<1x2xf32>) -> tensor<1x2xf32>
   %3 = "stablehlo.transpose"(%arg0) {permutation = array<i64: 1, 0>} : (tensor<1x2xf32>) -> tensor<2x1xf32>
-  %4 = "stablehlo.dynamic_slice"(%arg2, %arg3, %arg3) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
+  %4 = "stablehlo.dynamic_slice"(%arg2, %arg3, %arg3) {slice_sizes = array<i64: 1, 4>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
   %5 = "stablehlo.pad"(%arg4, %arg5) { edge_padding_high = dense<4> : tensor<1xi64>, edge_padding_low = dense<4> : tensor<1xi64>, interior_padding = dense<0> : tensor<1xi64>} : (tensor<8xf32>, tensor<f32>) -> tensor<16xf32>
   "stablehlo.return"() : () -> ()
 }

--- a/stablehlo/tests/print_stablehlo.mlir
+++ b/stablehlo/tests/print_stablehlo.mlir
@@ -305,7 +305,7 @@ func.func @op_einsum(%arg0: tensor<8x16xf32>, %arg1: tensor<16x8xf32>) -> tensor
 // CHECK-LABEL: func @fft_op
 func.func @fft_op(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>> {
   // CHECK: %0 = stablehlo.fft %arg0, type = FFT, length = [16] : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
-  %0 = "stablehlo.fft"(%arg0) {fft_type = #stablehlo<fft_type FFT>, fft_length = dense<16> : tensor<1xi64>} : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
+  %0 = "stablehlo.fft"(%arg0) {fft_type = #stablehlo<fft_type FFT>, fft_length = array<i64: 16>} : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }
 

--- a/stablehlo/tests/print_stablehlo.mlir
+++ b/stablehlo/tests/print_stablehlo.mlir
@@ -286,7 +286,7 @@ func.func @dimension_attr(%arg0 : tensor<1x2xf32>, %arg1 : tensor<3xi32>, %arg2 
   // CHECK-NEXT: %5 = stablehlo.pad %arg4, %arg5, low = [4], high = [4], interior = [0] : (tensor<8xf32>, tensor<f32>) -> tensor<16xf32>
   %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[0, 1]> : tensor<2xi64>} : (tensor<1x2xf32>) -> tensor<1x2x3xf32>
   %1 = "stablehlo.broadcast"(%arg1) {broadcast_sizes = dense<[1, 2]> : tensor<2xi64>} : (tensor<3xi32>) -> tensor<1x2x3xi32>
-  %2 = "stablehlo.reverse"(%arg0) {dimensions = dense<[0, 1]> : tensor<2xi64>} : (tensor<1x2xf32>) -> tensor<1x2xf32>
+  %2 = "stablehlo.reverse"(%arg0) {dimensions = array<i64: 0, 1>} : (tensor<1x2xf32>) -> tensor<1x2xf32>
   %3 = "stablehlo.transpose"(%arg0) {permutation = array<i64: 1, 0>} : (tensor<1x2xf32>) -> tensor<2x1xf32>
   %4 = "stablehlo.dynamic_slice"(%arg2, %arg3, %arg3) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
   %5 = "stablehlo.pad"(%arg4, %arg5) { edge_padding_high = dense<4> : tensor<1xi64>, edge_padding_low = dense<4> : tensor<1xi64>, interior_padding = dense<0> : tensor<1xi64>} : (tensor<8xf32>, tensor<f32>) -> tensor<16xf32>

--- a/stablehlo/tests/print_stablehlo.mlir
+++ b/stablehlo/tests/print_stablehlo.mlir
@@ -285,7 +285,7 @@ func.func @dimension_attr(%arg0 : tensor<1x2xf32>, %arg1 : tensor<3xi32>, %arg2 
   // CHECK-NEXT: %4 = stablehlo.dynamic_slice %arg2, %arg3, %arg3, sizes = [1, 4] : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>
   // CHECK-NEXT: %5 = stablehlo.pad %arg4, %arg5, low = [4], high = [4], interior = [0] : (tensor<8xf32>, tensor<f32>) -> tensor<16xf32>
   %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[0, 1]> : tensor<2xi64>} : (tensor<1x2xf32>) -> tensor<1x2x3xf32>
-  %1 = "stablehlo.broadcast"(%arg1) {broadcast_sizes = dense<[1, 2]> : tensor<2xi64>} : (tensor<3xi32>) -> tensor<1x2x3xi32>
+  %1 = "stablehlo.broadcast"(%arg1) {broadcast_sizes = array<i64: 1, 2>} : (tensor<3xi32>) -> tensor<1x2x3xi32>
   %2 = "stablehlo.reverse"(%arg0) {dimensions = array<i64: 0, 1>} : (tensor<1x2xf32>) -> tensor<1x2xf32>
   %3 = "stablehlo.transpose"(%arg0) {permutation = array<i64: 1, 0>} : (tensor<1x2xf32>) -> tensor<2x1xf32>
   %4 = "stablehlo.dynamic_slice"(%arg2, %arg3, %arg3) {slice_sizes = dense<[1, 4]> : tensor<2xi64>} : (tensor<3x4xi32>, tensor<i64>, tensor<i64>) -> tensor<1x4xi32>

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_10_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_10_0.mlir
@@ -908,7 +908,7 @@ func.func @op_broadcast(%arg0: tensor<16xf32>) -> tensor<16x16xf32> {
   // CHECK-SAME:   broadcast_sizes = #vhlo.tensor_v1<dense<16> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x16x!vhlo.f32_v1>
   %0 = "stablehlo.broadcast"(%arg0) {
-    broadcast_sizes = dense<16> : tensor<1xi64>
+    broadcast_sizes = array<i64: 16>
   } : (tensor<16xf32>) -> tensor<16x16xf32>
   func.return %0 : tensor<16x16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_10_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_10_0.mlir
@@ -1985,7 +1985,7 @@ func.func @op_transpose(%arg0: tensor<16x8xf32>) ->  tensor<8x16xf32> {
   // CHECK-SAME:   permutation = #vhlo.tensor_v1<dense<[1, 0]> : tensor<2xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x8x!vhlo.f32_v1>) -> !vhlo.tensor_v1<8x16x!vhlo.f32_v1>
   %0 = "stablehlo.transpose"(%arg0) {
-    permutation = dense<[1, 0]> : tensor<2xi64>
+    permutation = array<i64: 1, 0>
   } : (tensor<16x8xf32>) -> tensor<8x16xf32>
   func.return %0 : tensor<8x16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_10_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_10_0.mlir
@@ -1550,9 +1550,9 @@ func.func @op_pad(%arg0: tensor<8xf32>, %arg1: tensor<f32>) -> tensor<16xf32> {
   // CHECK-SAME:   interior_padding = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<8x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<4> : tensor<1xi64>,
-    edge_padding_low = dense<4> : tensor<1xi64>,
-    interior_padding = dense<0> : tensor<1xi64>
+    edge_padding_high = array<i64: 4>,
+    edge_padding_low = array<i64: 4>,
+    interior_padding = array<i64: 0>
   } : (tensor<8xf32>, tensor<f32>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_10_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_10_0.mlir
@@ -1721,7 +1721,7 @@ func.func @op_reverse(%arg0: tensor<16xf32>) -> tensor<16xf32> {
   // CHECK-SAME:   dimensions = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.reverse"(%arg0) {
-    dimensions = dense<0> : tensor<1xi64>
+    dimensions = array<i64: 0>
   } : (tensor<16xf32>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_10_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_10_0.mlir
@@ -160,7 +160,7 @@ func.func @attr_fft_type_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomple
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 FFT>
     fft_type = #stablehlo<fft_type FFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }
@@ -170,7 +170,7 @@ func.func @attr_fft_type_ifft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcompl
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 IFFT>
     fft_type = #stablehlo<fft_type IFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }
@@ -180,7 +180,7 @@ func.func @attr_fft_type_rfft(%arg0: tensor<16xf32>) -> tensor<9xcomplex<f32>> {
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 RFFT>
     fft_type = #stablehlo<fft_type RFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xf32>) -> tensor<9xcomplex<f32>>
   func.return %0 : tensor<9xcomplex<f32>>
 }
@@ -190,7 +190,7 @@ func.func @attr_fft_type_irfft(%arg0: tensor<9xcomplex<f32>>) -> tensor<16xf32> 
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 IRFFT>
     fft_type = #stablehlo<fft_type IRFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<9xcomplex<f32>>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }
@@ -1317,7 +1317,7 @@ func.func @op_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>> {
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.complex_v1<!vhlo.f32_v1>>) -> !vhlo.tensor_v1<16x!vhlo.complex_v1<!vhlo.f32_v1>>
   %0 = "stablehlo.fft"(%arg0) {
     fft_type = #stablehlo<fft_type FFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_10_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_10_0.mlir
@@ -1906,9 +1906,9 @@ func.func @op_slice(%arg0: tensor<16xf32>) -> tensor<4xf32> {
   // CHECK-SAME:   strides = #vhlo.tensor_v1<dense<1> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<4x!vhlo.f32_v1>
   %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<0> : tensor<1xi64>,
-    limit_indices = dense<4> : tensor<1xi64>,
-    strides = dense<1> : tensor<1xi64>
+    start_indices = array<i64: 0>,
+    limit_indices = array<i64: 4>,
+    strides = array<i64: 1>
   } : (tensor<16xf32>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_10_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_10_0.mlir
@@ -1272,7 +1272,7 @@ func.func @op_dynamic_slice(%arg0: tensor<16xf32>, %arg1: tensor<i64>) -> tensor
   // CHECK-SAME:   slice_sizes = #vhlo.tensor_v1<dense<4> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.i64_v1>) -> !vhlo.tensor_v1<4x!vhlo.f32_v1>
   %0 = "stablehlo.dynamic_slice"(%arg0, %arg1) {
-    slice_sizes = dense<4> : tensor<1xi64>
+    slice_sizes = array<i64: 4>
   } : (tensor<16xf32>, tensor<i64>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_11_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_11_0.mlir
@@ -908,7 +908,7 @@ func.func @op_broadcast(%arg0: tensor<16xf32>) -> tensor<16x16xf32> {
   // CHECK-SAME:   broadcast_sizes = #vhlo.tensor_v1<dense<16> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x16x!vhlo.f32_v1>
   %0 = "stablehlo.broadcast"(%arg0) {
-    broadcast_sizes = dense<16> : tensor<1xi64>
+    broadcast_sizes = array<i64: 16>
   } : (tensor<16xf32>) -> tensor<16x16xf32>
   func.return %0 : tensor<16x16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_11_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_11_0.mlir
@@ -1985,7 +1985,7 @@ func.func @op_transpose(%arg0: tensor<16x8xf32>) ->  tensor<8x16xf32> {
   // CHECK-SAME:   permutation = #vhlo.tensor_v1<dense<[1, 0]> : tensor<2xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x8x!vhlo.f32_v1>) -> !vhlo.tensor_v1<8x16x!vhlo.f32_v1>
   %0 = "stablehlo.transpose"(%arg0) {
-    permutation = dense<[1, 0]> : tensor<2xi64>
+    permutation = array<i64: 1, 0>
   } : (tensor<16x8xf32>) -> tensor<8x16xf32>
   func.return %0 : tensor<8x16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_11_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_11_0.mlir
@@ -1550,9 +1550,9 @@ func.func @op_pad(%arg0: tensor<8xf32>, %arg1: tensor<f32>) -> tensor<16xf32> {
   // CHECK-SAME:   interior_padding = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<8x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<4> : tensor<1xi64>,
-    edge_padding_low = dense<4> : tensor<1xi64>,
-    interior_padding = dense<0> : tensor<1xi64>
+    edge_padding_high = array<i64: 4>,
+    edge_padding_low = array<i64: 4>,
+    interior_padding = array<i64: 0>
   } : (tensor<8xf32>, tensor<f32>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_11_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_11_0.mlir
@@ -1721,7 +1721,7 @@ func.func @op_reverse(%arg0: tensor<16xf32>) -> tensor<16xf32> {
   // CHECK-SAME:   dimensions = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.reverse"(%arg0) {
-    dimensions = dense<0> : tensor<1xi64>
+    dimensions = array<i64: 0>
   } : (tensor<16xf32>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_11_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_11_0.mlir
@@ -160,7 +160,7 @@ func.func @attr_fft_type_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomple
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 FFT>
     fft_type = #stablehlo<fft_type FFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }
@@ -170,7 +170,7 @@ func.func @attr_fft_type_ifft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcompl
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 IFFT>
     fft_type = #stablehlo<fft_type IFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }
@@ -180,7 +180,7 @@ func.func @attr_fft_type_rfft(%arg0: tensor<16xf32>) -> tensor<9xcomplex<f32>> {
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 RFFT>
     fft_type = #stablehlo<fft_type RFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xf32>) -> tensor<9xcomplex<f32>>
   func.return %0 : tensor<9xcomplex<f32>>
 }
@@ -190,7 +190,7 @@ func.func @attr_fft_type_irfft(%arg0: tensor<9xcomplex<f32>>) -> tensor<16xf32> 
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 IRFFT>
     fft_type = #stablehlo<fft_type IRFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<9xcomplex<f32>>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }
@@ -1317,7 +1317,7 @@ func.func @op_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>> {
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.complex_v1<!vhlo.f32_v1>>) -> !vhlo.tensor_v1<16x!vhlo.complex_v1<!vhlo.f32_v1>>
   %0 = "stablehlo.fft"(%arg0) {
     fft_type = #stablehlo<fft_type FFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_11_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_11_0.mlir
@@ -1906,9 +1906,9 @@ func.func @op_slice(%arg0: tensor<16xf32>) -> tensor<4xf32> {
   // CHECK-SAME:   strides = #vhlo.tensor_v1<dense<1> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<4x!vhlo.f32_v1>
   %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<0> : tensor<1xi64>,
-    limit_indices = dense<4> : tensor<1xi64>,
-    strides = dense<1> : tensor<1xi64>
+    start_indices = array<i64: 0>,
+    limit_indices = array<i64: 4>,
+    strides = array<i64: 1>
   } : (tensor<16xf32>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_11_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_11_0.mlir
@@ -1272,7 +1272,7 @@ func.func @op_dynamic_slice(%arg0: tensor<16xf32>, %arg1: tensor<i64>) -> tensor
   // CHECK-SAME:   slice_sizes = #vhlo.tensor_v1<dense<4> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.i64_v1>) -> !vhlo.tensor_v1<4x!vhlo.f32_v1>
   %0 = "stablehlo.dynamic_slice"(%arg0, %arg1) {
-    slice_sizes = dense<4> : tensor<1xi64>
+    slice_sizes = array<i64: 4>
   } : (tensor<16xf32>, tensor<i64>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_12_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_12_0.mlir
@@ -908,7 +908,7 @@ func.func @op_broadcast(%arg0: tensor<16xf32>) -> tensor<16x16xf32> {
   // CHECK-SAME:   broadcast_sizes = #vhlo.tensor_v1<dense<16> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x16x!vhlo.f32_v1>
   %0 = "stablehlo.broadcast"(%arg0) {
-    broadcast_sizes = dense<16> : tensor<1xi64>
+    broadcast_sizes = array<i64: 16>
   } : (tensor<16xf32>) -> tensor<16x16xf32>
   func.return %0 : tensor<16x16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_12_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_12_0.mlir
@@ -1985,7 +1985,7 @@ func.func @op_transpose(%arg0: tensor<16x8xf32>) ->  tensor<8x16xf32> {
   // CHECK-SAME:   permutation = #vhlo.tensor_v1<dense<[1, 0]> : tensor<2xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x8x!vhlo.f32_v1>) -> !vhlo.tensor_v1<8x16x!vhlo.f32_v1>
   %0 = "stablehlo.transpose"(%arg0) {
-    permutation = dense<[1, 0]> : tensor<2xi64>
+    permutation = array<i64: 1, 0>
   } : (tensor<16x8xf32>) -> tensor<8x16xf32>
   func.return %0 : tensor<8x16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_12_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_12_0.mlir
@@ -1550,9 +1550,9 @@ func.func @op_pad(%arg0: tensor<8xf32>, %arg1: tensor<f32>) -> tensor<16xf32> {
   // CHECK-SAME:   interior_padding = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<8x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<4> : tensor<1xi64>,
-    edge_padding_low = dense<4> : tensor<1xi64>,
-    interior_padding = dense<0> : tensor<1xi64>
+    edge_padding_high = array<i64: 4>,
+    edge_padding_low = array<i64: 4>,
+    interior_padding = array<i64: 0>
   } : (tensor<8xf32>, tensor<f32>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_12_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_12_0.mlir
@@ -1721,7 +1721,7 @@ func.func @op_reverse(%arg0: tensor<16xf32>) -> tensor<16xf32> {
   // CHECK-SAME:   dimensions = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.reverse"(%arg0) {
-    dimensions = dense<0> : tensor<1xi64>
+    dimensions = array<i64: 0>
   } : (tensor<16xf32>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_12_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_12_0.mlir
@@ -160,7 +160,7 @@ func.func @attr_fft_type_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomple
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 FFT>
     fft_type = #stablehlo<fft_type FFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }
@@ -170,7 +170,7 @@ func.func @attr_fft_type_ifft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcompl
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 IFFT>
     fft_type = #stablehlo<fft_type IFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }
@@ -180,7 +180,7 @@ func.func @attr_fft_type_rfft(%arg0: tensor<16xf32>) -> tensor<9xcomplex<f32>> {
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 RFFT>
     fft_type = #stablehlo<fft_type RFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xf32>) -> tensor<9xcomplex<f32>>
   func.return %0 : tensor<9xcomplex<f32>>
 }
@@ -190,7 +190,7 @@ func.func @attr_fft_type_irfft(%arg0: tensor<9xcomplex<f32>>) -> tensor<16xf32> 
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 IRFFT>
     fft_type = #stablehlo<fft_type IRFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<9xcomplex<f32>>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }
@@ -1317,7 +1317,7 @@ func.func @op_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>> {
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.complex_v1<!vhlo.f32_v1>>) -> !vhlo.tensor_v1<16x!vhlo.complex_v1<!vhlo.f32_v1>>
   %0 = "stablehlo.fft"(%arg0) {
     fft_type = #stablehlo<fft_type FFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_12_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_12_0.mlir
@@ -1906,9 +1906,9 @@ func.func @op_slice(%arg0: tensor<16xf32>) -> tensor<4xf32> {
   // CHECK-SAME:   strides = #vhlo.tensor_v1<dense<1> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<4x!vhlo.f32_v1>
   %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<0> : tensor<1xi64>,
-    limit_indices = dense<4> : tensor<1xi64>,
-    strides = dense<1> : tensor<1xi64>
+    start_indices = array<i64: 0>,
+    limit_indices = array<i64: 4>,
+    strides = array<i64: 1>
   } : (tensor<16xf32>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_12_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_12_0.mlir
@@ -1272,7 +1272,7 @@ func.func @op_dynamic_slice(%arg0: tensor<16xf32>, %arg1: tensor<i64>) -> tensor
   // CHECK-SAME:   slice_sizes = #vhlo.tensor_v1<dense<4> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.i64_v1>) -> !vhlo.tensor_v1<4x!vhlo.f32_v1>
   %0 = "stablehlo.dynamic_slice"(%arg0, %arg1) {
-    slice_sizes = dense<4> : tensor<1xi64>
+    slice_sizes = array<i64: 4>
   } : (tensor<16xf32>, tensor<i64>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_13_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_13_0.mlir
@@ -908,7 +908,7 @@ func.func @op_broadcast(%arg0: tensor<16xf32>) -> tensor<16x16xf32> {
   // CHECK-SAME:   broadcast_sizes = #vhlo.tensor_v1<dense<16> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x16x!vhlo.f32_v1>
   %0 = "stablehlo.broadcast"(%arg0) {
-    broadcast_sizes = dense<16> : tensor<1xi64>
+    broadcast_sizes = array<i64: 16>
   } : (tensor<16xf32>) -> tensor<16x16xf32>
   func.return %0 : tensor<16x16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_13_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_13_0.mlir
@@ -1985,7 +1985,7 @@ func.func @op_transpose(%arg0: tensor<16x8xf32>) ->  tensor<8x16xf32> {
   // CHECK-SAME:   permutation = #vhlo.tensor_v1<dense<[1, 0]> : tensor<2xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x8x!vhlo.f32_v1>) -> !vhlo.tensor_v1<8x16x!vhlo.f32_v1>
   %0 = "stablehlo.transpose"(%arg0) {
-    permutation = dense<[1, 0]> : tensor<2xi64>
+    permutation = array<i64: 1, 0>
   } : (tensor<16x8xf32>) -> tensor<8x16xf32>
   func.return %0 : tensor<8x16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_13_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_13_0.mlir
@@ -1550,9 +1550,9 @@ func.func @op_pad(%arg0: tensor<8xf32>, %arg1: tensor<f32>) -> tensor<16xf32> {
   // CHECK-SAME:   interior_padding = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<8x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<4> : tensor<1xi64>,
-    edge_padding_low = dense<4> : tensor<1xi64>,
-    interior_padding = dense<0> : tensor<1xi64>
+    edge_padding_high = array<i64: 4>,
+    edge_padding_low = array<i64: 4>,
+    interior_padding = array<i64: 0>
   } : (tensor<8xf32>, tensor<f32>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_13_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_13_0.mlir
@@ -1721,7 +1721,7 @@ func.func @op_reverse(%arg0: tensor<16xf32>) -> tensor<16xf32> {
   // CHECK-SAME:   dimensions = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.reverse"(%arg0) {
-    dimensions = dense<0> : tensor<1xi64>
+    dimensions = array<i64: 0>
   } : (tensor<16xf32>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_13_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_13_0.mlir
@@ -160,7 +160,7 @@ func.func @attr_fft_type_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomple
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 FFT>
     fft_type = #stablehlo<fft_type FFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }
@@ -170,7 +170,7 @@ func.func @attr_fft_type_ifft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcompl
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 IFFT>
     fft_type = #stablehlo<fft_type IFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }
@@ -180,7 +180,7 @@ func.func @attr_fft_type_rfft(%arg0: tensor<16xf32>) -> tensor<9xcomplex<f32>> {
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 RFFT>
     fft_type = #stablehlo<fft_type RFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xf32>) -> tensor<9xcomplex<f32>>
   func.return %0 : tensor<9xcomplex<f32>>
 }
@@ -190,7 +190,7 @@ func.func @attr_fft_type_irfft(%arg0: tensor<9xcomplex<f32>>) -> tensor<16xf32> 
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 IRFFT>
     fft_type = #stablehlo<fft_type IRFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<9xcomplex<f32>>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }
@@ -1317,7 +1317,7 @@ func.func @op_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>> {
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.complex_v1<!vhlo.f32_v1>>) -> !vhlo.tensor_v1<16x!vhlo.complex_v1<!vhlo.f32_v1>>
   %0 = "stablehlo.fft"(%arg0) {
     fft_type = #stablehlo<fft_type FFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_13_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_13_0.mlir
@@ -1906,9 +1906,9 @@ func.func @op_slice(%arg0: tensor<16xf32>) -> tensor<4xf32> {
   // CHECK-SAME:   strides = #vhlo.tensor_v1<dense<1> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<4x!vhlo.f32_v1>
   %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<0> : tensor<1xi64>,
-    limit_indices = dense<4> : tensor<1xi64>,
-    strides = dense<1> : tensor<1xi64>
+    start_indices = array<i64: 0>,
+    limit_indices = array<i64: 4>,
+    strides = array<i64: 1>
   } : (tensor<16xf32>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_13_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_13_0.mlir
@@ -1272,7 +1272,7 @@ func.func @op_dynamic_slice(%arg0: tensor<16xf32>, %arg1: tensor<i64>) -> tensor
   // CHECK-SAME:   slice_sizes = #vhlo.tensor_v1<dense<4> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.i64_v1>) -> !vhlo.tensor_v1<4x!vhlo.f32_v1>
   %0 = "stablehlo.dynamic_slice"(%arg0, %arg1) {
-    slice_sizes = dense<4> : tensor<1xi64>
+    slice_sizes = array<i64: 4>
   } : (tensor<16xf32>, tensor<i64>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_14_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_14_0.mlir
@@ -908,7 +908,7 @@ func.func @op_broadcast(%arg0: tensor<16xf32>) -> tensor<16x16xf32> {
   // CHECK-SAME:   broadcast_sizes = #vhlo.tensor_v1<dense<16> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x16x!vhlo.f32_v1>
   %0 = "stablehlo.broadcast"(%arg0) {
-    broadcast_sizes = dense<16> : tensor<1xi64>
+    broadcast_sizes = array<i64: 16>
   } : (tensor<16xf32>) -> tensor<16x16xf32>
   func.return %0 : tensor<16x16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_14_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_14_0.mlir
@@ -1985,7 +1985,7 @@ func.func @op_transpose(%arg0: tensor<16x8xf32>) ->  tensor<8x16xf32> {
   // CHECK-SAME:   permutation = #vhlo.tensor_v1<dense<[1, 0]> : tensor<2xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x8x!vhlo.f32_v1>) -> !vhlo.tensor_v1<8x16x!vhlo.f32_v1>
   %0 = "stablehlo.transpose"(%arg0) {
-    permutation = dense<[1, 0]> : tensor<2xi64>
+    permutation = array<i64: 1, 0>
   } : (tensor<16x8xf32>) -> tensor<8x16xf32>
   func.return %0 : tensor<8x16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_14_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_14_0.mlir
@@ -1550,9 +1550,9 @@ func.func @op_pad(%arg0: tensor<8xf32>, %arg1: tensor<f32>) -> tensor<16xf32> {
   // CHECK-SAME:   interior_padding = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<8x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<4> : tensor<1xi64>,
-    edge_padding_low = dense<4> : tensor<1xi64>,
-    interior_padding = dense<0> : tensor<1xi64>
+    edge_padding_high = array<i64: 4>,
+    edge_padding_low = array<i64: 4>,
+    interior_padding = array<i64: 0>
   } : (tensor<8xf32>, tensor<f32>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_14_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_14_0.mlir
@@ -1721,7 +1721,7 @@ func.func @op_reverse(%arg0: tensor<16xf32>) -> tensor<16xf32> {
   // CHECK-SAME:   dimensions = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.reverse"(%arg0) {
-    dimensions = dense<0> : tensor<1xi64>
+    dimensions = array<i64: 0>
   } : (tensor<16xf32>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_14_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_14_0.mlir
@@ -160,7 +160,7 @@ func.func @attr_fft_type_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomple
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 FFT>
     fft_type = #stablehlo<fft_type FFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }
@@ -170,7 +170,7 @@ func.func @attr_fft_type_ifft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcompl
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 IFFT>
     fft_type = #stablehlo<fft_type IFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }
@@ -180,7 +180,7 @@ func.func @attr_fft_type_rfft(%arg0: tensor<16xf32>) -> tensor<9xcomplex<f32>> {
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 RFFT>
     fft_type = #stablehlo<fft_type RFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xf32>) -> tensor<9xcomplex<f32>>
   func.return %0 : tensor<9xcomplex<f32>>
 }
@@ -190,7 +190,7 @@ func.func @attr_fft_type_irfft(%arg0: tensor<9xcomplex<f32>>) -> tensor<16xf32> 
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 IRFFT>
     fft_type = #stablehlo<fft_type IRFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<9xcomplex<f32>>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }
@@ -1317,7 +1317,7 @@ func.func @op_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>> {
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.complex_v1<!vhlo.f32_v1>>) -> !vhlo.tensor_v1<16x!vhlo.complex_v1<!vhlo.f32_v1>>
   %0 = "stablehlo.fft"(%arg0) {
     fft_type = #stablehlo<fft_type FFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_14_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_14_0.mlir
@@ -1906,9 +1906,9 @@ func.func @op_slice(%arg0: tensor<16xf32>) -> tensor<4xf32> {
   // CHECK-SAME:   strides = #vhlo.tensor_v1<dense<1> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<4x!vhlo.f32_v1>
   %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<0> : tensor<1xi64>,
-    limit_indices = dense<4> : tensor<1xi64>,
-    strides = dense<1> : tensor<1xi64>
+    start_indices = array<i64: 0>,
+    limit_indices = array<i64: 4>,
+    strides = array<i64: 1>
   } : (tensor<16xf32>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_14_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_14_0.mlir
@@ -1272,7 +1272,7 @@ func.func @op_dynamic_slice(%arg0: tensor<16xf32>, %arg1: tensor<i64>) -> tensor
   // CHECK-SAME:   slice_sizes = #vhlo.tensor_v1<dense<4> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.i64_v1>) -> !vhlo.tensor_v1<4x!vhlo.f32_v1>
   %0 = "stablehlo.dynamic_slice"(%arg0, %arg1) {
-    slice_sizes = dense<4> : tensor<1xi64>
+    slice_sizes = array<i64: 4>
   } : (tensor<16xf32>, tensor<i64>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_15_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_15_0.mlir
@@ -1558,9 +1558,9 @@ func.func @op_pad(%arg0: tensor<8xf32>, %arg1: tensor<f32>) -> tensor<16xf32> {
   // CHECK-SAME:   interior_padding = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<8x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<4> : tensor<1xi64>,
-    edge_padding_low = dense<4> : tensor<1xi64>,
-    interior_padding = dense<0> : tensor<1xi64>
+    edge_padding_high = array<i64: 4>,
+    edge_padding_low = array<i64: 4>,
+    interior_padding = array<i64: 0>
   } : (tensor<8xf32>, tensor<f32>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_15_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_15_0.mlir
@@ -1993,7 +1993,7 @@ func.func @op_transpose(%arg0: tensor<16x8xf32>) ->  tensor<8x16xf32> {
   // CHECK-SAME:   permutation = #vhlo.tensor_v1<dense<[1, 0]> : tensor<2xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x8x!vhlo.f32_v1>) -> !vhlo.tensor_v1<8x16x!vhlo.f32_v1>
   %0 = "stablehlo.transpose"(%arg0) {
-    permutation = dense<[1, 0]> : tensor<2xi64>
+    permutation = array<i64: 1, 0>
   } : (tensor<16x8xf32>) -> tensor<8x16xf32>
   func.return %0 : tensor<8x16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_15_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_15_0.mlir
@@ -1729,7 +1729,7 @@ func.func @op_reverse(%arg0: tensor<16xf32>) -> tensor<16xf32> {
   // CHECK-SAME:   dimensions = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.reverse"(%arg0) {
-    dimensions = dense<0> : tensor<1xi64>
+    dimensions = array<i64: 0>
   } : (tensor<16xf32>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_15_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_15_0.mlir
@@ -1280,7 +1280,7 @@ func.func @op_dynamic_slice(%arg0: tensor<16xf32>, %arg1: tensor<i64>) -> tensor
   // CHECK-SAME:   slice_sizes = #vhlo.tensor_v1<dense<4> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.i64_v1>) -> !vhlo.tensor_v1<4x!vhlo.f32_v1>
   %0 = "stablehlo.dynamic_slice"(%arg0, %arg1) {
-    slice_sizes = dense<4> : tensor<1xi64>
+    slice_sizes = array<i64: 4>
   } : (tensor<16xf32>, tensor<i64>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_15_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_15_0.mlir
@@ -168,7 +168,7 @@ func.func @attr_fft_type_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomple
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 FFT>
     fft_type = #stablehlo<fft_type FFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }
@@ -178,7 +178,7 @@ func.func @attr_fft_type_ifft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcompl
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 IFFT>
     fft_type = #stablehlo<fft_type IFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }
@@ -188,7 +188,7 @@ func.func @attr_fft_type_rfft(%arg0: tensor<16xf32>) -> tensor<9xcomplex<f32>> {
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 RFFT>
     fft_type = #stablehlo<fft_type RFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xf32>) -> tensor<9xcomplex<f32>>
   func.return %0 : tensor<9xcomplex<f32>>
 }
@@ -198,7 +198,7 @@ func.func @attr_fft_type_irfft(%arg0: tensor<9xcomplex<f32>>) -> tensor<16xf32> 
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 IRFFT>
     fft_type = #stablehlo<fft_type IRFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<9xcomplex<f32>>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }
@@ -1325,7 +1325,7 @@ func.func @op_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>> {
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.complex_v1<!vhlo.f32_v1>>) -> !vhlo.tensor_v1<16x!vhlo.complex_v1<!vhlo.f32_v1>>
   %0 = "stablehlo.fft"(%arg0) {
     fft_type = #stablehlo<fft_type FFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_15_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_15_0.mlir
@@ -916,7 +916,7 @@ func.func @op_broadcast(%arg0: tensor<16xf32>) -> tensor<16x16xf32> {
   // CHECK-SAME:   broadcast_sizes = #vhlo.tensor_v1<dense<16> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x16x!vhlo.f32_v1>
   %0 = "stablehlo.broadcast"(%arg0) {
-    broadcast_sizes = dense<16> : tensor<1xi64>
+    broadcast_sizes = array<i64: 16>
   } : (tensor<16xf32>) -> tensor<16x16xf32>
   func.return %0 : tensor<16x16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_15_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_15_0.mlir
@@ -1914,9 +1914,9 @@ func.func @op_slice(%arg0: tensor<16xf32>) -> tensor<4xf32> {
   // CHECK-SAME:   strides = #vhlo.tensor_v1<dense<1> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<4x!vhlo.f32_v1>
   %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<0> : tensor<1xi64>,
-    limit_indices = dense<4> : tensor<1xi64>,
-    strides = dense<1> : tensor<1xi64>
+    start_indices = array<i64: 0>,
+    limit_indices = array<i64: 4>,
+    strides = array<i64: 1>
   } : (tensor<16xf32>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_16_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_16_0.mlir
@@ -1291,7 +1291,7 @@ func.func @op_dynamic_slice(%arg0: tensor<16xf32>, %arg1: tensor<i64>) -> tensor
   // CHECK-SAME:   slice_sizes = #vhlo.tensor_v1<dense<4> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.i64_v1>) -> !vhlo.tensor_v1<4x!vhlo.f32_v1>
   %0 = "stablehlo.dynamic_slice"(%arg0, %arg1) {
-    slice_sizes = dense<4> : tensor<1xi64>
+    slice_sizes = array<i64: 4>
   } : (tensor<16xf32>, tensor<i64>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_16_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_16_0.mlir
@@ -2004,7 +2004,7 @@ func.func @op_transpose(%arg0: tensor<16x8xf32>) ->  tensor<8x16xf32> {
   // CHECK-SAME:   permutation = #vhlo.tensor_v1<dense<[1, 0]> : tensor<2xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x8x!vhlo.f32_v1>) -> !vhlo.tensor_v1<8x16x!vhlo.f32_v1>
   %0 = "stablehlo.transpose"(%arg0) {
-    permutation = dense<[1, 0]> : tensor<2xi64>
+    permutation = array<i64: 1, 0>
   } : (tensor<16x8xf32>) -> tensor<8x16xf32>
   func.return %0 : tensor<8x16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_16_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_16_0.mlir
@@ -1569,9 +1569,9 @@ func.func @op_pad(%arg0: tensor<8xf32>, %arg1: tensor<f32>) -> tensor<16xf32> {
   // CHECK-SAME:   interior_padding = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<8x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<4> : tensor<1xi64>,
-    edge_padding_low = dense<4> : tensor<1xi64>,
-    interior_padding = dense<0> : tensor<1xi64>
+    edge_padding_high = array<i64: 4>,
+    edge_padding_low = array<i64: 4>,
+    interior_padding = array<i64: 0>
   } : (tensor<8xf32>, tensor<f32>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_16_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_16_0.mlir
@@ -1740,7 +1740,7 @@ func.func @op_reverse(%arg0: tensor<16xf32>) -> tensor<16xf32> {
   // CHECK-SAME:   dimensions = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.reverse"(%arg0) {
-    dimensions = dense<0> : tensor<1xi64>
+    dimensions = array<i64: 0>
   } : (tensor<16xf32>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_16_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_16_0.mlir
@@ -1925,9 +1925,9 @@ func.func @op_slice(%arg0: tensor<16xf32>) -> tensor<4xf32> {
   // CHECK-SAME:   strides = #vhlo.tensor_v1<dense<1> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<4x!vhlo.f32_v1>
   %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<0> : tensor<1xi64>,
-    limit_indices = dense<4> : tensor<1xi64>,
-    strides = dense<1> : tensor<1xi64>
+    start_indices = array<i64: 0>,
+    limit_indices = array<i64: 4>,
+    strides = array<i64: 1>
   } : (tensor<16xf32>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_16_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_16_0.mlir
@@ -167,7 +167,7 @@ func.func @attr_fft_type_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomple
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 FFT>
     fft_type = #stablehlo<fft_type FFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }
@@ -177,7 +177,7 @@ func.func @attr_fft_type_ifft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcompl
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 IFFT>
     fft_type = #stablehlo<fft_type IFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }
@@ -187,7 +187,7 @@ func.func @attr_fft_type_rfft(%arg0: tensor<16xf32>) -> tensor<9xcomplex<f32>> {
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 RFFT>
     fft_type = #stablehlo<fft_type RFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xf32>) -> tensor<9xcomplex<f32>>
   func.return %0 : tensor<9xcomplex<f32>>
 }
@@ -197,7 +197,7 @@ func.func @attr_fft_type_irfft(%arg0: tensor<9xcomplex<f32>>) -> tensor<16xf32> 
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 IRFFT>
     fft_type = #stablehlo<fft_type IRFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<9xcomplex<f32>>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }
@@ -1336,7 +1336,7 @@ func.func @op_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>> {
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.complex_v1<!vhlo.f32_v1>>) -> !vhlo.tensor_v1<16x!vhlo.complex_v1<!vhlo.f32_v1>>
   %0 = "stablehlo.fft"(%arg0) {
     fft_type = #stablehlo<fft_type FFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_16_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_16_0.mlir
@@ -927,7 +927,7 @@ func.func @op_broadcast(%arg0: tensor<16xf32>) -> tensor<16x16xf32> {
   // CHECK-SAME:   broadcast_sizes = #vhlo.tensor_v1<dense<16> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x16x!vhlo.f32_v1>
   %0 = "stablehlo.broadcast"(%arg0) {
-    broadcast_sizes = dense<16> : tensor<1xi64>
+    broadcast_sizes = array<i64: 16>
   } : (tensor<16xf32>) -> tensor<16x16xf32>
   func.return %0 : tensor<16x16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_9_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_9_0.mlir
@@ -908,7 +908,7 @@ func.func @op_broadcast(%arg0: tensor<16xf32>) -> tensor<16x16xf32> {
   // CHECK-SAME:   broadcast_sizes = #vhlo.tensor_v1<dense<16> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x16x!vhlo.f32_v1>
   %0 = "stablehlo.broadcast"(%arg0) {
-    broadcast_sizes = dense<16> : tensor<1xi64>
+    broadcast_sizes = array<i64: 16>
   } : (tensor<16xf32>) -> tensor<16x16xf32>
   func.return %0 : tensor<16x16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_9_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_9_0.mlir
@@ -1985,7 +1985,7 @@ func.func @op_transpose(%arg0: tensor<16x8xf32>) ->  tensor<8x16xf32> {
   // CHECK-SAME:   permutation = #vhlo.tensor_v1<dense<[1, 0]> : tensor<2xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x8x!vhlo.f32_v1>) -> !vhlo.tensor_v1<8x16x!vhlo.f32_v1>
   %0 = "stablehlo.transpose"(%arg0) {
-    permutation = dense<[1, 0]> : tensor<2xi64>
+    permutation = array<i64: 1, 0>
   } : (tensor<16x8xf32>) -> tensor<8x16xf32>
   func.return %0 : tensor<8x16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_9_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_9_0.mlir
@@ -1550,9 +1550,9 @@ func.func @op_pad(%arg0: tensor<8xf32>, %arg1: tensor<f32>) -> tensor<16xf32> {
   // CHECK-SAME:   interior_padding = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<8x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<4> : tensor<1xi64>,
-    edge_padding_low = dense<4> : tensor<1xi64>,
-    interior_padding = dense<0> : tensor<1xi64>
+    edge_padding_high = array<i64: 4>,
+    edge_padding_low = array<i64: 4>,
+    interior_padding = array<i64: 0>
   } : (tensor<8xf32>, tensor<f32>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_9_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_9_0.mlir
@@ -1721,7 +1721,7 @@ func.func @op_reverse(%arg0: tensor<16xf32>) -> tensor<16xf32> {
   // CHECK-SAME:   dimensions = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.reverse"(%arg0) {
-    dimensions = dense<0> : tensor<1xi64>
+    dimensions = array<i64: 0>
   } : (tensor<16xf32>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_9_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_9_0.mlir
@@ -160,7 +160,7 @@ func.func @attr_fft_type_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomple
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 FFT>
     fft_type = #stablehlo<fft_type FFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }
@@ -170,7 +170,7 @@ func.func @attr_fft_type_ifft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcompl
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 IFFT>
     fft_type = #stablehlo<fft_type IFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }
@@ -180,7 +180,7 @@ func.func @attr_fft_type_rfft(%arg0: tensor<16xf32>) -> tensor<9xcomplex<f32>> {
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 RFFT>
     fft_type = #stablehlo<fft_type RFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xf32>) -> tensor<9xcomplex<f32>>
   func.return %0 : tensor<9xcomplex<f32>>
 }
@@ -190,7 +190,7 @@ func.func @attr_fft_type_irfft(%arg0: tensor<9xcomplex<f32>>) -> tensor<16xf32> 
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 IRFFT>
     fft_type = #stablehlo<fft_type IRFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<9xcomplex<f32>>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }
@@ -1317,7 +1317,7 @@ func.func @op_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>> {
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.complex_v1<!vhlo.f32_v1>>) -> !vhlo.tensor_v1<16x!vhlo.complex_v1<!vhlo.f32_v1>>
   %0 = "stablehlo.fft"(%arg0) {
     fft_type = #stablehlo<fft_type FFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_9_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_9_0.mlir
@@ -1906,9 +1906,9 @@ func.func @op_slice(%arg0: tensor<16xf32>) -> tensor<4xf32> {
   // CHECK-SAME:   strides = #vhlo.tensor_v1<dense<1> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<4x!vhlo.f32_v1>
   %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<0> : tensor<1xi64>,
-    limit_indices = dense<4> : tensor<1xi64>,
-    strides = dense<1> : tensor<1xi64>
+    start_indices = array<i64: 0>,
+    limit_indices = array<i64: 4>,
+    strides = array<i64: 1>
   } : (tensor<16xf32>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_9_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_9_0.mlir
@@ -1272,7 +1272,7 @@ func.func @op_dynamic_slice(%arg0: tensor<16xf32>, %arg1: tensor<i64>) -> tensor
   // CHECK-SAME:   slice_sizes = #vhlo.tensor_v1<dense<4> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.i64_v1>) -> !vhlo.tensor_v1<4x!vhlo.f32_v1>
   %0 = "stablehlo.dynamic_slice"(%arg0, %arg1) {
-    slice_sizes = dense<4> : tensor<1xi64>
+    slice_sizes = array<i64: 4>
   } : (tensor<16xf32>, tensor<i64>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
@@ -930,7 +930,7 @@ func.func @op_broadcast(%arg0: tensor<16xf32>) -> tensor<16x16xf32> {
   // CHECK-SAME:   broadcast_sizes = #vhlo.tensor_v1<dense<16> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x16x!vhlo.f32_v1>
   %0 = "stablehlo.broadcast"(%arg0) {
-    broadcast_sizes = dense<16> : tensor<1xi64>
+    broadcast_sizes = array<i64: 16>
   } : (tensor<16xf32>) -> tensor<16x16xf32>
   func.return %0 : tensor<16x16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
@@ -1294,7 +1294,7 @@ func.func @op_dynamic_slice(%arg0: tensor<16xf32>, %arg1: tensor<i64>) -> tensor
   // CHECK-SAME:   slice_sizes = #vhlo.tensor_v1<dense<4> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.i64_v1>) -> !vhlo.tensor_v1<4x!vhlo.f32_v1>
   %0 = "stablehlo.dynamic_slice"(%arg0, %arg1) {
-    slice_sizes = dense<4> : tensor<1xi64>
+    slice_sizes = array<i64: 4>
   } : (tensor<16xf32>, tensor<i64>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
@@ -1743,7 +1743,7 @@ func.func @op_reverse(%arg0: tensor<16xf32>) -> tensor<16xf32> {
   // CHECK-SAME:   dimensions = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.reverse"(%arg0) {
-    dimensions = dense<0> : tensor<1xi64>
+    dimensions = array<i64: 0>
   } : (tensor<16xf32>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
@@ -1928,9 +1928,9 @@ func.func @op_slice(%arg0: tensor<16xf32>) -> tensor<4xf32> {
   // CHECK-SAME:   strides = #vhlo.tensor_v1<dense<1> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.f32_v1>) -> !vhlo.tensor_v1<4x!vhlo.f32_v1>
   %0 = "stablehlo.slice"(%arg0) {
-    start_indices = dense<0> : tensor<1xi64>,
-    limit_indices = dense<4> : tensor<1xi64>,
-    strides = dense<1> : tensor<1xi64>
+    start_indices = array<i64: 0>,
+    limit_indices = array<i64: 4>,
+    strides = array<i64: 1>
   } : (tensor<16xf32>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
@@ -170,7 +170,7 @@ func.func @attr_fft_type_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomple
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 FFT>
     fft_type = #stablehlo<fft_type FFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }
@@ -180,7 +180,7 @@ func.func @attr_fft_type_ifft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcompl
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 IFFT>
     fft_type = #stablehlo<fft_type IFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }
@@ -190,7 +190,7 @@ func.func @attr_fft_type_rfft(%arg0: tensor<16xf32>) -> tensor<9xcomplex<f32>> {
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 RFFT>
     fft_type = #stablehlo<fft_type RFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xf32>) -> tensor<9xcomplex<f32>>
   func.return %0 : tensor<9xcomplex<f32>>
 }
@@ -200,7 +200,7 @@ func.func @attr_fft_type_irfft(%arg0: tensor<9xcomplex<f32>>) -> tensor<16xf32> 
   %0 = "stablehlo.fft"(%arg0) {
     // CHECK: fft_type = #vhlo<fft_type_v1 IRFFT>
     fft_type = #stablehlo<fft_type IRFFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<9xcomplex<f32>>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }
@@ -1339,7 +1339,7 @@ func.func @op_fft(%arg0: tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>> {
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x!vhlo.complex_v1<!vhlo.f32_v1>>) -> !vhlo.tensor_v1<16x!vhlo.complex_v1<!vhlo.f32_v1>>
   %0 = "stablehlo.fft"(%arg0) {
     fft_type = #stablehlo<fft_type FFT>,
-    fft_length = dense<16> : tensor<1xi64>
+    fft_length = array<i64: 16>
   } : (tensor<16xcomplex<f32>>) -> tensor<16xcomplex<f32>>
   func.return %0 : tensor<16xcomplex<f32>>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
@@ -2007,7 +2007,7 @@ func.func @op_transpose(%arg0: tensor<16x8xf32>) ->  tensor<8x16xf32> {
   // CHECK-SAME:   permutation = #vhlo.tensor_v1<dense<[1, 0]> : tensor<2xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<16x8x!vhlo.f32_v1>) -> !vhlo.tensor_v1<8x16x!vhlo.f32_v1>
   %0 = "stablehlo.transpose"(%arg0) {
-    permutation = dense<[1, 0]> : tensor<2xi64>
+    permutation = array<i64: 1, 0>
   } : (tensor<16x8xf32>) -> tensor<8x16xf32>
   func.return %0 : tensor<8x16xf32>
 }

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
@@ -1572,9 +1572,9 @@ func.func @op_pad(%arg0: tensor<8xf32>, %arg1: tensor<f32>) -> tensor<16xf32> {
   // CHECK-SAME:   interior_padding = #vhlo.tensor_v1<dense<0> : tensor<1xi64>>
   // CHECK-SAME: }> : (!vhlo.tensor_v1<8x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<16x!vhlo.f32_v1>
   %0 = "stablehlo.pad"(%arg0, %arg1) {
-    edge_padding_high = dense<4> : tensor<1xi64>,
-    edge_padding_low = dense<4> : tensor<1xi64>,
-    interior_padding = dense<0> : tensor<1xi64>
+    edge_padding_high = array<i64: 4>,
+    edge_padding_low = array<i64: 4>,
+    interior_padding = array<i64: 0>
   } : (tensor<8xf32>, tensor<f32>) -> tensor<16xf32>
   func.return %0 : tensor<16xf32>
 }

--- a/stablehlo/tests/stablehlo_refine_shapes.mlir
+++ b/stablehlo/tests/stablehlo_refine_shapes.mlir
@@ -415,9 +415,9 @@ func.func @eval_slice() -> tensor<2xi64> {
   // CHECK: return [[RESULT]]
   %0 = stablehlo.constant dense<[1, 2, 3, 4]> : tensor<4xi64>
   %1 = "stablehlo.slice"(%0) {
-    start_indices = dense<0> : tensor<1xi64>,
-    limit_indices = dense<2> : tensor<1xi64>,
-    strides = dense<1> : tensor<1xi64>
+    start_indices = array<i64: 0>,
+    limit_indices = array<i64: 2>,
+    strides = array<i64: 1>
   } : (tensor<4xi64>) -> tensor<2xi64>
   func.return %1 : tensor<2xi64>
 }

--- a/stablehlo/tests/verify_while.mlir
+++ b/stablehlo/tests/verify_while.mlir
@@ -28,7 +28,7 @@ func.func @while_dynamic(%arg0: tensor<3xf32>) -> tensor<*xf32> {
   %1:4 = "stablehlo.while"(%cst_0, %cst_1, %cst_2, %arg0) ({
   ^bb0(%arg1: tensor<1xi32>, %arg2: tensor<2xi32>, %arg3: tensor<1xf32>, %arg4: tensor<*xf32>):
     %2 = arith.constant dense<0> : tensor<i32>
-    %3 = "stablehlo.slice"(%arg2) {limit_indices = dense<[1]> : tensor<1xi64>, start_indices = dense<[0]> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<1xi32>
+    %3 = "stablehlo.slice"(%arg2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xi32>) -> tensor<1xi32>
     %4 = "stablehlo.compare"(%arg1, %3) {comparison_direction = #stablehlo<comparison_direction LT>} : (tensor<1xi32>, tensor<1xi32>) -> tensor<1xi1>
     %5 = "stablehlo.reshape"(%4) : (tensor<1xi1>) -> tensor<i1>
     "stablehlo.return"(%5) : (tensor<i1>) -> ()
@@ -51,7 +51,7 @@ func.func @while_unranked(%arg0: tensor<3xf32>) -> tensor<*xf32> {
   %1:4 = "stablehlo.while"(%cst_0, %cst_1, %cst_2, %arg0) ({
   ^bb0(%arg1: tensor<1xi32>, %arg2: tensor<2xi32>, %arg3: tensor<1xf32>, %arg4: tensor<*xf32>):
     %2 = arith.constant dense<0> : tensor<i32>
-    %3 = "stablehlo.slice"(%arg2) {limit_indices = dense<[1]> : tensor<1xi64>, start_indices = dense<[0]> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<1xi32>
+    %3 = "stablehlo.slice"(%arg2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xi32>) -> tensor<1xi32>
     %4 = "stablehlo.compare"(%arg1, %3) {comparison_direction = #stablehlo<comparison_direction LT>} : (tensor<1xi32>, tensor<1xi32>) -> tensor<1xi1>
     %5 = "stablehlo.select"(%4, %4, %4) : (tensor<1xi1>, tensor<1xi1>, tensor<1xi1>) -> tensor<*xi1>
     "stablehlo.return"(%5) : (tensor<*xi1>) -> ()
@@ -74,7 +74,7 @@ func.func @while_with_different_types(%arg0: tensor<3xf32>) -> tensor<3xf32> {
   %1:4 = "stablehlo.while"(%cst_0, %cst_1, %cst_2, %arg0) ({
   ^bb0(%arg1: tensor<1xi32>, %arg2: tensor<2xi32>, %arg3: tensor<1xf32>, %arg4: tensor<3xf32>):
     %2 = arith.constant dense<0> : tensor<i32>
-    %3 = "stablehlo.slice"(%arg2) {limit_indices = dense<[1]> : tensor<1xi64>, start_indices = dense<[0]> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<1xi32>
+    %3 = "stablehlo.slice"(%arg2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xi32>) -> tensor<1xi32>
     %4 = "stablehlo.compare"(%arg1, %3) {comparison_direction = #stablehlo<comparison_direction LT>} : (tensor<1xi32>, tensor<1xi32>) -> tensor<1xi1>
     %5 = "stablehlo.reshape"(%4) : (tensor<1xi1>) -> tensor<i1>
     "stablehlo.return"(%5) : (tensor<i1>) -> ()
@@ -97,7 +97,7 @@ func.func @while_c1(%arg0: tensor<3xf32>) -> tensor<3xf32> {
   %1:4 = "stablehlo.while"(%cst_0, %cst_1, %cst_2, %arg0) ({
   ^bb0(%arg1: tensor<1xi32>, %arg2: tensor<2xi32>, %arg3: tensor<3xf32>, %arg4: tensor<3xf32>):
     %2 = arith.constant dense<0> : tensor<i32>
-    %3 = "stablehlo.slice"(%arg2) {limit_indices = dense<[1]> : tensor<1xi64>, start_indices = dense<[0]> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<1xi32>
+    %3 = "stablehlo.slice"(%arg2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xi32>) -> tensor<1xi32>
     %4 = "stablehlo.compare"(%arg1, %3) {comparison_direction = #stablehlo<comparison_direction LT>} : (tensor<1xi32>, tensor<1xi32>) -> tensor<1xi1>
     %5 = "stablehlo.reshape"(%4) : (tensor<1xi1>) -> tensor<i1>
     "stablehlo.return"(%5) : (tensor<i1>) -> ()
@@ -120,7 +120,7 @@ func.func @while_c1(%arg0: tensor<3xf32>) -> tensor<3xf32> {
   %1:4 = "stablehlo.while"(%cst_0, %cst_1, %cst_2, %arg0) ({
   ^bb0(%arg1: tensor<1xi32>, %arg2: tensor<2xi32>, %arg3: tensor<1xf32>):
     %2 = arith.constant dense<0> : tensor<i32>
-    %3 = "stablehlo.slice"(%arg2) {limit_indices = dense<[1]> : tensor<1xi64>, start_indices = dense<[0]> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<1xi32>
+    %3 = "stablehlo.slice"(%arg2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xi32>) -> tensor<1xi32>
     %4 = "stablehlo.compare"(%arg1, %3) {comparison_direction = #stablehlo<comparison_direction LT>} : (tensor<1xi32>, tensor<1xi32>) -> tensor<1xi1>
     %5 = "stablehlo.reshape"(%4) : (tensor<1xi1>) -> tensor<i1>
     "stablehlo.return"(%5) : (tensor<i1>) -> ()
@@ -143,7 +143,7 @@ func.func @while_c1(%arg0: tensor<3xf32>) -> tensor<3xf32> {
   %1:4 = "stablehlo.while"(%cst_0, %cst_1, %cst_2, %arg0) ({
   ^bb0(%arg1: tensor<1xi32>, %arg2: tensor<2xi32>, %arg3: tensor<1xf32>, %arg4: tensor<3xf32>):
     %2 = arith.constant dense<0> : tensor<i32>
-    %3 = "stablehlo.slice"(%arg2) {limit_indices = dense<[1]> : tensor<1xi64>, start_indices = dense<[0]> : tensor<1xi64>, strides = dense<1> : tensor<1xi64>} : (tensor<2xi32>) -> tensor<1xi32>
+    %3 = "stablehlo.slice"(%arg2) {limit_indices = array<i64: 1>, start_indices = array<i64: 0>, strides = array<i64: 1>} : (tensor<2xi32>) -> tensor<1xi32>
     %4 = "stablehlo.compare"(%arg1, %3) {comparison_direction = #stablehlo<comparison_direction LT>} : (tensor<1xi32>, tensor<1xi32>) -> tensor<1xi1>
     %5 = "stablehlo.reshape"(%4) : (tensor<1xi1>) -> tensor<i1>
     "stablehlo.return"(%5, %5) : (tensor<i1>, tensor<i1>) -> ()

--- a/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
+++ b/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
@@ -270,8 +270,7 @@ struct CanonicalizeRealDynamicSliceOpToDynamicSliceOpPattern
     }
 
     rewriter.replaceOpWithNewOp<DynamicSliceOp>(
-        op, op.getType(), op.getOperand(), startIndices,
-        rewriter.getI64TensorAttr(sliceSizes));
+        op, op.getType(), op.getOperand(), startIndices, sliceSizes);
     return success();
   }
 };

--- a/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
+++ b/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
@@ -261,8 +261,7 @@ struct CanonicalizeRealDynamicSliceOpToDynamicSliceOpPattern
       auto startIndex1DType = RankedTensorType::get({1}, startIndexElementType);
       auto startIndex1D = rewriter.create<SliceOp>(
           op.getLoc(), startIndex1DType, op.getStartIndices(),
-          rewriter.getI64TensorAttr(i), rewriter.getI64TensorAttr(i + 1),
-          rewriter.getI64TensorAttr(1));
+          ArrayRef<int64_t>{i}, ArrayRef<int64_t>{i + 1}, ArrayRef<int64_t>{1});
       auto startIndex0DType = RankedTensorType::get({}, startIndexElementType);
       auto startIndex0D = rewriter.create<ReshapeOp>(
           op.getLoc(), startIndex0DType, startIndex1D);
@@ -289,11 +288,8 @@ struct CanonicalizeRealDynamicSliceOpToSliceOpPattern
       return rewriter.notifyMatchFailure(op, "expected static limit");
     if (!succeeded(hlo::matchInts(op.getStrides(), strides)))
       return rewriter.notifyMatchFailure(op, "expected static strides");
-    rewriter.replaceOpWithNewOp<SliceOp>(
-        op, op.getType(), op.getOperand(),
-        rewriter.getI64TensorAttr(startIndices),
-        rewriter.getI64TensorAttr(limitIndices),
-        rewriter.getI64TensorAttr(strides));
+    rewriter.replaceOpWithNewOp<SliceOp>(op, op.getType(), op.getOperand(),
+                                         startIndices, limitIndices, strides);
     return success();
   }
 };

--- a/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
+++ b/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
@@ -189,11 +189,9 @@ struct CanonicalizeDynamicPadOpPattern : public OpRewritePattern<DynamicPadOp> {
       return rewriter.notifyMatchFailure(op, "expected static high");
     if (!succeeded(hlo::matchInts(op.getInteriorPadding(), interiorPadding)))
       return rewriter.notifyMatchFailure(op, "expected static interior");
-    rewriter.replaceOpWithNewOp<PadOp>(
-        op, op.getType(), op.getOperand(), op.getPaddingValue(),
-        rewriter.getI64TensorAttr(edgePaddingLow),
-        rewriter.getI64TensorAttr(edgePaddingHigh),
-        rewriter.getI64TensorAttr(interiorPadding));
+    rewriter.replaceOpWithNewOp<PadOp>(op, op.getType(), op.getOperand(),
+                                       op.getPaddingValue(), edgePaddingLow,
+                                       edgePaddingHigh, interiorPadding);
     return success();
   }
 };

--- a/stablehlo/transforms/StablehloLegalizeToVhlo.cpp
+++ b/stablehlo/transforms/StablehloLegalizeToVhlo.cpp
@@ -142,6 +142,15 @@ Attribute convertGeneric(Attribute stablehloAttr,
     return vhlo::TensorV1Attr::get(attr.getContext(), vhloType,
                                    attr.getRawData());
   }
+  if (auto attr = stablehloAttr.dyn_cast<DenseI64ArrayAttr>()) {
+    auto vhloType = vhlo::RankedTensorV1Type::get(
+        attr.getContext(), {attr.size()},
+        vhlo::IntegerSI64V1Type::get(attr.getContext()), Attribute{});
+    LLVM_DEBUG(llvm::dbgs() << "Converted " << vhloType << '\n');
+    if (!vhloType) return {};
+    return vhlo::TensorV1Attr::get(attr.getContext(), vhloType,
+                                   attr.getRawData());
+  }
   if (auto attr = stablehloAttr.dyn_cast<DictionaryAttr>()) {
     SmallVector<std::pair<Attribute, Attribute>> vhloAttrs;
     for (auto namedAttr : attr.getValue()) {

--- a/stablehlo/transforms/StablehloLegalizeToVhlo.cpp
+++ b/stablehlo/transforms/StablehloLegalizeToVhlo.cpp
@@ -500,7 +500,7 @@ SpecialResult convertUseGlobalDeviceIds(
 
 template <typename StablehloOpTy>
 SpecialResult convertSpecial(const OpConversionPattern<StablehloOpTy>& pattern,
-                             StringRef stablehloName, Attribute stablehloAttr,
+                             StringAttr stablehloName, Attribute stablehloAttr,
                              SmallVector<NamedAttribute>& vhloAttrs) {
   if constexpr (std::is_same<StablehloOpTy, stablehlo::AllGatherOp>::value ||
                 std::is_same<StablehloOpTy, stablehlo::AllReduceOp>::value ||

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -849,10 +849,8 @@ struct RefineDynamicPadOpPattern : public OpRewritePattern<DynamicPadOp> {
     SmallVector<Type> inferredReturnTypes;
     if (failed(hlo::inferPadOp(
             /*location=*/{}, op.getOperand().getType(),
-            op.getPaddingValue().getType(),
-            rewriter.getI64TensorAttr(edgePaddingLow),
-            rewriter.getI64TensorAttr(edgePaddingHigh),
-            rewriter.getI64TensorAttr(interiorPadding), inferredReturnTypes)))
+            op.getPaddingValue().getType(), edgePaddingLow, edgePaddingHigh,
+            interiorPadding, inferredReturnTypes)))
       return rewriter.notifyMatchFailure(op, "inferPadOp failed");
     return refineReturnTypes(rewriter, op, inferredReturnTypes);
   }

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -394,9 +394,9 @@ struct EvalSliceOpPattern : public OpRewritePattern<SliceOp> {
     if (failed(hlo::matchInts(op.getOperand(), operand)))
       return rewriter.notifyMatchFailure(op, "expected constant operand");
 
-    int64_t start = op.getStartIndices().getValues<int64_t>()[0];
-    int64_t limit = op.getLimitIndices().getValues<int64_t>()[0];
-    int64_t stride = op.getStrides().getValues<int64_t>()[0];
+    int64_t start = op.getStartIndices()[0];
+    int64_t limit = op.getLimitIndices()[0];
+    int64_t stride = op.getStrides()[0];
     SmallVector<APSInt> result;
     for (auto i = start; i < limit; i += stride) {
       result.push_back(operand[i]);
@@ -906,9 +906,7 @@ struct RefineRealDynamicSliceOpPattern
         succeeded(hlo::matchInts(op.getStrides(), strides))) {
       SmallVector<Type> inferredReturnTypes;
       if (failed(hlo::inferSliceOp(/*location=*/{}, op.getOperand().getType(),
-                                   rewriter.getI64TensorAttr(startIndices),
-                                   rewriter.getI64TensorAttr(limitIndices),
-                                   rewriter.getI64TensorAttr(strides),
+                                   startIndices, limitIndices, strides,
                                    inferredReturnTypes)))
         return rewriter.notifyMatchFailure(op, "inferSliceOp failed");
       return refineReturnTypes(rewriter, op, inferredReturnTypes);

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -950,7 +950,7 @@ struct RefineRealDynamicSliceOpPattern
       SmallVector<ShapedTypeComponents> inferredReturnTypes;
       if (failed(hlo::inferDynamicSliceOp(
               op.getLoc(), op.getOperand().getType(), startIndicesTypes,
-              rewriter.getI64TensorAttr(sliceSizes), inferredReturnTypes)))
+              rewriter.getDenseI64ArrayAttr(sliceSizes), inferredReturnTypes)))
         return rewriter.notifyMatchFailure(op, "inferDynamicSliceOp failed");
       return refineReturnTypes(rewriter, op, inferredReturnTypes);
     }

--- a/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
+++ b/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
@@ -500,6 +500,11 @@ SpecialResult convertSpecial(const OpConversionPattern<VhloOpTy>& pattern,
     if (vhloName == "permutation")
       return convertDenseArray(vhloName, vhloAttr, stablehloAttrs);
   }
+  if constexpr (std::is_same<VhloOpTy, vhlo::PadOpV1>::value) {
+    if (vhloName == "edge_padding_low" || vhloName == "edge_padding_high" ||
+        vhloName == "interior_padding")
+      return convertDenseArray(vhloName, vhloAttr, stablehloAttrs);
+  }
   if constexpr (std::is_same<VhloOpTy, vhlo::SliceOpV1>::value) {
     if (vhloName == "start_indices" || vhloName == "limit_indices" ||
         vhloName == "strides")

--- a/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
+++ b/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
@@ -500,6 +500,11 @@ SpecialResult convertSpecial(const OpConversionPattern<VhloOpTy>& pattern,
     if (vhloName == "permutation")
       return convertDenseArray(vhloName, vhloAttr, stablehloAttrs);
   }
+  if constexpr (std::is_same<VhloOpTy, vhlo::SliceOpV1>::value) {
+    if (vhloName == "start_indices" || vhloName == "limit_indices" ||
+        vhloName == "strides")
+      return convertDenseArray(vhloName, vhloAttr, stablehloAttrs);
+  }
   return notSpecial();
 }
 

--- a/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
+++ b/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
@@ -484,6 +484,10 @@ SpecialResult convertSpecial(const OpConversionPattern<VhloOpTy>& pattern,
     if (vhloName == "fft_length")
       return convertDenseArray(vhloName, vhloAttr, stablehloAttrs);
   }
+  if constexpr (std::is_same<VhloOpTy, vhlo::TransposeOpV1>::value) {
+    if (vhloName == "permutation")
+      return convertDenseArray(vhloName, vhloAttr, stablehloAttrs);
+  }
   return notSpecial();
 }
 

--- a/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
+++ b/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
@@ -484,6 +484,10 @@ SpecialResult convertSpecial(const OpConversionPattern<VhloOpTy>& pattern,
     if (vhloName == "fft_length")
       return convertDenseArray(vhloName, vhloAttr, stablehloAttrs);
   }
+  if constexpr (std::is_same<VhloOpTy, vhlo::ReverseOpV1>::value) {
+    if (vhloName == "dimensions")
+      return convertDenseArray(vhloName, vhloAttr, stablehloAttrs);
+  }
   if constexpr (std::is_same<VhloOpTy, vhlo::TransposeOpV1>::value) {
     if (vhloName == "permutation")
       return convertDenseArray(vhloName, vhloAttr, stablehloAttrs);

--- a/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
+++ b/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
@@ -484,6 +484,10 @@ SpecialResult convertSpecial(const OpConversionPattern<VhloOpTy>& pattern,
     if (vhloName == "fft_length")
       return convertDenseArray(vhloName, vhloAttr, stablehloAttrs);
   }
+  if constexpr (std::is_same<VhloOpTy, vhlo::BroadcastOpV1>::value) {
+    if (vhloName == "broadcast_sizes")
+      return convertDenseArray(vhloName, vhloAttr, stablehloAttrs);
+  }
   if constexpr (std::is_same<VhloOpTy, vhlo::ReverseOpV1>::value) {
     if (vhloName == "dimensions")
       return convertDenseArray(vhloName, vhloAttr, stablehloAttrs);

--- a/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
+++ b/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
@@ -488,6 +488,10 @@ SpecialResult convertSpecial(const OpConversionPattern<VhloOpTy>& pattern,
     if (vhloName == "broadcast_sizes")
       return convertDenseArray(vhloName, vhloAttr, stablehloAttrs);
   }
+  if constexpr (std::is_same<VhloOpTy, vhlo::DynamicSliceOpV1>::value) {
+    if (vhloName == "slice_sizes")
+      return convertDenseArray(vhloName, vhloAttr, stablehloAttrs);
+  }
   if constexpr (std::is_same<VhloOpTy, vhlo::ReverseOpV1>::value) {
     if (vhloName == "dimensions")
       return convertDenseArray(vhloName, vhloAttr, stablehloAttrs);


### PR DESCRIPTION
This PR is based on #1658. I rebased the commits onto main, resolved conflicts, and made necessary changes to code that had been added since the last rebase.

Since I was getting a _lot_ of compilation failures after rebasing and I'm new to the project/MLIR, I decided to port each op one at a time and I gave each op its own commit. 

Porting slice op required a lot of changes to `testdata` files. I wrote a Python script that used a regex to make the replacements:

```
r'(.*?)"stablehlo.slice"(.*?){limit_indices = dense<([^>]+?)> : tensor<(\d)xi64>, start_indices = dense<([^>]+?)> : tensor<(\d)xi64>, strides = dense<([^>]+?)> : tensor<(\d)xi64>}( : .*)'
```

This change partially implements #1578.

**Special note for reviewers:** because I split the original commit into multiple commits, I don't know if authorship will be appropriately reflected (the original change was made by @joker-eph). Please advise.