### PR TITLE
Fix VHLO DenseI64Array bug and refactor shape refinement pass

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -890,6 +890,7 @@ cc_library(
     hdrs = [
         "stablehlo/transforms/MapStablehloToVhlo.h",
         "stablehlo/transforms/Passes.h",
+        "stablehlo/transforms/StablehloRefineShapes.h",
     ],
     strip_include_prefix = ".",
     deps = [

--- a/stablehlo/transforms/Passes.h
+++ b/stablehlo/transforms/Passes.h
@@ -18,9 +18,12 @@ limitations under the License.
 
 #include <memory>
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Quant/QuantOps.h"
 #include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir {
@@ -34,6 +37,14 @@ namespace stablehlo {
 #define GEN_PASS_DECL_VHLOTOVERSIONPASS
 #define GEN_PASS_REGISTRATION
 #include "stablehlo/transforms/Passes.h.inc"
+
+// Populates --stablehlo-canonicalize-dynamism patterns.
+void populateStablehloCanonicalizeDynamismPatterns(RewritePatternSet *patterns,
+                                                   MLIRContext *context);
+
+// Populates --stablehlo-refine-shapes patterns.
+void populateStablehloRefineShapesPatterns(RewritePatternSet *patterns,
+                                           MLIRContext *context);
 
 // Populates StableHLO ops to VHLO ops rewriting patterns.
 void populateStablehloToVhloPatterns(RewritePatternSet *patterns,

--- a/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
+++ b/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
@@ -307,16 +307,7 @@ struct StablehloCanonicalizeDynamismPass
     config.strictMode = GreedyRewriteStrictness::AnyOp;
 
     RewritePatternSet patterns(&getContext());
-    patterns.add<CanonicalizeCustomCallOpPattern>(&getContext());
-    patterns.add<CanonicalizeDynamicBroadcastInDimOpPattern>(&getContext());
-    patterns.add<CanonicalizeDynamicConvOpPattern>(&getContext());
-    patterns.add<CanonicalizeDynamicGatherOpPattern>(&getContext());
-    patterns.add<CanonicalizeDynamicIotaOpPattern>(&getContext());
-    patterns.add<CanonicalizeDynamicPadOpPattern>(&getContext());
-    patterns.add<CanonicalizeDynamicReshapeOpPattern>(&getContext());
-    patterns.add<CanonicalizeRealDynamicSliceOpToDynamicSliceOpPattern>(
-        &getContext());
-    patterns.add<CanonicalizeRealDynamicSliceOpToSliceOpPattern>(&getContext());
+    populateStablehloCanonicalizeDynamismPatterns(&patterns, &getContext());
     if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns),
                                             config))) {
       return signalPassFailure();
@@ -325,5 +316,19 @@ struct StablehloCanonicalizeDynamismPass
 };
 
 }  // namespace
+
+void populateStablehloCanonicalizeDynamismPatterns(RewritePatternSet* patterns,
+                                                   MLIRContext* context) {
+  patterns->add<CanonicalizeCustomCallOpPattern>(context);
+  patterns->add<CanonicalizeDynamicBroadcastInDimOpPattern>(context);
+  patterns->add<CanonicalizeDynamicConvOpPattern>(context);
+  patterns->add<CanonicalizeDynamicGatherOpPattern>(context);
+  patterns->add<CanonicalizeDynamicIotaOpPattern>(context);
+  patterns->add<CanonicalizeDynamicPadOpPattern>(context);
+  patterns->add<CanonicalizeDynamicReshapeOpPattern>(context);
+  patterns->add<CanonicalizeRealDynamicSliceOpToDynamicSliceOpPattern>(context);
+  patterns->add<CanonicalizeRealDynamicSliceOpToSliceOpPattern>(context);
+}
+
 }  // namespace stablehlo
 }  // namespace mlir

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -12,6 +12,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include "stablehlo/transforms/StablehloRefineShapes.h"
+
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -52,6 +54,193 @@ namespace stablehlo {
 
 #define GEN_PASS_DEF_STABLEHLOREFINESHAPESPASS
 #include "stablehlo/transforms/Passes.h.inc"
+
+LogicalResult refineValues(PatternRewriter& rewriter, Operation* op,
+                           ValueRange values, TypeRange types) {
+  if (values.size() != types.size())
+    return rewriter.notifyMatchFailure(op, [&](Diagnostic& diag) {
+      diag << "refineValues failed for " << types << ": expected "
+           << values.size() << " types, got " << types.size();
+    });
+
+  // Check whether `types` contain any new information with respect to existing
+  // return types. Even if just a single dimension size out of an entire tensor
+  // type got updated, using `inferMostSpecificType` ensures that we don't
+  // miss that.
+  bool needsRefinement = false;
+  SmallVector<Type> refinedTypes;
+  for (auto it : llvm::zip(values.getTypes(), types)) {
+    // Cannot use structured bindings to simplify this because capturing
+    // structured bindings in a lambda is a C++ 20 extension.
+    auto currentType = std::get<0>(it);
+    auto refinement = std::get<1>(it);
+    auto refinedType = hlo::inferMostSpecificType(
+        /*location=*/{}, {currentType, refinement});
+    if (failed(refinedType))
+      return rewriter.notifyMatchFailure(op, [&](Diagnostic& diag) {
+        diag << "inferMostSpecificType failed for " << currentType << " and "
+             << refinement;
+      });
+    refinedTypes.push_back(*refinedType);
+    needsRefinement |= (currentType != *refinedType);
+  }
+  if (!needsRefinement)
+    return rewriter.notifyMatchFailure(op, "doesn't need refinement");
+
+  for (auto it : llvm::zip(values, refinedTypes)) {
+    // Cannot use structured bindings to simplify this because capturing
+    // structured bindings in a lambda is a C++ 20 extension.
+    auto value = std::get<0>(it);
+    auto refinedType = std::get<1>(it);
+    if (value.getType() == refinedType) continue;
+
+    // Check whether the users of this value are ready for the type of the
+    // value to be refined.
+    for (Operation* user : value.getUsers()) {
+      // CHLO and StableHLO ops are designed to support type refinements of
+      // their operands and results. Any operand type in these ops can change
+      // within what's supported by `inferMostSpecificType` without breaking
+      // verification of the op.
+      if (isa<chlo::ChloDialect, StablehloDialect>(user->getDialect()))
+        continue;
+
+      // Simply changing operand type of `func.return` won't work because
+      // that won't update the FunctionType of the enclosing `func.func`.
+      // Nonetheless, we still want to support these ops because they are widely
+      // used in StableHLO programs (although the plan of record is to replace
+      // `func.return` ops in StableHLO programs with `stablehlo.return`:
+      // https://github.com/openxla/stablehlo/issues/425).
+      if (isa<func::ReturnOp>(user)) continue;
+
+      // Unlike in TensorFlow's type inference pass, here we work only with
+      // allowlisted ops to focus our support on well-defined semantics of
+      // StableHLO programs.
+      return rewriter.notifyMatchFailure(op, [&](Diagnostic& diag) {
+        diag << "unsupported refinement: tried to refine " << value.getType()
+             << " to " << refinedType << " for user " << user;
+      });
+    }
+
+    // Happy path: simply call setType here because most of our users are
+    // fine with that.
+    auto unrefinedType = value.getType();
+    value.setType(refinedType);
+
+    // Special case: for `func.return`, guard the refinement with a cast
+    // and leave propagation of the refined return type to a dedicated pattern.
+    auto isFuncReturn = [](OpOperand& use) -> bool {
+      return isa<func::ReturnOp>(use.getOwner());
+    };
+    if (llvm::none_of(value.getUses(), isFuncReturn)) continue;
+    rewriter.setInsertionPointAfter(op);
+    auto castToUnrefinedType = rewriter.create<UnrealizedConversionCastOp>(
+        op->getLoc(), unrefinedType, value);
+    value.replaceUsesWithIf(castToUnrefinedType.getOutputs()[0], isFuncReturn);
+  }
+
+  return success();
+}
+
+LogicalResult refineReturnTypes(PatternRewriter& rewriter, Operation* op,
+                                ArrayRef<Type> types) {
+  if (failed(refineValues(rewriter, op, op->getResults(), types)))
+    return failure();
+
+  // This `replaceOpWithIf` call doesn't actually change the IR, but
+  // it does ask the rewriter to visit all the users of this op. There is no
+  // upstream API to achieve this directly, but if it's introduced in the
+  // future, we could use it here.
+  rewriter.replaceOpWithIf(op, op->getResults(),
+                           [](OpOperand& use) { return false; });
+  return success();
+}
+
+LogicalResult refineReturnTypes(PatternRewriter& rewriter, Operation* op,
+                                ArrayRef<ShapedTypeComponents> refinements) {
+  SmallVector<Type> flattenedTypes;
+  hlo::flattenTupleTypes(op->getResultTypes(), flattenedTypes);
+  auto flattenedSize = flattenedTypes.size();
+  if (flattenedSize != refinements.size())
+    return rewriter.notifyMatchFailure(op, [&](Diagnostic& diag) {
+      diag << "refineReturnTypes failed: expected " << flattenedSize
+           << " refinements, got " << refinements.size();
+    });
+
+  SmallVector<Type> flattenedRefinedTypes;
+  for (auto it : llvm::zip(flattenedTypes, refinements)) {
+    // Cannot use structured bindings to simplify this because capturing
+    // structured bindings in a lambda is a C++ 20 extension.
+    ShapedType currentType = std::get<0>(it).dyn_cast<ShapedType>();
+    ShapedTypeComponents refinement = std::get<1>(it);
+    auto failWithReason = [&](StringRef reason) {
+      return rewriter.notifyMatchFailure(op, [&](Diagnostic& diag) {
+        diag << "refineTypes failed: refining " << currentType
+             << "with refinement: {";
+        if (refinement.hasRank()) {
+          diag << "shape = [" << refinement.getDims() << "]";
+          if (refinement.getAttribute())
+            diag << "attribute = " << refinement.getAttribute();
+        } else {
+          diag << "hasRank = false";
+        }
+        diag << ", elementType = " << refinement.getElementType();
+        diag << "} failed: " << reason;
+      });
+    };
+
+    // If the current type is not a shaped type, then the refinement must
+    // be completely empty.
+    if (!currentType) {
+      if (refinement.hasRank() || refinement.getElementType() ||
+          refinement.getAttribute())
+        return failWithReason("unsupported refinement");
+      flattenedRefinedTypes.push_back(currentType);
+      continue;
+    }
+
+    // If the refinement has an element type, then it must be the same as
+    // the current element type.
+    Type currentElementType = currentType.getElementType();
+    if (refinement.getElementType() &&
+        currentElementType != refinement.getElementType())
+      return failWithReason("expected compatible element types");
+
+    // If neither the current type nor the refinement are ranked, then there's
+    // nothing to refine, and we return the current type.
+    bool hasRank = currentType.hasRank() || refinement.hasRank();
+    if (!hasRank) {
+      flattenedRefinedTypes.push_back(currentType);
+      continue;
+    }
+
+    // If either the current type or the refinement have encodings, then
+    // we fail. Encodings are left for future work.
+    Attribute currentEncoding = nullptr;
+    if (auto currentRankedType = currentType.dyn_cast<RankedTensorType>()) {
+      currentEncoding = currentRankedType.getEncoding();
+    }
+    Attribute refinedEncoding = refinement.getAttribute();
+    if (currentEncoding || refinedEncoding)
+      return failWithReason("expected compatible encodings");
+
+    // If both the current type and the refinement have shapes, use the shape
+    // from the refinement. Otherwise, pick whatever is available.
+    // Make sure that the resulting type is compatible with the current type
+    // to avoid creating invalid code.
+    auto refinedShape =
+        refinement.hasRank() ? refinement.getDims() : currentType.getShape();
+    auto refinedType = RankedTensorType::get(refinedShape, currentElementType);
+    if (!hlo::isCompatibleForHloTypeInference(currentType, refinedType))
+      return failWithReason("expected compatible shapes");
+    flattenedRefinedTypes.push_back(refinedType);
+  }
+
+  SmallVector<Type> refinedTypes;
+  if (failed(hlo::unflattenTupleTypes(op->getResultTypes(),
+                                      flattenedRefinedTypes, refinedTypes)))
+    return failure();
+  return refineReturnTypes(rewriter, op, refinedTypes);
+}
 
 namespace {
 
@@ -421,245 +610,6 @@ struct EvalSubtractOpPattern : public OpRewritePattern<SubtractOp> {
 // In a nutshell, they use the upstream type inference infrastructure and a
 // StableHLO-specific extension to refine return types based on potentially
 // refined operands.
-
-// Refines the values using the given types.
-// Tricky implementation details:
-//   1) Need to support partial shape refinements, e.g. if just a single
-//      dimension size out of an entire tensor type got refined. This is done
-//      via inferMostSpecificType.
-//   2) Need to signal propagation of the refined shapes across the
-//      StableHLO program. Different callers of this function have different
-//      propagation needs, so this function doesn't signal anything on its own
-//      and leaves that to the callers.
-LogicalResult refineValues(PatternRewriter& rewriter, Operation* op,
-                           ValueRange values, TypeRange types) {
-  if (values.size() != types.size())
-    return rewriter.notifyMatchFailure(op, [&](Diagnostic& diag) {
-      diag << "refineValues failed for " << types << ": expected "
-           << values.size() << " types, got " << types.size();
-    });
-
-  // Check whether `types` contain any new information with respect to existing
-  // return types. Even if just a single dimension size out of an entire tensor
-  // type got updated, using `inferMostSpecificType` ensures that we don't
-  // miss that.
-  bool needsRefinement = false;
-  SmallVector<Type> refinedTypes;
-  for (auto it : llvm::zip(values.getTypes(), types)) {
-    // Cannot use structured bindings to simplify this because capturing
-    // structured bindings in a lambda is a C++ 20 extension.
-    auto currentType = std::get<0>(it);
-    auto refinement = std::get<1>(it);
-    auto refinedType = hlo::inferMostSpecificType(
-        /*location=*/{}, {currentType, refinement});
-    if (failed(refinedType))
-      return rewriter.notifyMatchFailure(op, [&](Diagnostic& diag) {
-        diag << "inferMostSpecificType failed for " << currentType << " and "
-             << refinement;
-      });
-    refinedTypes.push_back(*refinedType);
-    needsRefinement |= (currentType != *refinedType);
-  }
-  if (!needsRefinement)
-    return rewriter.notifyMatchFailure(op, "doesn't need refinement");
-
-  for (auto it : llvm::zip(values, refinedTypes)) {
-    // Cannot use structured bindings to simplify this because capturing
-    // structured bindings in a lambda is a C++ 20 extension.
-    auto value = std::get<0>(it);
-    auto refinedType = std::get<1>(it);
-    if (value.getType() == refinedType) continue;
-
-    // Check whether the users of this value are ready for the type of the
-    // value to be refined.
-    for (Operation* user : value.getUsers()) {
-      // CHLO and StableHLO ops are designed to support type refinements of
-      // their operands and results. Any operand type in these ops can change
-      // within what's supported by `inferMostSpecificType` without breaking
-      // verification of the op.
-      if (isa<chlo::ChloDialect, StablehloDialect>(user->getDialect()))
-        continue;
-
-      // Simply changing operand type of `func.return` won't work because
-      // that won't update the FunctionType of the enclosing `func.func`.
-      // Nonetheless, we still want to support these ops because they are widely
-      // used in StableHLO programs (although the plan of record is to replace
-      // `func.return` ops in StableHLO programs with `stablehlo.return`:
-      // https://github.com/openxla/stablehlo/issues/425).
-      if (isa<func::ReturnOp>(user)) continue;
-
-      // Unlike in TensorFlow's type inference pass, here we work only with
-      // allowlisted ops to focus our support on well-defined semantics of
-      // StableHLO programs.
-      return rewriter.notifyMatchFailure(op, [&](Diagnostic& diag) {
-        diag << "unsupported refinement: tried to refine " << value.getType()
-             << " to " << refinedType << " for user " << user;
-      });
-    }
-
-    // Happy path: simply call setType here because most of our users are
-    // fine with that.
-    auto unrefinedType = value.getType();
-    value.setType(refinedType);
-
-    // Special case: for `func.return`, guard the refinement with a cast
-    // and leave propagation of the refined return type to a dedicated pattern.
-    auto isFuncReturn = [](OpOperand& use) -> bool {
-      return isa<func::ReturnOp>(use.getOwner());
-    };
-    if (llvm::none_of(value.getUses(), isFuncReturn)) continue;
-    rewriter.setInsertionPointAfter(op);
-    auto castToUnrefinedType = rewriter.create<UnrealizedConversionCastOp>(
-        op->getLoc(), unrefinedType, value);
-    value.replaceUsesWithIf(castToUnrefinedType.getOutputs()[0], isFuncReturn);
-  }
-
-  return success();
-}
-
-// Refines the return types of the given operation using the given types.
-// This function also signals PatternRewriter that it needs to visit all the
-// users of this op if any updates to its results have happened during execution
-// of the function.
-LogicalResult refineReturnTypes(PatternRewriter& rewriter, Operation* op,
-                                ArrayRef<Type> types) {
-  if (failed(refineValues(rewriter, op, op->getResults(), types)))
-    return failure();
-
-  // This `replaceOpWithIf` call doesn't actually change the IR, but
-  // it does ask the rewriter to visit all the users of this op. There is no
-  // upstream API to achieve this directly, but if it's introduced in the
-  // future, we could use it here.
-  rewriter.replaceOpWithIf(op, op->getResults(),
-                           [](OpOperand& use) { return false; });
-  return success();
-}
-
-// Refines the return types of the given operation using the given types.
-// Tricky implementation details:
-//   1) `types` can include non-shaped types. If there are tuple types,
-//      then they are first flattened into non-tuple types using in-order
-//      traversal, and only then we apply the refinements. If there are other
-//      types, then the corresponding refinements must be completely empty.
-//   2) Encodings are not supported. In principle, TypeExtensions should be
-//      supportable, but this needs careful thinking through. Given that no one
-//      asked for support for bounded dynamism in this pass yet, this is left
-//      for future work.
-// This function also signals PatternRewriter that it needs to visit all the
-// users of this op if any updates to its results have happened during execution
-// of the function.
-LogicalResult refineReturnTypes(PatternRewriter& rewriter, Operation* op,
-                                ArrayRef<ShapedTypeComponents> refinements) {
-  SmallVector<Type> flattenedTypes;
-  hlo::flattenTupleTypes(op->getResultTypes(), flattenedTypes);
-  auto flattenedSize = flattenedTypes.size();
-  if (flattenedSize != refinements.size())
-    return rewriter.notifyMatchFailure(op, [&](Diagnostic& diag) {
-      diag << "refineReturnTypes failed: expected " << flattenedSize
-           << " refinements, got " << refinements.size();
-    });
-
-  SmallVector<Type> flattenedRefinedTypes;
-  for (auto it : llvm::zip(flattenedTypes, refinements)) {
-    // Cannot use structured bindings to simplify this because capturing
-    // structured bindings in a lambda is a C++ 20 extension.
-    ShapedType currentType = std::get<0>(it).dyn_cast<ShapedType>();
-    ShapedTypeComponents refinement = std::get<1>(it);
-    auto failWithReason = [&](StringRef reason) {
-      return rewriter.notifyMatchFailure(op, [&](Diagnostic& diag) {
-        diag << "refineTypes failed: refining " << currentType
-             << "with refinement: {";
-        if (refinement.hasRank()) {
-          diag << "shape = [" << refinement.getDims() << "]";
-          if (refinement.getAttribute())
-            diag << "attribute = " << refinement.getAttribute();
-        } else {
-          diag << "hasRank = false";
-        }
-        diag << ", elementType = " << refinement.getElementType();
-        diag << "} failed: " << reason;
-      });
-    };
-
-    // If the current type is not a shaped type, then the refinement must
-    // be completely empty.
-    if (!currentType) {
-      if (refinement.hasRank() || refinement.getElementType() ||
-          refinement.getAttribute())
-        return failWithReason("unsupported refinement");
-      flattenedRefinedTypes.push_back(currentType);
-      continue;
-    }
-
-    // If the refinement has an element type, then it must be the same as
-    // the current element type.
-    Type currentElementType = currentType.getElementType();
-    if (refinement.getElementType() &&
-        currentElementType != refinement.getElementType())
-      return failWithReason("expected compatible element types");
-
-    // If neither the current type nor the refinement are ranked, then there's
-    // nothing to refine, and we return the current type.
-    bool hasRank = currentType.hasRank() || refinement.hasRank();
-    if (!hasRank) {
-      flattenedRefinedTypes.push_back(currentType);
-      continue;
-    }
-
-    // If either the current type or the refinement have encodings, then
-    // we fail. Encodings are left for future work.
-    Attribute currentEncoding = nullptr;
-    if (auto currentRankedType = currentType.dyn_cast<RankedTensorType>()) {
-      currentEncoding = currentRankedType.getEncoding();
-    }
-    Attribute refinedEncoding = refinement.getAttribute();
-    if (currentEncoding || refinedEncoding)
-      return failWithReason("expected compatible encodings");
-
-    // If both the current type and the refinement have shapes, use the shape
-    // from the refinement. Otherwise, pick whatever is available.
-    // Make sure that the resulting type is compatible with the current type
-    // to avoid creating invalid code.
-    auto refinedShape =
-        refinement.hasRank() ? refinement.getDims() : currentType.getShape();
-    auto refinedType = RankedTensorType::get(refinedShape, currentElementType);
-    if (!hlo::isCompatibleForHloTypeInference(currentType, refinedType))
-      return failWithReason("expected compatible shapes");
-    flattenedRefinedTypes.push_back(refinedType);
-  }
-
-  SmallVector<Type> refinedTypes;
-  if (failed(hlo::unflattenTupleTypes(op->getResultTypes(),
-                                      flattenedRefinedTypes, refinedTypes)))
-    return failure();
-  return refineReturnTypes(rewriter, op, refinedTypes);
-}
-
-// Refines the return type of the given operation using the given shape.
-// This function also signals PatternRewriter that it needs to visit all the
-// users of this op if any updates to its results have happened during execution
-// of the function.
-template <typename OpType>
-LogicalResult refineReturnShape(PatternRewriter& rewriter, OpType op,
-                                ArrayRef<int64_t> shape) {
-  return refineReturnTypes(rewriter, op, ShapedTypeComponents(shape));
-}
-
-// Refines the return type of the given operation using the given shape.
-// This function also signals PatternRewriter that it needs to visit all the
-// users of this op if any updates to its results have happened during execution
-// of the function.
-template <typename OpType>
-LogicalResult refineReturnShape(PatternRewriter& rewriter, OpType op,
-                                Value shapeValue) {
-  // At the moment, we only support refining return types using fully static
-  // shape values which serves the current use cases well.
-  // Support for partially static shape values is left for future work.
-  SmallVector<int64_t> shape;
-  if (failed(hlo::matchInts(shapeValue, shape)))
-    return rewriter.notifyMatchFailure(op, "expected constant output shape");
-  return refineReturnShape(rewriter, op, shape);
-}
 
 struct RefineAllGatherOpPattern : public OpRewritePattern<AllGatherOp> {
   using OpRewritePattern::OpRewritePattern;
@@ -1115,39 +1065,8 @@ struct StablehloRefineShapesPass
   using StablehloRefineShapesPassBase::StablehloRefineShapesPassBase;
 
   void runOnOperation() override {
-    // Only one function per module is supported at the moment to avoid the need
-    // to think about iterative type inference algorithms.
-    // Current use cases are served well by inlining multiple functions into
-    // a single function, so we leave native support for multiple functions to
-    // future work.
-    // To enable modules that contain CustomCallOp::called_computations,
-    // we allow multiple functions, in which case we only refine the main
-    // function called "main", assuming that the called computations will have
-    // static shapes. Lifting this assumption and expanding refinement to
-    // multiple functions is left for future work.
-    ModuleOp module = getOperation();
-    auto funcs = llvm::to_vector(module.getOps<func::FuncOp>());
-    if (funcs.empty()) return;
-    func::FuncOp func;
-    if (funcs.size() == 1) {
-      func = funcs[0];
-    } else {
-      func = module.lookupSymbol<func::FuncOp>("main");
-    }
-    if (!func) {
-      module.emitOpError()
-          << "must have no more than one function or a `main`"
-          << " function to clearly identify which function will be refined";
-      return signalPassFailure();
-    }
-
-    // Similarly, only one block per function is supported at the moment.
-    // At the StableHLO level, functions are expected to only have one block,
-    // so supporting more is out of scope for this pass.
-    if (!func.getRegion().hasOneBlock()) {
-      func.emitOpError() << "must have exactly one block";
-      return signalPassFailure();
-    }
+    auto func = getStablehloRefineShapesTarget(getOperation());
+    if (!func) return signalPassFailure();
 
     // The algorithm behind this pass consists of a single traversal of the
     // function. This is sufficient because we only support one function per
@@ -1163,44 +1082,7 @@ struct StablehloRefineShapesPass
     config.strictMode = GreedyRewriteStrictness::AnyOp;
 
     RewritePatternSet patterns(&getContext());
-    patterns.add<EvalAddOpPattern>(&getContext());
-    patterns.add<EvalAndOpPattern>(&getContext());
-    patterns.add<EvalBroadcastInDimOpPattern>(&getContext());
-    patterns.add<EvalClampOpPattern>(&getContext());
-    patterns.add<EvalCompareOpPattern>(&getContext());
-    patterns.add<EvalConcatenateOpPattern>(&getContext());
-    patterns.add<EvalConvertOpPattern>(&getContext());
-    patterns.add<EvalDivOpPattern>(&getContext());
-    patterns.add<EvalGetDimensionSizeOpPattern>(&getContext());
-    patterns.add<EvalMaxOpPattern>(&getContext());
-    patterns.add<EvalMinOpPattern>(&getContext());
-    patterns.add<EvalMulOpPattern>(&getContext());
-    patterns.add<EvalOrOpPattern>(&getContext());
-    patterns.add<EvalRemOpPattern>(&getContext());
-    patterns.add<EvalReshapeOpPattern>(&getContext());
-    patterns.add<EvalSelectOpPattern>(&getContext());
-    patterns.add<EvalSignOpPattern>(&getContext());
-    patterns.add<EvalSliceOpPattern>(&getContext());
-    patterns.add<EvalSubtractOpPattern>(&getContext());
-    patterns.add<RefineAllGatherOpPattern>(&getContext());
-    patterns.add<RefineBitcastConvertOpPattern>(&getContext());
-    patterns.add<RefineConvertOpPattern>(&getContext());
-    patterns.add<RefineConvolutionOpPattern>(&getContext());
-    patterns.add<RefineCustomCallOpPattern>(&getContext());
-    patterns.add<RefineDotGeneralOpPattern>(&getContext());
-    patterns.add<RefineDynamicBroadcastInDimOpPattern>(&getContext());
-    patterns.add<RefineDynamicConvOpPattern>(&getContext());
-    patterns.add<RefineDynamicIotaOpPattern>(&getContext());
-    patterns.add<RefineDynamicPadOpPattern>(&getContext());
-    patterns.add<RefineDynamicReshapeOpPattern>(&getContext());
-    patterns.add<RefineInferTypeOpInterfacePattern>(&getContext());
-    patterns.add<RefineRealDynamicSliceOpPattern>(&getContext());
-    patterns.add<RefineReduceScatterOpPattern>(&getContext());
-    patterns.add<RefineRngOpPattern>(&getContext());
-    patterns.add<RefineUniformQuantizeOpPattern>(&getContext());
-    patterns.add<RefineWhileOpPattern>(&getContext());
-    patterns.add<UpdateFunctionTypePattern>(&getContext());
-    patterns.add<UpdateRegionTypePattern>(&getContext());
+    populateStablehloRefineShapesPatterns(&patterns, &getContext());
     if (failed(
             applyPatternsAndFoldGreedily(func, std::move(patterns), config))) {
       return signalPassFailure();
@@ -1209,5 +1091,86 @@ struct StablehloRefineShapesPass
 };
 
 }  // namespace
+
+func::FuncOp getStablehloRefineShapesTarget(ModuleOp module) {
+  // Only one function per module is supported at the moment to avoid the need
+  // to think about iterative type inference algorithms.
+  // Current use cases are served well by inlining multiple functions into
+  // a single function, so we leave native support for multiple functions to
+  // future work.
+  // To enable modules that contain CustomCallOp::called_computations,
+  // we allow multiple functions, in which case we only refine the main
+  // function called "main", assuming that the called computations will have
+  // static shapes. Lifting this assumption and expanding refinement to
+  // multiple functions is left for future work.
+  auto funcs = llvm::to_vector(module.getOps<func::FuncOp>());
+  if (funcs.empty()) return nullptr;
+
+  func::FuncOp result;
+  if (funcs.size() == 1) {
+    result = funcs[0];
+  } else {
+    result = module.lookupSymbol<func::FuncOp>("main");
+  }
+  if (!result) {
+    module.emitOpError()
+        << "must have no more than one function or a `main`"
+        << " function to clearly identify which function will be refined";
+    return nullptr;
+  }
+
+  // Similarly, only one block per function is supported at the moment.
+  // At the StableHLO level, functions are expected to only have one block,
+  // so supporting more is out of scope for this pass.
+  if (!result.getRegion().hasOneBlock()) {
+    result.emitOpError() << "must have exactly one block";
+    return nullptr;
+  }
+
+  return result;
+}
+
+void populateStablehloRefineShapesPatterns(RewritePatternSet* patterns,
+                                           MLIRContext* context) {
+  patterns->add<EvalAddOpPattern>(context);
+  patterns->add<EvalAndOpPattern>(context);
+  patterns->add<EvalBroadcastInDimOpPattern>(context);
+  patterns->add<EvalClampOpPattern>(context);
+  patterns->add<EvalCompareOpPattern>(context);
+  patterns->add<EvalConcatenateOpPattern>(context);
+  patterns->add<EvalConvertOpPattern>(context);
+  patterns->add<EvalDivOpPattern>(context);
+  patterns->add<EvalGetDimensionSizeOpPattern>(context);
+  patterns->add<EvalMaxOpPattern>(context);
+  patterns->add<EvalMinOpPattern>(context);
+  patterns->add<EvalMulOpPattern>(context);
+  patterns->add<EvalOrOpPattern>(context);
+  patterns->add<EvalRemOpPattern>(context);
+  patterns->add<EvalReshapeOpPattern>(context);
+  patterns->add<EvalSelectOpPattern>(context);
+  patterns->add<EvalSignOpPattern>(context);
+  patterns->add<EvalSliceOpPattern>(context);
+  patterns->add<EvalSubtractOpPattern>(context);
+  patterns->add<RefineAllGatherOpPattern>(context);
+  patterns->add<RefineBitcastConvertOpPattern>(context);
+  patterns->add<RefineConvertOpPattern>(context);
+  patterns->add<RefineConvolutionOpPattern>(context);
+  patterns->add<RefineCustomCallOpPattern>(context);
+  patterns->add<RefineDotGeneralOpPattern>(context);
+  patterns->add<RefineDynamicBroadcastInDimOpPattern>(context);
+  patterns->add<RefineDynamicConvOpPattern>(context);
+  patterns->add<RefineDynamicIotaOpPattern>(context);
+  patterns->add<RefineDynamicPadOpPattern>(context);
+  patterns->add<RefineDynamicReshapeOpPattern>(context);
+  patterns->add<RefineInferTypeOpInterfacePattern>(context);
+  patterns->add<RefineRealDynamicSliceOpPattern>(context);
+  patterns->add<RefineReduceScatterOpPattern>(context);
+  patterns->add<RefineRngOpPattern>(context);
+  patterns->add<RefineUniformQuantizeOpPattern>(context);
+  patterns->add<RefineWhileOpPattern>(context);
+  patterns->add<UpdateFunctionTypePattern>(context);
+  patterns->add<UpdateRegionTypePattern>(context);
+}
+
 }  // namespace stablehlo
 }  // namespace mlir

--- a/stablehlo/transforms/StablehloRefineShapes.h
+++ b/stablehlo/transforms/StablehloRefineShapes.h
@@ -1,0 +1,102 @@
+/* Copyright 2022 The StableHLO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef STABLEHLO_TRANSFORMS_STABLEHLO_REFINE_SHAPES_H
+#define STABLEHLO_TRANSFORMS_STABLEHLO_REFINE_SHAPES_H
+
+#include "llvm/ADT/SmallVector.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Support/LogicalResult.h"
+#include "stablehlo/dialect/Base.h"
+
+namespace mlir {
+namespace stablehlo {
+
+// Gets a FuncOp that --stablehlo-refine-shapes will run on.
+// Returns a nullptr and emits appropriate errors if such a function cannot
+// be obtained from the module.
+func::FuncOp getStablehloRefineShapesTarget(ModuleOp module);
+
+// Refines the values using the given types.
+// Tricky implementation details:
+//   1) Need to support partial shape refinements, e.g. if just a single
+//      dimension size out of an entire tensor type got refined. This is done
+//      via inferMostSpecificType.
+//   2) Need to signal propagation of the refined shapes across the
+//      StableHLO program. Different callers of this function have different
+//      propagation needs, so this function doesn't signal anything on its own
+//      and leaves that to the callers.
+LogicalResult refineValues(PatternRewriter& rewriter, Operation* op,
+                           ValueRange values, TypeRange types);
+
+// Refines the return types of the given operation using the given types.
+// This function also signals PatternRewriter that it needs to visit all the
+// users of this op if any updates to its results have happened during execution
+// of the function.
+LogicalResult refineReturnTypes(PatternRewriter& rewriter, Operation* op,
+                                ArrayRef<Type> types);
+
+// Refines the return types of the given operation using the given types.
+// Tricky implementation details:
+//   1) `types` can include non-shaped types. If there are tuple types,
+//      then they are first flattened into non-tuple types using in-order
+//      traversal, and only then we apply the refinements. If there are other
+//      types, then the corresponding refinements must be completely empty.
+//   2) Encodings are not supported. In principle, TypeExtensions should be
+//      supportable, but this needs careful thinking through. Given that no one
+//      asked for support for bounded dynamism in this pass yet, this is left
+//      for future work.
+// This function also signals PatternRewriter that it needs to visit all the
+// users of this op if any updates to its results have happened during execution
+// of the function.
+LogicalResult refineReturnTypes(PatternRewriter& rewriter, Operation* op,
+                                ArrayRef<ShapedTypeComponents> refinements);
+
+// Refines the return type of the given operation using the given shape.
+// This function also signals PatternRewriter that it needs to visit all the
+// users of this op if any updates to its results have happened during execution
+// of the function.
+template <typename OpType>
+LogicalResult refineReturnShape(PatternRewriter& rewriter, OpType op,
+                                ArrayRef<int64_t> shape) {
+  return refineReturnTypes(rewriter, op, ShapedTypeComponents(shape));
+}
+
+// Refines the return type of the given operation using the given shape.
+// This function also signals PatternRewriter that it needs to visit all the
+// users of this op if any updates to its results have happened during execution
+// of the function.
+template <typename OpType>
+LogicalResult refineReturnShape(PatternRewriter& rewriter, OpType op,
+                                Value shapeValue) {
+  // At the moment, we only support refining return types using fully static
+  // shape values which serves the current use cases well.
+  // Support for partially static shape values is left for future work.
+  SmallVector<int64_t> shape;
+  if (failed(hlo::matchInts(shapeValue, shape)))
+    return rewriter.notifyMatchFailure(op, "expected constant output shape");
+  return refineReturnShape(rewriter, op, shape);
+}
+
+}  // namespace stablehlo
+}  // namespace mlir
+
+#endif  // STABLEHLO_TRANSFORMS_STABLEHLO_REFINE_SHAPES_H


### PR DESCRIPTION
VHLO bug: `DenseI64ArrayAttr` doesn't have a notion of splats like `DenseIntElementsAttr` does. The following array when serialized as as the VHLO wrapper around `DenseIntElementsAttr` could not be converted to `DenseI64ArrayAttr` properly:

```
dense<0> : tensor<2xi64>
vs
array<i64: 0, 0>
```

There the value that gets serialized is just `0`. When converting to `DenseI64ArrayAttr` must look at the type and see if the splat should be expanded. This isn't a huge memory issue since these attrs are only used in cases where the number of values in the array is small.

Shape refinement: Refactor into a header file with some patterns that can be populated, instead of a single API entrypoint.