### PR TITLE
Dynamism RFC

### DIFF
--- a/rfcs/20230704-dynamism-101.md
+++ b/rfcs/20230704-dynamism-101.md
@@ -17,7 +17,7 @@ the following:
 * [(P2) Ratify the existing convention for shape mismatches constituting undefined behavior](#p2).
 * [(P3) Ratify the existing convention for relaxed constraints already implemented in the StableHLO dialect](#p3).
 * [(P4) Enable shape-dependent dynamism for all size-related program elements but keep all axis-related program elements static](#p4).
-* [(P5) Represent shape computations as StableHLO operations on 0-dimensional tensors and drop support for unranked dynamism](#p5).
+* [(P5) Represent shape computations as StableHLO operations on variadic 0-dimensional tensors and drop support for unranked dynamism](#p5).
 <!-- markdownlint-enable line-length -->
 
 These proposals address a considerable chunk of community feedback on the
@@ -522,7 +522,7 @@ ops like `DynamicPadOp` has some drawbacks, which are denoted in [O7](#o7) as
 out of scope for this RFC.
 
 <!-- markdownlint-disable line-length -->
-## <a id="p5" /> (P5) Represent shape computations as StableHLO operations on 0-dimensional tensors and drop support for unranked dynamism
+## <a id="p5" /> (P5) Represent shape computations as StableHLO operations on variadic 0-dimensional tensors and drop support for unranked dynamism
 <!-- markdownlint-enable line-length -->
 
 **Baseline:** The StableHLO dialect represents sizes as 1-dimensional tensors,
@@ -565,8 +565,9 @@ then reshaped to 1-dimensional tensors and then concatenated together
 ([example](https://github.com/tensorflow/mlir-hlo/blob/1fd13ef28d3f423363e59b1a80eb2c26e0c0979d/mhlo/transforms/chlo_legalize_to_hlo/chlo_legalize_to_hlo.cc#L1577-L1587)).
 
 **Proposal:** The RFC proposes to standardize on representing shape computations
-as StableHLO operations working 0-dimensional tensors. More specifically,
-the proposal is to:
+as StableHLO operations working 0-dimensional tensors, changing from using a
+single operand of `tensor<Nxi64>` to using `N` operands of `tensor<i64>`. More
+specifically, the proposal is to:
 
 1) Affirm that only shape computations that use StableHLO operations are
    supported in StableHLO portable artifacts (this can be changed in future
@@ -643,7 +644,8 @@ appears to be TensorFlow, and TensorFlow can encapsulate handling unranked
 dynamism in a different layer, so overall this proposal looks like an
 improvement - it does require a non-trivial refactoring in one user, but in
 return it simplifies the StableHLO specification and implementation for
-everyone.
+everyone. The ops of concern in TF are `StridedSlice`, `Reshape`, and `Squeeze`,
+and it appears that interop between these ops and StableHLO is not required.
 
 B\) As discussed in [O2](#o2), the community is oftentimes using other dialects,
 including `arith` and `shape`, for shape computations. These dialects can be

--- a/rfcs/20230704-dynamism-101.md
+++ b/rfcs/20230704-dynamism-101.md
@@ -1,0 +1,826 @@
+# RFC: Dynamism 101
+
+Status: Under review<br/>
+Initial version: 7/4/2023<br/>
+Last updated: 7/4/2023<br/>
+Discussion thread: [openxla-discuss](https://groups.google.com/a/openxla.org/g/openxla-discuss/c/HJRvFBum65k/m/7QtJxgB9AQAJ).
+
+## Summary
+
+This RFC aims to leverage existing support for dynamism in the StableHLO
+dialect, discuss improvements to the existing design and then formalize the
+improved design in the StableHLO opset. To that end, this document proposes
+the following:
+
+<!-- markdownlint-disable line-length -->
+* [(P1) Move TensorFlow-specific operations out of StableHLO](#p1).
+* [(P2) Ratify the existing convention for shape mismatches constituting undefined behavior](#p2).
+* [(P3) Ratify the existing convention for relaxed constraints already implemented in the StableHLO dialect](#p3).
+* [(P4) Enable dynamism for all size-related program elements but keep all axis-related program elements static](#p4).
+* [(P5) Unify static and dynamic versions of StableHLO operations](#p5).
+* [(P6) Represent shape computations as StableHLO operations on 0-dimensional tensors and drop support for unranked dynamism](#p6).
+<!-- markdownlint-enable line-length -->
+
+These proposals address a considerable chunk of community feedback on the
+existing design, but some feedback is deliberately left out of scope for this
+RFC to enable incremental progress while areas which require additional
+alignment are developed in parallel. See sections
+["Community feedback"](#community-feedback) and
+["Out of scope"](#out-of-scope) for details.
+
+## Existing design
+
+This is an RFC that affects the entirety of the StableHLO opset, and there are
+multiple groups of operations which are affected differently. Taking into
+account all these operations appropriately was quite laborious, but
+[the StableHLO Ops spreadsheet](https://docs.google.com/spreadsheets/d/1rvhxQMFUtCZ5DsY6X0_lJOCg9rVO2MdyeZlRorsc0UI/edit?resourcekey=0-5gMjnlkXDL6hCntv2yltaQ#gid=0)
+was a big help. Referring to this spreadsheet will likely help in reviewing this
+RFC as well.
+
+Before beginning, let's align on terminology. In discussions around MLIR, it is
+fairly conventional to use the word "dimension" ambiguously - to refer to either
+an actual dimension or the size of a dimension. Most of the time, the exact
+meaning of the word "dimension" is clear from the context, but sometimes it's
+ambiguous. For example, it is not obvious whether
+`mlir::ShapedTypeComponents::getDims` returns dimension numbers or dimension
+sizes (for what it's worth, it is the latter - it returns dimension sizes).
+
+To avoid ambiguity, this document will be using the following terminology:
+
+* **Dimension numbers** (or **axes**) to refer to actual dimensions,
+  e.g. "`tensor<16x?xf32>` has two axes".
+* **Dimension sizes** (or **sizes**) to refer to sizes of dimensions,
+  e.g. "`tensor<16x?xf32>` has the following dimension sizes: 16 and unknown".
+* Unqualified "dimension" will not be used at all.
+
+By the virtue of being bootstrapped from MHLO, the StableHLO dialect already
+has support for **dynamism within types**:
+
+* **Unbounded dynamism**: In a tensor type, some or all dimension sizes may be
+  unknown (aka "dynamic"). In MLIR syntax, these dimension sizes are expressed
+  via question marks.
+* **Bounded dynamism**: The same but some of dynamic dimensions sizes may have
+  known upper bounds. In MLIR syntax, these dimension sizes are expressed via
+  question marks, and bounds are expressed via `#stablehlo.bounds`.
+* **Unranked dynamism**: In a tensor type, rank may be unknown. In MLIR
+  syntax, this fact is expressed via asterisks.
+
+```mlir
+// Static shapes:
+// All dimension sizes are known.
+%0 = stablehlo.add %arg0, %arg1 : tensor<16x16xf32>
+
+// Unbounded dynamism:
+// First dimension size is unknown (?).
+// Second dimension size is known (16).
+%1 = stablehlo.add %arg0, %arg1 : tensor<?x16xf32>
+
+// Bounded dynamism:
+// First dimension size is unknown (?), but its bound is known (16).
+// Second dimension size is known (16), so its bound is N/A (?).
+%2 = stablehlo.add %arg0, %arg1 : tensor<?x16xf32, #stablehlo.bounds<16, ?>>
+
+// Unranked dynamism:
+// The rank is unknown (*).
+%3 = stablehlo.add %arg0, %arg1 : tensor<*xf32>
+```
+
+Similarly, the StableHLO dialect already has support for **dynamism within
+operations**, with some ops such as PadOp having dynamic counterparts such as
+DynamicPadOp. For example:
+
+```mlir
+// "vanilla" PadOp:
+// low, high and interior paddings are implemented via MLIR attributes,
+// i.e. they are static.
+%0 = stablehlo.pad %arg0, %arg1, low = [1, 1], high = [1, 1], interior = [0, 0]
+  : (tensor<16x16xf32>, tensor<f32>) -> tensor<20x20xf32>
+
+// DynamicPadOp:
+// low, high and interior paddings are implemented via MLIR operands,
+// i.e. they are dynamic.
+%1 = stablehlo.dynamic_pad %arg0, %arg1, %arg2, %arg3, %arg4 :
+  : (tensor<?x?xf32>, tensor<f32>, tensor<2xindex>, tensor<2xindex>, tensor<2xindex>) -> tensor<?x?xf32>
+```
+
+Finally, dynamism (both within types and within operations) creates new
+opportunities for errors. For example, the semantics of elementwise operations
+like `add` are only defined when inputs and outputs have the same shape.
+For the static shape case, this can be checked **at compile time** (i.e. before
+the execution of the StableHLO program). However, when dynamism is involved,
+this can only be checked **at run time**.
+
+If some operation doesn't make sense at run time because some unknown ranks
+and/or unknown dimension sizes turned out to be incompatible with the operation
+and/or with each other, an error condition called **"shape mismatch"** occurs.
+In order to guard against shape mismatches, StableHLO programs may employ
+**shape checks**.
+
+## Community feedback
+
+The current design of dynamism in MHLO and StableHLO has been practically
+useful. There are success stories of it connecting JAX, PyTorch and TensorFlow
+to a number of compilers, in a mix of research and production environments.
+However, this design can be improved. Over the years of using this design in
+practice, the community has provided the following feedback which is summarized
+below (see [#8](https://github.com/openxla/stablehlo/issues/8) for the full
+version):
+
+<a id="f1" /> **(F1)** Unranked dynamism introduces considerable complexity to
+StableHLO, but the only user of unranked dynamism in StableHLO/MHLO
+appears to be TensorFlow's KernelGen toolchain, and KernelGen can encapsulate
+handling unranked dynamism in a different layer. Unranked tensors shouldn't be
+needed in StableHLO.
+
+<a id="f2" /> **(F2)** Having different code paths for producing/consuming
+static and dynamic ops (e.g. PadOp vs DynamicPadOp in the example above) is a
+testing/maintenance/cognitive burden.
+
+<a id="f3" /> **(F3)** Dynamism within operations is modelled inconsistently.
+Some ops have two versions (e.g. PadOp and DynamicPadOp), some ops have three
+versions (e.g. SliceOp, DynamicSliceOp and RealDynamicSliceOp), and some ops
+don't have dynamic versions even though there are use cases for them (e.g.
+ReduceWindowOp).
+
+<a id="f4" /> **(F4)** Specifying dynamic sizes as 1-dimensional tensors
+introduces considerable complexity because many adjacent abstractions and
+typical shape computations operate in terms of scalars. The tensor
+representation is needed to support unranked dynamism, but since unranked
+tensors shouldn't be needed in StableHLO (see above), shape tensors shouldn't be
+needed either.
+
+<a id="f5" /> **(F5)** Shape computations are an essential part of dynamic
+programs, and there are currently multiple approaches to doing these
+computations in StableHLO programs. Some of these approaches involve only
+operations from the StableHLO dialect, some of these approaches use operations
+from other dialects including `arith` and `shape`. This inconsistency affects
+user experience (producers are uncertain which approach to use, consumers are
+uncertain which approaches to support) and presents compatibility issues
+(StableHLO project can only provide compatibility guarantees for the StableHLO
+opset).
+
+<a id="f6" /> **(F6)** Dimension numbers and dimension sizes are modelled
+inconsistently. For example, PadOp represents paddings as arrays of `i64`.
+However, DynamicPadOp takes all sorts of paddings - tensors of `index`,
+tensors of `i32`, tensors of `i64`, etc.
+
+<a id="f7" /> **(F7)** There is alignment on shape mismatches being undefined
+behavior, but there are multiple schools of thought on how this undefined
+behavior should be guarded against (use `shape` dialect, use asserts, don't do
+anything).
+
+<a id="f8" /> **(F8)**. Even though StableHLO dynamism is used fairly actively,
+it is not reflected in the StableHLO specification. As a result, dynamism
+semantics and especially constraints are underspecified.
+
+## Out of scope
+
+This RFC aims to address a considerable part of community feedback on the
+existing design of dynamism in MHLO and StableHLO, but some feedback is
+deliberately out of scope because further discussion is needed to obtain
+alignment in the corresponding areas.
+
+<a id="o1" /> **(O1)** There is promising related work on alternative
+representations for dynamism, e.g. involving symbols and formulas in modeling
+dynamic sizes rather than representing dynamic sizes as question marks. These
+representations are more expressive than the design proposed in this RFC, and
+they have the potential to solve the problem of shape mismatches, to convey
+additional information to consumers improving overall performance, etc.
+
+However, this is a very new area for the OpenXLA stack, so a considerable
+amount of design exploration will be needed before these ideas can be turned
+into concrete proposals. Meanwhile, this RFC is focused on making design
+improvements which have been already socialized within the community.
+
+<a id="o2" /> **(O2)** Shape computations are considerably improved by this RFC,
+but not all of the feedback from [F5](#f5)/[F6](#f6) is addressed.
+
+More specifically, this RFC proposes to represent shape computations as
+StableHLO operations on 0-dimensional tensors, which is a practically important
+simplification for StableHLO programs and their producers/consumers.
+However, interoperability with other dialects, including `arith` and `shape`
+which are oftentimes used by the community for shape computations, is out of
+scope, and [P6](#p6) goes into details about the rationale.
+
+<a id="o3" /> **(O3)** Working out a common solution for shape checks would be
+nice. Per [F7](#f7), there are multiple incompatible approaches, so a common
+solution would result in a simplification of the overall stack.
+
+However, based on author's experience, alignment in this area requires
+non-trivial effort (different approaches have different benefits, plus they have
+limited interoperability), so this is left for future work.
+
+<a id="o4" /> **(O4)** Shape inference is an essential part of the StableHLO
+dialect, and dynamism non-trivially affects it by complicating the API (without
+dynamism, almost all ops can unambiguously infer their output types from their
+inputs; with dynamism, this is not the case) and complicating the implementation
+(checking constraints become more involved).
+
+Much of this is already implemented in the StableHLO dialect (e.g. verifiers and
+shape functions already support dynamism in a fairly robust manner, although
+some open questions still remain), but formalizing this area is left for future
+work, because that would require formalizing the general notion of shape
+inference which represents a significant amount of work.
+
+<a id="o5" /> **(O5)** [Value inference](https://github.com/tensorflow/tensorflow/blob/cc71ba69fa9d25a21009b6e377f3dc3d1323aa6c/tensorflow/compiler/xla/client/value_inference.h)
+is an algorithm implemented in the XLA compiler. It "analyzes values in XlaOp
+answers following questions: 1) What's the upper-bound of each value in a
+tensor, 2) What's the lower-bound of each value in a tensor, 3) What's the
+constant value of each tensor, 4) Whether or not each value in a tensor
+is dynamic". This algorithm is used in the TF/XLA bridge to automatically
+compute bounds for bounded types in HLO programs.
+
+Similarly to shape inference, this area is out of scope for this RFC.
+From the implementation standpoint, value inference is currently not available
+for the StableHLO dialect, but this may change in the future depending on
+community feedback.
+
+<a id="o6" /> **(O6)** Shape specialization is a practically important problem
+because not all consumers support dynamic shapes. In the StableHLO repository,
+there are `--stablehlo-refine-shapes` and `--stablehlo-canonicalize-dynamism`
+passes which address this problem. Furthermore, based on a semi-formal proof and
+the experience with JAX native serialization, the author believes that these
+passes are guaranteed to fully specialize dynamic StableHLO programs which only
+involve shape polymorphism and have static arguments to static StableHLO programs.
+
+However, similarly to formalizing shape inference, formalizing shape
+specialization is a significant amount of work which is not on the critical
+path to [StableHLO v1.0](../docs/roadmap.md), so it is left for future work.
+
+<!-- markdownlint-disable line-length -->
+## <a id="p1" /> (P1) Move TensorFlow-specific operations out of StableHLO
+<!-- markdownlint-enable line-length -->
+
+**Baseline:** The MHLO and CHLO dialects have been initially co-designed with
+the TensorFlow dialect, the MLIR-based TF/XLA bridge and TensorFlow's
+[KernelGen toolchain](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/compiler/mlir/tools/kernel_gen).
+This has been inherited by the StableHLO repository when the StableHLO dialect
+was bootstrapped from MHLO and the CHLO dialect was moved to the StableHLO
+repository.
+
+As a result, there are 2 StableHLO ops (`compute_reshape_shape` and
+`cstr_reshapable`) as well as 4 CHLO ops (`dynamic_reshape`,
+`minimum_broadcast_shapes`, `rank_specialization_cluster` and
+`rank_specialization_cluster_yield`) which appear specific to TensorFlow, i.e.
+it looks like they are only used in [legalize_tf.cc](https://github.com/tensorflow/tensorflow/blob/cf2e180455065ce718b1c5328014dd953b1fddc9/tensorflow/compiler/mlir/tf2xla/transforms/legalize_tf.cc)
+and [rank_specialization.cc](https://github.com/tensorflow/mlir-hlo/blob/cb944f56130eab16b746e680772305b006743006/mhlo/transforms/rank_specialization/rank_specialization.cc)
+passes within the TensorFlow ecosystem. This specific nature of these ops does
+not meet the bar for inclusion in the StableHLO repository.
+
+**Proposal:** This RFC proposes to immediately remove these 6 operations from
+their current dialects and move them into a new dialect called `chlo_legacy`.
+
+StableHLO [doesn't guarantee](../docs/compatibility.md#out-of-scope)
+compatibility for these operations (see the "Unspecced features" clause).
+However, this RFC proposes to provide compatibility guarantees on exceptional
+basis given that they don't appear to involve a lot of work. More specifically,
+the proposal is to keep the `chlo_legacy` dialect in the StableHLO repository
+for 6 months from the date of its creation and only then remove it.
+
+<!-- markdownlint-disable line-length -->
+## <a id="p2" /> (P2) Ratify the existing convention for shape mismatches constituting undefined behavior
+<!-- markdownlint-enable line-length -->
+
+**Baseline:** As mentioned in [F7](#f7), there is broad consensus that shape
+mismatches in StableHLO operations should constitute undefined behavior, i.e.
+that guarding against shape mismatches should be made a producer responsibility.
+This has been a subject of many informal conversations as well as one of the
+discussion items
+[at the StableHLO dynamism breakout session](https://drive.google.com/drive/u/1/folders/1fGqq8Tcebhcwq1KJqAZPDgXksRdqRvM2)
+during the OpenXLA Dev Summit in April 2023.
+
+**Proposal:** This RFC proposes to ratify this convention as a StableHLO design
+principle, so that the folklore consensus becomes codified in the StableHLO
+specification.
+
+**Discussion:** A) The rationale for this proposal is that lower-level
+abstractions (e.g. HLO or Linalg) typically don't want to concern themselves
+with shape checks - they are focused on generating high-performance code, so
+they want shape checks to be handled at a higher level, i.e. at StableHLO
+or above.
+
+Furthermore, different producers have different requirements and different
+preferences for expressing shape checks (e.g. JAX's type system enables it to
+need fewer checks than TensorFlow's type system), so a specific way of
+performing shape checks don't look like something that should be standardized
+at the StableHLO level either.
+
+B\) From the implementation standpoint, this proposal would involve updating
+[the "Errors" section](../docs/spec.md#errors) of the specification, and
+changing the StableHLO dialect to implement the `ConditionallySpeculatable`
+interface, prohibiting speculation for StableHLO ops that involve dynamism
+([documentation](https://mlir.llvm.org/docs/Rationale/SideEffectsAndSpeculation/)).
+
+<!-- markdownlint-disable line-length -->
+## <a id="p3" /> (P3) Ratify the existing convention for relaxed constraints already implemented in the StableHLO dialect
+<!-- markdownlint-enable line-length -->
+
+**Baseline:** At the moment, the StableHLO dialect supports
+[relaxed constraints](https://github.com/openxla/stablehlo/blob/8993ad54839add6648b88801f1d223b7f9bc2e58/stablehlo/dialect/Base.cpp#L102-L120)
+that were inherited from the MHLO dialect. For example, the code below is valid
+in the StableHLO dialect:
+
+```mlir
+func.func @main(%arg0: tensor<?xf32>, %arg1: tensor<1xf32>) {
+  %0 = stablehlo.add %arg0, %arg0 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
+  %1 = stablehlo.add %arg0, %arg0 : (tensor<?xf32>, tensor<?xf32>) -> tensor<1xf32>
+  %2 = stablehlo.add %arg0, %arg1 : (tensor<?xf32>, tensor<1xf32>) -> tensor<?xf32>
+  %3 = stablehlo.add %arg0, %arg1 : (tensor<?xf32>, tensor<1xf32>) -> tensor<1xf32>
+  %4 = stablehlo.add %arg1, %arg0 : (tensor<1xf32>, tensor<?xf32>) -> tensor<?xf32>
+  %5 = stablehlo.add %arg1, %arg0 : (tensor<1xf32>, tensor<?xf32>) -> tensor<1xf32>
+  %6 = stablehlo.add %arg1, %arg1 : (tensor<1xf32>, tensor<1xf32>) -> tensor<?xf32>
+  %7 = stablehlo.add %arg1, %arg1 : (tensor<1xf32>, tensor<1xf32>) -> tensor<1xf32>
+  func.return
+}
+```
+
+More formally, these relaxed constraints generalize the constraints that are
+already documented in the StableHLO specification. If a constraint for a
+specific operation cannot be evaluated at compile time because it involves an
+unknown rank or an unknown dimension size, it gets deferred until the run time
+of the operation. If at that point the constraint fails, a shape mismatch
+occurs, and [P2](#p2) discusses what should happen in that case.
+
+```mlir
+// Static case - constraints I1-I5 and C1-C4 can be evaluated at compile time.
+%0 = stablehlo.pad %arg0, %arg1, low = [1, 1], high = [1, 1], interior = [0, 0]
+  : (tensor<16x16xf32>, tensor<f32>) -> tensor<20x20xf32>
+
+// Dynamic case - constraints C2 and C4 cannot be evaluated at compile time.
+// C2 depends on rank(operand) which is unknown.
+// C4 depends on shape(operand) and shape(result) which are both unknown.
+// These constraints are deferred until run time.
+%1 = stablehlo.pad %arg0, %arg1, low = [1, 1], high = [1, 1], interior = [0, 0]
+  : (tensor<*xf32>, tensor<f32>) -> tensor<?x20xf32>
+
+// Dynamic case - constraints C3 and C4 cannot be evaluated at compile time.
+// C3 depends on the value of interior_padding which is unknown.
+// C4 depends on a number of shapes and values which are all unknown.
+// Note that C2 can be evaluated at compile time - even though the values of
+// edge_padding_low, edge_padding_high, interior_padding and operand are
+// unknown, their size and rank are actually known.
+%2 = stablehlo.dynamic_pad %arg0, %arg1, %arg2, %arg3, %arg4 :
+  : (tensor<?x?xf32>, tensor<f32>, tensor<2xindex>, tensor<2xindex>, tensor<2xindex>) -> tensor<?x?xf32>
+```
+
+**Proposal:** A) This RFC proposes to ratify this convention as a StableHLO
+design principle, given that: I) it allows the flexibility for producers to mix
+static and dynamic elements in StableHLO programs at their convenience (which
+has been proven to be practically useful, e.g. for JAX native serialization),
+II\) it has a concise formulation that is demonstrably sound (it only affects
+constraints, and no constraints are disregarded - they just move from compile
+time to run time).
+
+B\) From the implementation standpoint, this proposal would involve updating
+[the "Notation" section](../docs/spec.md#values) of the specification, and
+auditing the existing verifiers and shape functions in the StableHLO dialect to
+identify specification compliance issues, update [status.md](../docs/status.md)
+accordingly and file
+[Specification Compliance](https://github.com/orgs/openxla/projects/9) tickets.
+
+<!-- markdownlint-disable line-length -->
+## <a id="p4" /> (P4) Enable dynamism for all size-related program elements but keep all axis-related program elements static
+<!-- markdownlint-enable line-length -->
+
+**Baseline:** The StableHLO dialect has inherited a considerable degree of
+support for dynamism from the MHLO dialect. All MLIR operands can have dynamic
+shapes, almost all MLIR results can have dynamic shapes and many
+size-related MLIR attributes have dynamic counterparts.
+
+1\) As far as MLIR results go, for 7 operations in the StableHLO dialect -
+`BroadcastInDimOp`, `ConstantOp`, `InfeedOp`, `IotaOp`, `RecvOp`, `ReshapeOp`
+and `RngBitGeneratorOp` - the static shape of the results is "load-bearing",
+i.e. allowing dynamic shapes there would not make sense as is.
+
+```mlir
+// Static result type - makes sense.
+%0 = stablehlo.broadcast_in_dim %arg0, dims = [0] : (tensor<1xf32>) -> tensor<1x2xf32>
+
+// Dynamic result type - doesn't make sense as is.
+// How does the operation know what result to produce? 1x1xf32? 1x2xf32? etc.
+// Resolving this would need an additional argument - see below.
+%1 = stablehlo.broadcast_in_dim %arg0, dims = [0] : (tensor<1xf32>) -> tensor<1x?xf32>
+```
+
+2\) As far as MLIR attributes go, there are 9 operations in the StableHLO
+dialect which have size-related attributes (operations are grouped together
+using the categories from
+[the StableHLO Ops spreadsheet](https://docs.google.com/spreadsheets/d/1rvhxQMFUtCZ5DsY6X0_lJOCg9rVO2MdyeZlRorsc0UI/edit?resourcekey=0-5gMjnlkXDL6hCntv2yltaQ#gid=0)
+, operations from the Dynamism category are analyzed below, operations from the
+Not in HLO category are not included because they are on their way out of the
+StableHLO dialect):
+
+* Data Movement: `DynamicSliceOp`, `GatherOp`, `PadOp`, `ScatterOp`,
+  `SliceOp`.
+* Miscellaneous: `FftOp`.
+* Reduction: `ConvolutionOp`, `ReduceWindowOp`, `SelectAndScatterOp`.
+
+Furthermore, there are 18 operations in the StableHLO dialect which have
+axis-related attributes (some of these operations overlap with the operations
+from the previous section):
+
+* Data Movement: `BroadcastInDimOp`, `ConcatenateOp`, `GatherOp`, `ReverseOp`,
+  `ScatterOp`, `SortOp`, `TransposeOp`.
+* Distribution: `AllGatherOp`, `AllToAllOp`, `ReduceScatterOp`.
+* Elementwise: `MapOp`.
+* Miscellaneous: `BatchNormGradOp`, `BatchNormInferenceOp`,
+  `BatchNormTrainingOp`, `IotaOp`.
+* Reduction: `ConvolutionOp`, `DotGeneralOp`, `ReduceOp`.
+
+3\) Finally, there are 7 operations in the StableHLO
+dialect which provide dynamic versions of existing StableHLO operations:
+`DynamicBroadcastInDimOp`, `DynamicConvOp`, `DynamicGatherOp`, `DynamicIotaOp`,
+`DynamicPadOp`, `DynamicReshapeOp` and `RealDynamicSliceOp`. Not all StableHLO
+operations have dynamic counterparts, e.g. there is no `DynamicReduceWindowOp`.
+
+```mlir
+// The StableHLO dialect resolves the conundrum mentioned in the previous
+// example by providing a dynamic version of BroadcastInDimOp which takes
+// the shape of the result as an operand.
+%0 = stablehlo.dynamic_broadcast_in_dim %arg0, %arg1, dims = [0] :
+  (tensor<1xf32>, tensor<2xi64>) -> tensor<1x?xf32>
+```
+
+Overall, as mentioned in [F3](#f3) and further elaborated above in this section,
+dynamism within operations is modelled inconsistently. Some ops have two
+versions (e.g. PadOp and DynamicPadOp), some ops have three versions (e.g.
+SliceOp, DynamicSliceOp and RealDynamicSliceOp), and some ops don't have dynamic
+versions even though there are use cases for them (e.g. ReduceWindowOp).
+
+**Proposal:** This RFC proposes to address the inconsistencies in the existing
+support for dynamism in StableHLO summarized in
+["Status of dynamic versions"](https://docs.google.com/spreadsheets/d/1rvhxQMFUtCZ5DsY6X0_lJOCg9rVO2MdyeZlRorsc0UI/edit?resourcekey=0-5gMjnlkXDL6hCntv2yltaQ#gid=335520762&fvid=75321273)
+by establishing a concise design principle:
+
+1) If a program element is related to sizes, then it should be possible
+   to express it both statically and dynamically.
+2) If a program element is related to axes, then it should only be possible
+   to express it statically.
+
+**Discussion:** A) This proposal builds on a broad consensus to treat dimension
+sizes dynamically and axes statically, which has come up both in informal
+conversations and at the OpenXLA Dev Summit.
+
+For 1), there's already a significant precedent to provide both static and
+dynamic representations - which started in HLO and continued in MHLO
+(plus, we have several feature requests from JAX:
+[for ConvolutionOp](https://github.com/openxla/stablehlo/issues/1268),
+[for FftOp](https://github.com/openxla/stablehlo/issues/1366),
+[for ReduceWindowOp](https://github.com/openxla/stablehlo/issues/1258) and
+[for RngBitGeneratorOp](https://github.com/openxla/stablehlo/issues/1344)).
+This RFC proposes to extend this predecent to the entire opset, with the
+rationale that the burden of adding a few extensions that were not previously
+supported or requested (for ConstantOp, for InfeedOp and for RecvOp) is smaller
+than the burden of having to define and maintain carveouts in the specification.
+
+For 2), the proposal is to keep them static because: A) there doesn't seem
+to be precedent or feature requests to make them dynamic, B) when this topic
+came up with several StableHLO consumers, there was considerable pushback since
+that would considerably complicate code generation.
+
+B\) From the implementation standpoint, this proposal would involve updating
+[the "Types" section](../docs/spec.md#types) of the specification to extend
+the definition of `TensorType` to express **dynamism within types** and
+accommodate both unbounded and bounded dynamism (but not unranked dynamism -
+see [P6](#p6) for details).
+
+However, this section doesn't provide an opinion on what representations should
+be used to express **dynamism within operations**. As mentioned in [F2](#f2),
+the existing design where static ops like `PadOp` are accompanied with dynamic
+ops like `DynamicPadOp` has some drawbacks, and the next section proposes how an
+improved design could look like.
+
+<!-- markdownlint-disable line-length -->
+## <a id="p5" /> (P5) Unify static and dynamic versions of StableHLO operations
+<!-- markdownlint-enable line-length -->
+
+**Baseline:** There are several operations in the StableHLO dialect which
+provide dynamic versions of existing StableHLO operations. For example, `PadOp`
+defines `edge_padding_low`, `edge_padding_high` and `interior_padding` as static
+attributes, whereas `DynamicPadOp` has the same contract except that those
+arguments are dynamic values.
+
+```mlir
+// Static version - in PadOp, padding options are represented as attributes.
+// %arg0 is the operand, %arg1 is the padding value.
+%0 = stablehlo.pad %arg0, %arg1, low = [1, 1], high = [1, 1], interior = [0, 0]
+  : (tensor<16x16xf32>, tensor<f32>) -> tensor<20x20xf32>
+
+// Dynamic version - in DynamicPadOp, padding options are represented as values.
+// The rest of the contract is the same.
+%2 = stablehlo.dynamic_pad %arg0, %arg1, %arg2, %arg3, %arg4 :
+  : (tensor<?x?xf32>, tensor<f32>, tensor<2xindex>, tensor<2xindex>, tensor<2xindex>) -> tensor<?x?xf32>
+```
+
+**Proposal:** This RFC proposes to take the 16 operations from [P4](#p4)
+(7 operations with "load-bearing" result types and 9 operations with
+size-related attributes) and generalize them to express both static and dynamic
+semantics.
+
+More specifically, the specification of these operations would change as follows
+(with special cases for `broadcast_in_dim` and `dynamic_slice` which are
+discussed separately below):
+
+1) For operations with "load-bearing" output types, add a new `output_shape`
+   input that has type "variadic number of 0-dimensional tensors of integer
+   type" and add a constraint `output_shape = shape(result)`. If the operation
+   has a variadic number of results, that would be `output_shapes`,
+   "variadic number of variadic number of ..." and
+   `output_shapes = shape(results...)`.
+2) For operations with size-related inputs, generalize them from
+   "1-dimensional tensor constant of type si64" to "variadic number of
+   0-dimensional tensors of integer type". The notation for existing
+   constraints pertaining to generalized inputs doesn't need to change
+   per [P3](#p3).
+
+The implementation of the StableHLO dialect would change as well, building
+on the experience from MLIR upstream where operations like
+`tensor::ExtractSliceOp`, `tensor::InsertSliceOp`, `tensor::PadOp` and others
+support both static and dynamic arguments
+([example](https://github.com/llvm/llvm-project/blob/f8cf2105760d2dfd58de4ca1c459c5bb1e2802dc/mlir/include/mlir/Dialect/Tensor/IR/TensorOps.td#L1161)
+). Note that this section is still using tensors to represent dynamic sizes,
+whereas MLIR upstream is using scalars. As mentioned in [F4](#f4), there's been
+community feedback that this design can be improved, and the next section
+proposes how an improved design could look like.
+
+```tablegen
+// Before: static version.
+def StableHLO_PadOp ... {
+  let arguments = (ins
+    HLO_Tensor:$operand,
+    HLO_Tensor:$padding_value,
+    I64ElementsAttr:$edge_padding_low,
+    I64ElementsAttr:$edge_padding_high,
+    I64ElementsAttr:$interior_padding
+  );
+}
+
+// Before: dynamic version.
+def StableHLO_DynamicPadOp ... {
+  let arguments = (ins
+    HLO_Tensor:$operand,
+    HLO_Tensor:$padding_value,
+    HLO_DimensionTensor:$edge_padding_low,
+    HLO_DimensionTensor:$edge_padding_high,
+    HLO_DimensionTensor:$interior_padding
+  );
+}
+
+// After: unified static and dynamic versions.
+def StableHLO_PadOp ... {
+  let arguments = (ins
+    HLO_Tensor:$operand,
+    HLO_Tensor:$padding_value,
+    I64ElementsAttr:$static_edge_padding_low,
+    I64ElementsAttr:$static_edge_padding_high,
+    I64ElementsAttr:$static_interior_padding,
+    HLO_DimensionTensor:$dynamic_edge_padding_low,
+    HLO_DimensionTensor:$dynamic_edge_padding_high,
+    HLO_DimensionTensor:$dynamic_interior_padding
+  );
+
+  let extraClassDeclaration = [{
+    // Breaks source compatibility with consumers: they will need to deal with
+    // the fact that arguments can now be either attributes or values.
+    OpFoldResult getEdgePaddingLow();
+    OpFoldResult getEdgePaddingHigh();
+    OpFoldResult getInteriorPadding();
+  }]
+
+  let builders = [
+    // Maintains source compatibility with PadOp producers.
+    OpBuilder<(ins "Type":$resultType, "Value":$operand,
+      "Value":$padding_value, "DenseIntElementsAttr":$edgePaddingLow,
+      "DenseIntElementsAttr":$edgePaddingHigh, "DenseIntElementsAttr":$interiorPadding)>,
+    OpBuilder<(ins "Value":$operand,
+      "Value":$padding_value, "DenseIntElementsAttr":$edgePaddingLow,
+      "DenseIntElementsAttr":$edgePaddingHigh, "DenseIntElementsAttr":$interiorPadding)>,
+
+    // Maintains source compatibility with DynamicPadOp producers.
+    // At the moment, StableHLO dialect doesn't support type inference for
+    // DynamicPadOp, so there's just one builder.
+    OpBuilder<(ins "Type":$resultType, "Value":$operand,
+      "Value":$padding_value, "Value":$edgePaddingLow,
+      "Value":$edgePaddingHigh, "Value":$interiorPadding)>,
+  ];
+}
+
+// After: deprecated and removed after the compatibility window expires.
+// Strictly speaking, DynamicPadOp is out of scope for StableHLO compatibility
+// guarantees per the "Unspecced features" clause.
+// However, dynamic ops are actively used in the community, so the RFC proposes
+// to provide exceptional compatibility guarantees for them.
+def StableHLO_DynamicPadOp ...
+```
+
+**Discussion:** A) The alternative to this proposal is to continue with the
+split between static and dynamic ops, which would mean introducing 7 new
+`DynamicFooOp` ops, e.g. `DynamicReduceWindowOp`, and additionally updating
+`DynamicConvOp` to be fully dynamic in size-related arguments.
+
+On the one hand, this alternative provides full source compatibility for both
+producers and consumers (in the main proposal, only producers have source
+compatibility). Furthermore, not all consumers support dynamic shapes, and the
+alternative makes it easy to reject dynamic ops by simply not supporting the
+corresponding `DynamicFooOp` ops.
+
+On the other hand, [per community feedback](#f2) (both the OpenXLA Dev Summit
+and in various conversations) there is considerable appetite for a unified
+solution. Furthermore, none of the benefits of the alternative are particularly
+compelling: StableHLO [doesn't guarantee](../docs/compatibility.md#out-of-scope)
+source compatibility at the moment, and consumers that don't support dynamic
+shapes already need to do more than just rejecting dynamic ops (they would also
+want to reject regular ops which are used with dynamic types). Therefore, the
+alternative proposal looks less attractive that the main proposal.
+
+B\) Two out of the 16 operations affected by the proposal - `broadcast_in_dim`
+and `dynamic_slice` - are special in that the general design principles in 1)
+and 2) are insufficient for handling them. This section dives into the details
+on that.
+
+B1) `broadcast_in_dim`: This is one of the special operations with a
+"load-bearing" output type, i.e. some parts of its semantics are defined only
+by the shape of the output. However, unlike other such operations, it is doubly
+special in that it doesn't treat this shape uniformly but additionally depends
+on magic values. For example, `reshape` works the same way for all kinds of
+shapes, but `broadcast_in_dim` distinguishes dimension sizes equal to 1
+(broadcast) and not equal to 1 (no broadcast).
+
+This presents a problem for some consumers, because this prevents efficient
+code generation for dynamic broadcasts (dynamically deciding on whether to
+broadcast isn't compatible with how most of the existing consumers express code
+at lower levels, e.g. there is no efficient lowering from the general case of
+dynamic broadcasts to Linalg).
+
+As a result, `DynamicBroadcastInDimOp` has two additional attributes:
+`known_expanding_dimensions` and `known_nonexpanding_dimensions` - which provide
+hints to consumers about whether specific axes are known to always broadcast,
+are known to never broadcast or neither. Depending on these hints, consumers can
+then decide to reject broadcasts which are insufficiently specific (e.g.
+this is exactly what happens in the MHLO to Linalg lowering:
+[here](https://github.com/tensorflow/mlir-hlo/blob/1fd13ef28d3f423363e59b1a80eb2c26e0c0979d/mhlo/transforms/legalize_to_linalg/legalize_to_linalg.cc#L938-L940)
+and
+[here](https://github.com/tensorflow/mlir-hlo/blob/1fd13ef28d3f423363e59b1a80eb2c26e0c0979d/mhlo/transforms/legalize_to_linalg/legalize_to_linalg.cc#L1006-L1008)).
+
+Based on practical experience with MHLO, this design has been recognized by the
+community as cumbersome, so
+[an alternative design](https://docs.google.com/document/d/1x8kCUsYzFEIeWO38h32bHlmDrieeu9UJTxpKe9gUm_g/edit)
+has been implemented in TCP: "The axes that need to be broadcast must be
+statically known. All broadcasted axes in the input tensor must have
+statically known size = 1. All other cases will result in compile-time errors".
+
+The design implemented in TCP looks attractive in its simplicity, but applying
+it to StableHLO would require non-trivial effort to migrate producers and
+consumers. Therefore, getting to the bottom of this is left for future work,
+and this RFCs merely proposes to use the `DynamicBroadcastInDimOp` design,
+adding `known_expanding_dimensions` and `known_nonexpanding_dimensions` inputs
+to `broadcast_in_dim`.
+
+B2) `dynamic_slice`: This operation is part of a 3-op family that includes
+`SliceOp`, `DynamicSliceOp` and `RealDynamicSliceOp`, and anecdotally this
+family is notoriously confusing for newcomers, so it is tempting to unify all
+the three ops into just `slice` as described above.
+
+However, semantics of `slice` and `dynamic_slice` are materially different
+in that `slice` expects slice sizes to be in bounds of the operand shape, but
+`dynamic_slice` doesn't - it clamps slice sizes to bring them in bounds before
+performing slicing.
+
+Similarly to B1, unifying `slice` and `dynamic_slice` would require non-trivial
+effort (and unlike B1, it is probably infeasible because of how heavily
+`DynamicSliceOp` is used). Therefore, getting to the bottom of this is left for
+future work, and this RFCs proposes to keep `dynamic_slice` unchanged.
+(But `RealDynamicSliceOp` would still be unified with `SliceOp`).
+
+C\) From the implementation standpoint, in addition to updating the
+specification and the StableHLO dialect as described in the "Proposal" section,
+there is one practical consideration worth discussing. Even though the proposed
+design doesn't involve `DynamicFooOp` operations, it may be worth it to
+introduce these operations (only in the StableHLO dialect) as an intermediate
+step. This would allow to roll out the new functionality (e.g.
+`DynamicReduceWindowOp`) sooner, without blocking on refactoring of the
+existing functionality (e.g. updating `ReduceWindowOp` as discussed above).
+
+<!-- markdownlint-disable line-length -->
+## <a id="p6" /> (P6) Represent shape computations as StableHLO operations on 0-dimensional tensors and drop support for unranked dynamism
+<!-- markdownlint-enable line-length -->
+
+**Baseline:** The StableHLO dialect represents sizes as 1-dimensional tensors,
+with static sizes expressed as `DenseIntElementsAttr` and dynamic sizes
+expressed as `1DTensorOf<[HLO_DimensionValue]>`.
+
+```c++
+class PadOp ... {
+  // This is how static sizes are represented in TableGen:
+  // I64ElementsAttr:$edge_padding_low
+  // I64ElementsAttr:$edge_padding_high
+  // I64ElementsAttr:$interior_padding
+  DenseIntElementsAttr getEdgePaddingLow();
+  DenseIntElementsAttr getEdgePaddingHigh();
+  DenseIntElementsAttr getInteriorPadding();
+}
+
+class DynamicPadOp ... {
+  // This is how dynamic sizes are represented in TableGen:
+  // HLO_DimensionTensor:$edge_padding_low
+  // HLO_DimensionTensor:$edge_padding_high
+  // HLO_DimensionTensor:$interior_padding
+  TypedValue<RankedTensorType> getEdgePaddingLow();
+  TypedValue<RankedTensorType> getEdgePaddingHigh();
+  TypedValue<RankedTensorType> getInteriorPadding();
+}
+```
+
+As mentioned in [F5](#f5), shape computations in StableHLO programs produce
+these 1-dimensional tensors using one of several approaches, including ops from
+Arith, Shape, StableHLO as well as other dialects. E.g. addition of dimension
+sizes can be represented via `stablehlo::AddOp`, `arith::AddIOp`, `shape::AddOp`
+and in a few other ways.
+
+Furthermore, as mentioned in [F4](#f4), using 1-dimensional tensors introduces
+considerable complexity because typical shape computations operate in terms of
+scalars. As a result, in code that constructs dynamic StableHLO ops, it is not
+unusual to encounter computations on 0-dimensional tensors whose results are
+then reshaped to 1-dimensional tensors and then concatenated together
+([example](https://github.com/tensorflow/mlir-hlo/blob/1fd13ef28d3f423363e59b1a80eb2c26e0c0979d/mhlo/transforms/chlo_legalize_to_hlo/chlo_legalize_to_hlo.cc#L1577-L1587)).
+
+**Proposal:** The RFC proposes to standardize on representing shape computations
+as StableHLO operations working 0-dimensional tensors. More specifically,
+the proposal is to:
+
+1) Affirm that only shape computations that use StableHLO operations are
+   supported in StableHLO portable artifacts (this can be changed in future
+   RFCs, but is out of scope for this one).
+2) Use `Variadic<0DTensorOf<HLO_DimensionValue>>` instead of
+   `HLO_DimensionTensor` in the StableHLO dialect (this is consistent with
+   "variadic number of 0-dimensional tensors of integer type" from [P5](#p5)).
+3) Drop support for unranked dynamism in StableHLO (otherwise the operations
+   from P5 will no longer work for unranked operands).
+
+```tablegen
+// See P5 for the "before" and "after" of unifying static and dynamic ops.
+// This snippet only shows the "after" for this section.
+def StableHLO_PadOp ... {
+  let arguments = (ins
+    HLO_Tensor:$operand,
+    HLO_Tensor:$padding_value,
+    I64ElementsAttr:$static_edge_padding_low,
+    I64ElementsAttr:$static_edge_padding_high,
+    I64ElementsAttr:$static_interior_padding,
+    Variadic<0DTensorOf<HLO_DimensionValue>>:$dynamic_edge_padding_low,
+    Variadic<0DTensorOf<HLO_DimensionValue>>:$dynamic_edge_padding_high,
+    Variadic<0DTensorOf<HLO_DimensionValue>>:$dynamic_interior_padding
+  );
+
+  let extraClassDeclaration = [{
+    // Breaks source compatibility with consumers.
+    // However, it's already broken by P5.
+    ArrayRef<OpFoldResult> getEdgePaddingLow();
+    ArrayRef<OpFoldResult> getEdgePaddingHigh();
+    ArrayRef<OpFoldResult> getInteriorPadding();
+  }]
+
+  let builders = [
+    // Maintains source compatibility with PadOp producers.
+    OpBuilder<(ins "Type":$resultType, "Value":$operand,
+      "Value":$padding_value, "DenseIntElementsAttr":$edgePaddingLow,
+      "DenseIntElementsAttr":$edgePaddingHigh, "DenseIntElementsAttr":$interiorPadding)>,
+    OpBuilder<(ins "Value":$operand,
+      "Value":$padding_value, "DenseIntElementsAttr":$edgePaddingLow,
+      "DenseIntElementsAttr":$edgePaddingHigh, "DenseIntElementsAttr":$interiorPadding)>,
+
+    // Breaks source compatibility with DynamicPadOp producers: they will need
+    // to deal with the fact that edgePaddingLow, edgePaddingHigh and
+    // interiorPadding are no longer 1-dimensional tensors.
+    OpBuilder<(ins "Type":$resultType, "Value":$operand,
+      "Value":$padding_value, "ValueRange":$edgePaddingLow,
+      "ValueRange":$edgePaddingHigh, "ValueRange":$interiorPadding)>,
+  ];
+}
+```
+
+**Discussion:** A) This proposal reduces the expressiveness of shape
+computations in StableHLO, since it removes the capability to pass around
+shapes of dynamic size. Based on the conversations with StableHLO/MHLO users,
+support for unranked dynamism appears to be the only usage of this capability.
+
+As mentioned in [F1](#f1), the only user of unranked dynamism in StableHLO/MHLO
+appears to be TensorFlow, and TensorFlow can encapsulate handling unranked
+dynamism in a different layer, so overall this proposal looks like an
+improvement - it does require a non-trivial refactoring in one user, but in
+return it simplifies the StableHLO specification and implementation for
+everyone.
+
+B\) As discussed in [O2](#o2), the community is oftentimes using other dialects,
+including `arith` and `shape`, for shape computations. These dialects can be
+used with StableHLO programs, but there are interoperability issues which could
+be improved if: I) StableHLO used scalars instead of 0-dimensional tensors,
+II\) StableHLO used `index` instead of allowing integer and index types.
+
+However both of these changes need a significant amount of work, so they
+are not included in this RFC. I) requires extending the StableHLO opset with
+scalar operations, which involves defining semantics for these operations within
+StableHLO programs and getting buy-in from producers to support them. This is a
+fairly novel notion for the StableHLO ecosystem, so some further design
+exploration is needed here. II) is conceptually straightforward but will need
+updating a lot of code.

--- a/rfcs/20230704-dynamism-101.md
+++ b/rfcs/20230704-dynamism-101.md
@@ -16,9 +16,8 @@ the following:
 * [(P1) Move TensorFlow-specific operations out of StableHLO](#p1).
 * [(P2) Ratify the existing convention for shape mismatches constituting undefined behavior](#p2).
 * [(P3) Ratify the existing convention for relaxed constraints already implemented in the StableHLO dialect](#p3).
-* [(P4) Enable dynamism for all size-related program elements but keep all axis-related program elements static](#p4).
-* [(P5) Unify static and dynamic versions of StableHLO operations](#p5).
-* [(P6) Represent shape computations as StableHLO operations on 0-dimensional tensors and drop support for unranked dynamism](#p6).
+* [(P4) Enable shape-dependent dynamism for all size-related program elements but keep all axis-related program elements static](#p4).
+* [(P5) Represent shape computations as StableHLO operations on 0-dimensional tensors and drop support for unranked dynamism](#p5).
 <!-- markdownlint-enable line-length -->
 
 These proposals address a considerable chunk of community feedback on the
@@ -173,6 +172,11 @@ anything).
 it is not reflected in the StableHLO specification. As a result, dynamism
 semantics and especially constraints are underspecified.
 
+<a id="f9" /> **(F9)**. It is important for StableHLO programs to be hardware
+agnostic. As such the importance of having machinery which can refine dynamic
+programs into static programs for compilation for backends that require static
+shapes is of high important.
+
 ## Out of scope
 
 This RFC aims to address a considerable part of community feedback on the
@@ -200,7 +204,7 @@ StableHLO operations on 0-dimensional tensors, which is a practically important
 simplification for StableHLO programs and their producers/consumers.
 However, interoperability with other dialects, including `arith` and `shape`
 which are oftentimes used by the community for shape computations, is out of
-scope, and [P6](#p6) goes into details about the rationale.
+scope, and [P5](#p5) goes into details about the rationale.
 
 <a id="o3" /> **(O3)** Working out a common solution for shape checks would be
 nice. Per [F7](#f7), there are multiple incompatible approaches, so a common
@@ -241,11 +245,28 @@ there are `--stablehlo-refine-shapes` and `--stablehlo-canonicalize-dynamism`
 passes which address this problem. Furthermore, based on a semi-formal proof and
 the experience with JAX native serialization, the author believes that these
 passes are guaranteed to fully specialize dynamic StableHLO programs which only
-involve shape polymorphism and have static arguments to static StableHLO programs.
+involve shape polymorphism and have static arguments to static StableHLO
+programs.
 
 However, similarly to formalizing shape inference, formalizing shape
 specialization is a significant amount of work which is not on the critical
-path to [StableHLO v1.0](../docs/roadmap.md), so it is left for future work.
+path to [StableHLO v1.0](../docs/roadmap.md), so it is left for future work. In
+the meantime this refinement machinery and verification which ensures that
+programs are refinable will be made available to frameworks and hardware teams.
+Per the feedback in [F9](#f9), this RFC aims to only support shape dependent
+dynamism. Anything beyond shape dependent dynamism will be left to future RFCs.
+
+<a id="o7" /> **(O7)** Unifying dynamic and static op definitions was initially
+proposed in this RFC, but per reviewer feedback has been taken out of scope.
+
+There are several operations in the StableHLO dialect which provide dynamic
+versions of existing StableHLO operations. For example, `PadOp` defines
+`edge_padding_low`, `edge_padding_high` and `interior_padding` as static
+attributes, whereas `DynamicPadOp` has the same contract except that those
+arguments are dynamic values. Unifying these ops may be nice, but prior to that
+significant investigation to determine the usability of unified ops, as well as
+the impact of having unified ops on DRR users needs to be investigated. In this
+RFC [F2](#f2) remains unaddressed.
 
 <!-- markdownlint-disable line-length -->
 ## <a id="p1" /> (P1) Move TensorFlow-specific operations out of StableHLO
@@ -379,7 +400,7 @@ accordingly and file
 [Specification Compliance](https://github.com/orgs/openxla/projects/9) tickets.
 
 <!-- markdownlint-disable line-length -->
-## <a id="p4" /> (P4) Enable dynamism for all size-related program elements but keep all axis-related program elements static
+## <a id="p4" /> (P4) Enable shape-dependent dynamism for all size-related program elements but keep all axis-related program elements static
 <!-- markdownlint-enable line-length -->
 
 **Baseline:** The StableHLO dialect has inherited a considerable degree of
@@ -390,7 +411,9 @@ size-related MLIR attributes have dynamic counterparts.
 1\) As far as MLIR results go, for 7 operations in the StableHLO dialect -
 `BroadcastInDimOp`, `ConstantOp`, `InfeedOp`, `IotaOp`, `RecvOp`, `ReshapeOp`
 and `RngBitGeneratorOp` - the static shape of the results is "load-bearing",
-i.e. allowing dynamic shapes there would not make sense as is.
+i.e. allowing dynamic shapes there would not make sense as is. Operations that
+do not have "load-bearing" result shapes can infer result shapes with static
+operand shapes.
 
 ```mlir
 // Static result type - makes sense.
@@ -432,6 +455,14 @@ dialect which provide dynamic versions of existing StableHLO operations:
 `DynamicBroadcastInDimOp`, `DynamicConvOp`, `DynamicGatherOp`, `DynamicIotaOp`,
 `DynamicPadOp`, `DynamicReshapeOp` and `RealDynamicSliceOp`. Not all StableHLO
 operations have dynamic counterparts, e.g. there is no `DynamicReduceWindowOp`.
+Per the feedback in [F9](#f9), this RFC proposes to support shape-dependent uses
+of these operations, which are refinable to be used by the entire StableHLO
+ecosystem. In PyTorch and JAX, only shape-dependent uses of these operations
+exist. Meaning, the the dynamic operand value to specify the result shapes is a
+computation of the shape of on another operation. With this principle all
+StableHLO programs with dynamism are refinable to static programs by providing
+concrete input types. A refinement verification pass will be offered to ensure
+in frameworks that a generated program is shape-dependent / refinable.
 
 ```mlir
 // The StableHLO dialect resolves the conundrum mentioned in the previous
@@ -482,242 +513,31 @@ B\) From the implementation standpoint, this proposal would involve updating
 [the "Types" section](../docs/spec.md#types) of the specification to extend
 the definition of `TensorType` to express **dynamism within types** and
 accommodate both unbounded and bounded dynamism (but not unranked dynamism -
-see [P6](#p6) for details).
+see [P5](#p5) for details).
 
 However, this section doesn't provide an opinion on what representations should
 be used to express **dynamism within operations**. As mentioned in [F2](#f2),
 the existing design where static ops like `PadOp` are accompanied with dynamic
-ops like `DynamicPadOp` has some drawbacks, and the next section proposes how an
-improved design could look like.
+ops like `DynamicPadOp` has some drawbacks, which are denoted in [O7](#o7) as
+out of scope for this RFC.
 
 <!-- markdownlint-disable line-length -->
-## <a id="p5" /> (P5) Unify static and dynamic versions of StableHLO operations
-<!-- markdownlint-enable line-length -->
-
-**Baseline:** There are several operations in the StableHLO dialect which
-provide dynamic versions of existing StableHLO operations. For example, `PadOp`
-defines `edge_padding_low`, `edge_padding_high` and `interior_padding` as static
-attributes, whereas `DynamicPadOp` has the same contract except that those
-arguments are dynamic values.
-
-```mlir
-// Static version - in PadOp, padding options are represented as attributes.
-// %arg0 is the operand, %arg1 is the padding value.
-%0 = stablehlo.pad %arg0, %arg1, low = [1, 1], high = [1, 1], interior = [0, 0]
-  : (tensor<16x16xf32>, tensor<f32>) -> tensor<20x20xf32>
-
-// Dynamic version - in DynamicPadOp, padding options are represented as values.
-// The rest of the contract is the same.
-%2 = stablehlo.dynamic_pad %arg0, %arg1, %arg2, %arg3, %arg4 :
-  : (tensor<?x?xf32>, tensor<f32>, tensor<2xindex>, tensor<2xindex>, tensor<2xindex>) -> tensor<?x?xf32>
-```
-
-**Proposal:** This RFC proposes to take the 16 operations from [P4](#p4)
-(7 operations with "load-bearing" result types and 9 operations with
-size-related attributes) and generalize them to express both static and dynamic
-semantics.
-
-More specifically, the specification of these operations would change as follows
-(with special cases for `broadcast_in_dim` and `dynamic_slice` which are
-discussed separately below):
-
-1) For operations with "load-bearing" output types, add a new `output_shape`
-   input that has type "variadic number of 0-dimensional tensors of integer
-   type" and add a constraint `output_shape = shape(result)`. If the operation
-   has a variadic number of results, that would be `output_shapes`,
-   "variadic number of variadic number of ..." and
-   `output_shapes = shape(results...)`.
-2) For operations with size-related inputs, generalize them from
-   "1-dimensional tensor constant of type si64" to "variadic number of
-   0-dimensional tensors of integer type". The notation for existing
-   constraints pertaining to generalized inputs doesn't need to change
-   per [P3](#p3).
-
-The implementation of the StableHLO dialect would change as well, building
-on the experience from MLIR upstream where operations like
-`tensor::ExtractSliceOp`, `tensor::InsertSliceOp`, `tensor::PadOp` and others
-support both static and dynamic arguments
-([example](https://github.com/llvm/llvm-project/blob/f8cf2105760d2dfd58de4ca1c459c5bb1e2802dc/mlir/include/mlir/Dialect/Tensor/IR/TensorOps.td#L1161)
-). Note that this section is still using tensors to represent dynamic sizes,
-whereas MLIR upstream is using scalars. As mentioned in [F4](#f4), there's been
-community feedback that this design can be improved, and the next section
-proposes how an improved design could look like.
-
-```tablegen
-// Before: static version.
-def StableHLO_PadOp ... {
-  let arguments = (ins
-    HLO_Tensor:$operand,
-    HLO_Tensor:$padding_value,
-    I64ElementsAttr:$edge_padding_low,
-    I64ElementsAttr:$edge_padding_high,
-    I64ElementsAttr:$interior_padding
-  );
-}
-
-// Before: dynamic version.
-def StableHLO_DynamicPadOp ... {
-  let arguments = (ins
-    HLO_Tensor:$operand,
-    HLO_Tensor:$padding_value,
-    HLO_DimensionTensor:$edge_padding_low,
-    HLO_DimensionTensor:$edge_padding_high,
-    HLO_DimensionTensor:$interior_padding
-  );
-}
-
-// After: unified static and dynamic versions.
-def StableHLO_PadOp ... {
-  let arguments = (ins
-    HLO_Tensor:$operand,
-    HLO_Tensor:$padding_value,
-    I64ElementsAttr:$static_edge_padding_low,
-    I64ElementsAttr:$static_edge_padding_high,
-    I64ElementsAttr:$static_interior_padding,
-    HLO_DimensionTensor:$dynamic_edge_padding_low,
-    HLO_DimensionTensor:$dynamic_edge_padding_high,
-    HLO_DimensionTensor:$dynamic_interior_padding
-  );
-
-  let extraClassDeclaration = [{
-    // Breaks source compatibility with consumers: they will need to deal with
-    // the fact that arguments can now be either attributes or values.
-    OpFoldResult getEdgePaddingLow();
-    OpFoldResult getEdgePaddingHigh();
-    OpFoldResult getInteriorPadding();
-  }]
-
-  let builders = [
-    // Maintains source compatibility with PadOp producers.
-    OpBuilder<(ins "Type":$resultType, "Value":$operand,
-      "Value":$padding_value, "DenseIntElementsAttr":$edgePaddingLow,
-      "DenseIntElementsAttr":$edgePaddingHigh, "DenseIntElementsAttr":$interiorPadding)>,
-    OpBuilder<(ins "Value":$operand,
-      "Value":$padding_value, "DenseIntElementsAttr":$edgePaddingLow,
-      "DenseIntElementsAttr":$edgePaddingHigh, "DenseIntElementsAttr":$interiorPadding)>,
-
-    // Maintains source compatibility with DynamicPadOp producers.
-    // At the moment, StableHLO dialect doesn't support type inference for
-    // DynamicPadOp, so there's just one builder.
-    OpBuilder<(ins "Type":$resultType, "Value":$operand,
-      "Value":$padding_value, "Value":$edgePaddingLow,
-      "Value":$edgePaddingHigh, "Value":$interiorPadding)>,
-  ];
-}
-
-// After: deprecated and removed after the compatibility window expires.
-// Strictly speaking, DynamicPadOp is out of scope for StableHLO compatibility
-// guarantees per the "Unspecced features" clause.
-// However, dynamic ops are actively used in the community, so the RFC proposes
-// to provide exceptional compatibility guarantees for them.
-def StableHLO_DynamicPadOp ...
-```
-
-**Discussion:** A) The alternative to this proposal is to continue with the
-split between static and dynamic ops, which would mean introducing 7 new
-`DynamicFooOp` ops, e.g. `DynamicReduceWindowOp`, and additionally updating
-`DynamicConvOp` to be fully dynamic in size-related arguments.
-
-On the one hand, this alternative provides full source compatibility for both
-producers and consumers (in the main proposal, only producers have source
-compatibility). Furthermore, not all consumers support dynamic shapes, and the
-alternative makes it easy to reject dynamic ops by simply not supporting the
-corresponding `DynamicFooOp` ops.
-
-On the other hand, [per community feedback](#f2) (both the OpenXLA Dev Summit
-and in various conversations) there is considerable appetite for a unified
-solution. Furthermore, none of the benefits of the alternative are particularly
-compelling: StableHLO [doesn't guarantee](../docs/compatibility.md#out-of-scope)
-source compatibility at the moment, and consumers that don't support dynamic
-shapes already need to do more than just rejecting dynamic ops (they would also
-want to reject regular ops which are used with dynamic types). Therefore, the
-alternative proposal looks less attractive that the main proposal.
-
-B\) Two out of the 16 operations affected by the proposal - `broadcast_in_dim`
-and `dynamic_slice` - are special in that the general design principles in 1)
-and 2) are insufficient for handling them. This section dives into the details
-on that.
-
-B1) `broadcast_in_dim`: This is one of the special operations with a
-"load-bearing" output type, i.e. some parts of its semantics are defined only
-by the shape of the output. However, unlike other such operations, it is doubly
-special in that it doesn't treat this shape uniformly but additionally depends
-on magic values. For example, `reshape` works the same way for all kinds of
-shapes, but `broadcast_in_dim` distinguishes dimension sizes equal to 1
-(broadcast) and not equal to 1 (no broadcast).
-
-This presents a problem for some consumers, because this prevents efficient
-code generation for dynamic broadcasts (dynamically deciding on whether to
-broadcast isn't compatible with how most of the existing consumers express code
-at lower levels, e.g. there is no efficient lowering from the general case of
-dynamic broadcasts to Linalg).
-
-As a result, `DynamicBroadcastInDimOp` has two additional attributes:
-`known_expanding_dimensions` and `known_nonexpanding_dimensions` - which provide
-hints to consumers about whether specific axes are known to always broadcast,
-are known to never broadcast or neither. Depending on these hints, consumers can
-then decide to reject broadcasts which are insufficiently specific (e.g.
-this is exactly what happens in the MHLO to Linalg lowering:
-[here](https://github.com/tensorflow/mlir-hlo/blob/1fd13ef28d3f423363e59b1a80eb2c26e0c0979d/mhlo/transforms/legalize_to_linalg/legalize_to_linalg.cc#L938-L940)
-and
-[here](https://github.com/tensorflow/mlir-hlo/blob/1fd13ef28d3f423363e59b1a80eb2c26e0c0979d/mhlo/transforms/legalize_to_linalg/legalize_to_linalg.cc#L1006-L1008)).
-
-Based on practical experience with MHLO, this design has been recognized by the
-community as cumbersome, so
-[an alternative design](https://docs.google.com/document/d/1x8kCUsYzFEIeWO38h32bHlmDrieeu9UJTxpKe9gUm_g/edit)
-has been implemented in TCP: "The axes that need to be broadcast must be
-statically known. All broadcasted axes in the input tensor must have
-statically known size = 1. All other cases will result in compile-time errors".
-
-The design implemented in TCP looks attractive in its simplicity, but applying
-it to StableHLO would require non-trivial effort to migrate producers and
-consumers. Therefore, getting to the bottom of this is left for future work,
-and this RFCs merely proposes to use the `DynamicBroadcastInDimOp` design,
-adding `known_expanding_dimensions` and `known_nonexpanding_dimensions` inputs
-to `broadcast_in_dim`.
-
-B2) `dynamic_slice`: This operation is part of a 3-op family that includes
-`SliceOp`, `DynamicSliceOp` and `RealDynamicSliceOp`, and anecdotally this
-family is notoriously confusing for newcomers, so it is tempting to unify all
-the three ops into just `slice` as described above.
-
-However, semantics of `slice` and `dynamic_slice` are materially different
-in that `slice` expects slice sizes to be in bounds of the operand shape, but
-`dynamic_slice` doesn't - it clamps slice sizes to bring them in bounds before
-performing slicing.
-
-Similarly to B1, unifying `slice` and `dynamic_slice` would require non-trivial
-effort (and unlike B1, it is probably infeasible because of how heavily
-`DynamicSliceOp` is used). Therefore, getting to the bottom of this is left for
-future work, and this RFCs proposes to keep `dynamic_slice` unchanged.
-(But `RealDynamicSliceOp` would still be unified with `SliceOp`).
-
-C\) From the implementation standpoint, in addition to updating the
-specification and the StableHLO dialect as described in the "Proposal" section,
-there is one practical consideration worth discussing. Even though the proposed
-design doesn't involve `DynamicFooOp` operations, it may be worth it to
-introduce these operations (only in the StableHLO dialect) as an intermediate
-step. This would allow to roll out the new functionality (e.g.
-`DynamicReduceWindowOp`) sooner, without blocking on refactoring of the
-existing functionality (e.g. updating `ReduceWindowOp` as discussed above).
-
-<!-- markdownlint-disable line-length -->
-## <a id="p6" /> (P6) Represent shape computations as StableHLO operations on 0-dimensional tensors and drop support for unranked dynamism
+## <a id="p5" /> (P5) Represent shape computations as StableHLO operations on 0-dimensional tensors and drop support for unranked dynamism
 <!-- markdownlint-enable line-length -->
 
 **Baseline:** The StableHLO dialect represents sizes as 1-dimensional tensors,
-with static sizes expressed as `DenseIntElementsAttr` and dynamic sizes
+with static sizes expressed as `DenseI64ArrayAttr` and dynamic sizes
 expressed as `1DTensorOf<[HLO_DimensionValue]>`.
 
 ```c++
 class PadOp ... {
   // This is how static sizes are represented in TableGen:
-  // I64ElementsAttr:$edge_padding_low
-  // I64ElementsAttr:$edge_padding_high
-  // I64ElementsAttr:$interior_padding
-  DenseIntElementsAttr getEdgePaddingLow();
-  DenseIntElementsAttr getEdgePaddingHigh();
-  DenseIntElementsAttr getInteriorPadding();
+  // DenseI64ArrayAttr:$edge_padding_low
+  // DenseI64ArrayAttr:$edge_padding_high
+  // DenseI64ArrayAttr:$interior_padding
+  DenseI64ArrayAttr getEdgePaddingLow();
+  DenseI64ArrayAttr getEdgePaddingHigh();
+  DenseI64ArrayAttr getInteriorPadding();
 }
 
 class DynamicPadOp ... {
@@ -752,50 +572,64 @@ the proposal is to:
    supported in StableHLO portable artifacts (this can be changed in future
    RFCs, but is out of scope for this one).
 2) Use `Variadic<0DTensorOf<HLO_DimensionValue>>` instead of
-   `HLO_DimensionTensor` in the StableHLO dialect (this is consistent with
-   "variadic number of 0-dimensional tensors of integer type" from [P5](#p5)).
-3) Drop support for unranked dynamism in StableHLO (otherwise the operations
-   from P5 will no longer work for unranked operands).
+   `HLO_DimensionTensor` in the StableHLO dialect.
+3) Drop support for unranked dynamism in StableHLO.
 
 ```tablegen
-// See P5 for the "before" and "after" of unifying static and dynamic ops.
-// This snippet only shows the "after" for this section.
-def StableHLO_PadOp ... {
+def StableHLO_DynamicPadOp ... {
   let arguments = (ins
     HLO_Tensor:$operand,
     HLO_Tensor:$padding_value,
-    I64ElementsAttr:$static_edge_padding_low,
-    I64ElementsAttr:$static_edge_padding_high,
-    I64ElementsAttr:$static_interior_padding,
-    Variadic<0DTensorOf<HLO_DimensionValue>>:$dynamic_edge_padding_low,
-    Variadic<0DTensorOf<HLO_DimensionValue>>:$dynamic_edge_padding_high,
-    Variadic<0DTensorOf<HLO_DimensionValue>>:$dynamic_interior_padding
+    Variadic<0DTensorOf<HLO_DimensionValue>>:$edge_padding_low,
+    Variadic<0DTensorOf<HLO_DimensionValue>>:$edge_padding_high,
+    Variadic<0DTensorOf<HLO_DimensionValue>>:$interior_padding
   );
+}
+```
 
-  let extraClassDeclaration = [{
-    // Breaks source compatibility with consumers.
-    // However, it's already broken by P5.
-    ArrayRef<OpFoldResult> getEdgePaddingLow();
-    ArrayRef<OpFoldResult> getEdgePaddingHigh();
-    ArrayRef<OpFoldResult> getInteriorPadding();
-  }]
+In terms of a shape computation in a program, the following example roughly
+correlates to CHLO's broadcasting of unbounded dimensions. Currently there are
+additional `reshape` and `concatenate` operations that can be avoided by
+changing to use 0D tensor values in shape computations.
 
-  let builders = [
-    // Maintains source compatibility with PadOp producers.
-    OpBuilder<(ins "Type":$resultType, "Value":$operand,
-      "Value":$padding_value, "DenseIntElementsAttr":$edgePaddingLow,
-      "DenseIntElementsAttr":$edgePaddingHigh, "DenseIntElementsAttr":$interiorPadding)>,
-    OpBuilder<(ins "Value":$operand,
-      "Value":$padding_value, "DenseIntElementsAttr":$edgePaddingLow,
-      "DenseIntElementsAttr":$edgePaddingHigh, "DenseIntElementsAttr":$interiorPadding)>,
+CHLO `broadcast_add(tensor<?x?xf32>, tensor<?x?xf32>)`` with output shape
+specified using 1D tensors:
 
-    // Breaks source compatibility with DynamicPadOp producers: they will need
-    // to deal with the fact that edgePaddingLow, edgePaddingHigh and
-    // interiorPadding are no longer 1-dimensional tensors.
-    OpBuilder<(ins "Type":$resultType, "Value":$operand,
-      "Value":$padding_value, "ValueRange":$edgePaddingLow,
-      "ValueRange":$edgePaddingHigh, "ValueRange":$interiorPadding)>,
-  ];
+```mlir
+func.func @same_rank_broadcast_1D(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = stablehlo.get_dimension_size %arg0, dim = 0 : (tensor<?x?xf32>) -> tensor<i32>
+  %1 = stablehlo.get_dimension_size %arg0, dim = 1 : (tensor<?x?xf32>) -> tensor<i32>
+  %2 = stablehlo.get_dimension_size %arg1, dim = 0 : (tensor<?x?xf32>) -> tensor<i32>
+  %3 = stablehlo.get_dimension_size %arg1, dim = 1 : (tensor<?x?xf32>) -> tensor<i32>
+  %4 = stablehlo.reshape %0 : (tensor<i32>) -> tensor<1xi32>
+  %5 = stablehlo.reshape %1 : (tensor<i32>) -> tensor<1xi32>
+  %6 = stablehlo.reshape %2 : (tensor<i32>) -> tensor<1xi32>
+  %7 = stablehlo.reshape %3 : (tensor<i32>) -> tensor<1xi32>
+  %8 = stablehlo.concatenate %4, %5, dim = 0 : (tensor<1xi32>, tensor<1xi32>) -> tensor<2xi32>
+  %9 = stablehlo.concatenate %6, %7, dim = 0 : (tensor<1xi32>, tensor<1xi32>) -> tensor<2xi32>
+  %10 = stablehlo.maximum %8, %9 : tensor<2xi32>
+  %11 = stablehlo.dynamic_broadcast_in_dim %arg0, %10, dims = [0, 1] : (tensor<?x?xf32>, tensor<2xi32>) -> tensor<?x?xf32>
+  %12 = stablehlo.dynamic_broadcast_in_dim %arg1, %10, dims = [0, 1] : (tensor<?x?xf32>, tensor<2xi32>) -> tensor<?x?xf32>
+  %13 = stablehlo.add %11, %12 : tensor<?x?xf32>
+  return %13 : tensor<?x?xf32>
+}
+```
+
+The same computation with output shape specified using a variadic number of
+0D tensors:
+
+```mlir
+func.func @same_rank_broadcast_0D(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = stablehlo.get_dimension_size %arg0, dim = 0 : (tensor<?x?xf32>) -> tensor<i32>
+  %1 = stablehlo.get_dimension_size %arg0, dim = 1 : (tensor<?x?xf32>) -> tensor<i32>
+  %2 = stablehlo.get_dimension_size %arg1, dim = 0 : (tensor<?x?xf32>) -> tensor<i32>
+  %3 = stablehlo.get_dimension_size %arg1, dim = 1 : (tensor<?x?xf32>) -> tensor<i32>
+  %4 = stablehlo.maximum %0, %2 : tensor<i32>
+  %5 = stablehlo.maximum %1, %3 : tensor<i32>
+  %6 = stablehlo.dynamic_broadcast_in_dim %arg0, shape = [%4, %5], dims = [0, 1] : (tensor<?x?xf32>, tensor<2xi32>) -> tensor<?x?xf32>
+  %7 = stablehlo.dynamic_broadcast_in_dim %arg1, shape = [%4, %5], dims = [0, 1] : (tensor<?x?xf32>, tensor<2xi32>) -> tensor<?x?xf32>
+  %8 = stablehlo.add %6, %7 : tensor<?x?xf32>
+  return %8 : tensor<?x?xf32>
 }
 ```
 


### PR DESCRIPTION
The current design of dynamism in MHLO and StableHLO has been practically useful. There are success stories of it connecting JAX, PyTorch and TensorFlow to a number of compilers, in a mix of research and production environments. This RFC aims to leverage existing support for dynamism in the StableHLO dialect, discuss improvements to the existing design and then formalize the improved design in the StableHLO opset.

The main challenge with writing this RFC was that it affects the entire opset. The current design involves a lot of corner cases, so it took about a year of practical evaluation by the author - primarily within JAX native serialization, but also correlating with other ongoing and prior projects - to distill the design into just a few general design principles. I think I'm happy with the outcome, but please take a look at the "Summary" section for what that entails.

This RFC addresses a considerable chunk of community feedback on the existing design, but some feedback is deliberately left out of scope for this RFC to enable incremental progress while areas which require additional alignment are developed in parallel. See sections "Community feedback" and "Out of scope" for details.

The only open question at the moment is interoperability with HLO with respect to bounded dynamism. The proposed representation for bounded dynamic types in StableHLO is in parity with the representation for bounded dynamic types in HLO. However, I'm not sure whether this parity covers 100% of bounded dynamism functionality. For example: 1) there appears to be a mismatch in how broadcasts are represented, 2) there is misalignment in representations of dynamic windows (HLO has a high-level representation: VALID and SAME, whereas StableHLO expects the producers to dynamically compute window sizes). Nonetheless, I think that this shouldn't block the initial review of the RFC, since there's a lot of stuff to discuss - and in the meanwhile, I'll be working on confirming interoperability with HLO.

Finally, I'd like to acknowledge Smit Hinsu's work on the [Bounded Dynamism RFC](https://github.com/openxla/stablehlo/pull/194) from Q4 2022, which was superseded by this work. The representation for bounded dynamic types in the StableHLO dialect was designed and implemented by Smit, and Smit's proposal to allow bounded dynamic types everywhere is compatible with the more general proposal from this RFC to enable dynamism for all size-related program elements. Furthermore, Smit contributed the formal spec for get_dimension_size as well as the informal spec for set_dimension_size.