### PR TITLE
Fix broken links

### DIFF
--- a/docs/reference_checklist.md
+++ b/docs/reference_checklist.md
@@ -14,9 +14,7 @@ on those fronts alongside the interpreter implementation.
    methods, and the corresponding tests. The reviewer will double check that the
    description is comprehensive.
 1. Consult
-   [hlo_evaluator](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/hlo/evaluator)
-   and
-   [mlir_interpreter](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/compiler/xla/mlir_hlo/tools/mlir_interpreter)
+   [hlo_evaluator](https://github.com/openxla/xla/blob/main/xla/hlo/evaluator)
    to identify tricky implementation details and potential functionality gaps.
 1. File tickets for the corresponding software components if you find any bugs
    or missing functionality.

--- a/docs/spec_checklist.md
+++ b/docs/spec_checklist.md
@@ -12,15 +12,15 @@ reviews:
      [Operation Semantics](https://www.tensorflow.org/xla/operation_semantics).
   1. Check whether the "Inputs" and "Outputs" sections:
       1. List the same items as the ODS.
-      1. List the same items as [HloInstruction::CreateFromProto](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/hlo/ir/hlo_instruction.cc).
+      1. List the same items as [HloInstruction::CreateFromProto](https://github.com/openxla/xla/blob/main/xla/hlo/ir/hlo_instruction.cc).
       1. Are ordered exactly like ODS.
       1. If there are any mismatches, check that there are corresponding
          tickets.
   1. Check whether the "Constraints" section:
       1. Matches XLA's
-         [shape_inference.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/service/shape_inference.cc).
+         [shape_inference.cc](https://github.com/openxla/xla/blob/main/xla/service/shape_inference.cc).
       1. Matches XLA's
-         [hlo_verifier.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/service/hlo_verifier.cc).
+         [hlo_verifier.cc](https://github.com/openxla/xla/blob/main/xla/service/hlo_verifier.cc).
       1. Matches the ODS.
       1. Matches
          [StablehloOps.cpp](https://github.com/openxla/stablehlo/blob/main/stablehlo/dialect/StablehloOps.cpp).

--- a/docs/status.md
+++ b/docs/status.md
@@ -19,7 +19,7 @@ one of the following tracking labels.
 - Generic labels
   - **yes**: there is a comprehensive implementation.
   - **no**: there is no implementation, but working on that is part of
-    [the roadmap](https://github.com/openxla/stablehlo#roadmap).
+    [the roadmap](https://github.com/openxla/stablehlo/blob/main/docs/roadmap.md).
     Note that Verifier can never be labeled as "no" because the ODS already
     implements some verification.
 - Customized labels for Verifier and Type Inference
@@ -28,8 +28,8 @@ one of the following tracking labels.
   - **yes\***: there is an implementation, and it's in sync with
     [XLA semantics](https://www.tensorflow.org/xla/operation_semantics).
     Since XLA semantics is oftentimes underdocumented, we are using
-    [hlo_verifier.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/service/hlo_verifier.cc)
-    and [shape_inference.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/service/shape_inference.cc)
+    [hlo_verifier.cc](https://github.com/openxla/xla/blob/main/xla/service/hlo_verifier.cc)
+    and [shape_inference.cc](https://github.com/openxla/xla/blob/main/xla/service/shape_inference.cc)
     as the reference.
   - **revisit**: there is an implementation, but it doesn't fall under "yes"
     or "yes\*" - either because we haven't audited it yet, or because we have

--- a/docs/type_inference.md
+++ b/docs/type_inference.md
@@ -22,8 +22,8 @@ existing verifiers and shape functions of every op need to be revisited to be
 fully aligned with the specification. Note that the specification document keeps
 evolving. In cases where the spec for an op is not available, the XLA
 implementation should be used as the source of truth instead, including
-[xla/service/shape\_inference.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/service/shape_inference.cc)
-and [xla/service/hlo\_verifier.cc](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/compiler/xla/service/hlo_verifier.cc).
+[xla/service/shape\_inference.cc](https://github.com/openxla/xla/blob/main/xla/service/shape_inference.cc)
+and [xla/service/hlo\_verifier.cc](https://github.com/openxla/xla/blob/main/xla/service/hlo_verifier.cc).
 The XLA implementation doesn't cover unbounded dynamism, so for unbounded
 dynamism we'll apply common sense until the dynamism RFC is available.
 


### PR DESCRIPTION
The roadmap is in its own document (it no longer has a header in the README) and some XLA stuff was moved out of tensorflow.

The XLA MLIR interpreter was deleted in https://github.com/tensorflow/tensorflow/commit/079ab56a5b0c5aefcdffa4f20f79c7bb137c6bd0.