### PR TITLE
Port CHLO ops to I64DenseArrayOrElements1DAttr

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -95,6 +95,7 @@ cc_library(
     ],
     strip_include_prefix = ".",
     deps = [
+        ":base",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:ShapeDialect",
@@ -331,7 +332,6 @@ td_library(
     ],
 )
 
-
 gentbl_cc_library(
     name = "linalg_pass_inc_gen",
     strip_include_prefix = ".",
@@ -372,9 +372,9 @@ cc_library(
     ],
     strip_include_prefix = ".",
     deps = [
+        ":chlo_ops",
         ":linalg_pass_inc_gen",
         ":stablehlo_ops",
-        ":chlo_ops",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:BufferizationDialect",
@@ -396,7 +396,6 @@ cc_library(
         "@llvm-project//mlir:VectorDialect",
     ],
 )
-
 
 cc_library(
     name = "reference_api",
@@ -1462,10 +1461,9 @@ gentbl_cc_library(
 test_suite(
     name = "stablehlo_ci_tests",
     tests = [
+        "//stablehlo/conversions/linalg/tests:stablehlo_linalg_tests",
+        "//stablehlo/conversions/tosa/tests:stablehlo_tosa_tests",
         "//stablehlo/testdata:stablehlo_testdata_tests",
         "//stablehlo/tests:stablehlo_tests",
-        "//stablehlo/conversions/tosa/tests:stablehlo_tosa_tests",
-        "//stablehlo/conversions/linalg/tests:stablehlo_linalg_tests",
     ],
 )
-

--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -602,7 +602,7 @@ ShapedType createShapedType(ShapedTypeComponents components) {
 
 // TODO(#1578): Remove this code once all uses of I64DenseArrayOrElements1DAttr
 // have been removed.
-SmallVector<int64_t> i64ArrayOrElementsValues(Attribute attr) {
+SmallVector<int64_t> getI64Array(Attribute attr) {
   SmallVector<int64_t> vec;
   if (!attr) return vec;
   if (auto elements = dyn_cast_or_null<DenseIntElementsAttr>(attr)) {

--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -603,19 +603,15 @@ ShapedType createShapedType(ShapedTypeComponents components) {
 // TODO(#1578): Remove this code once all uses of I64DenseArrayOrElements1DAttr
 // have been removed.
 SmallVector<int64_t> getI64Array(Attribute attr) {
-  SmallVector<int64_t> vec;
-  if (!attr) return vec;
-  if (auto elements = dyn_cast_or_null<DenseIntElementsAttr>(attr)) {
-    vec = llvm::to_vector(elements.getValues<int64_t>());
-  } else if (auto array = dyn_cast_or_null<DenseI64ArrayAttr>(attr)) {
-    vec = llvm::to_vector(array.asArrayRef());
-  } else {
-    llvm::report_fatal_error(
-        "called i64ArrayOrElementsValues on Attribute that was neither a "
-        "DenseIntElementsAttr or a DenseI64ArrayAttr",
-        false);
-  }
-  return vec;
+  if (!attr) return {};
+  if (auto elements = attr.dyn_cast<DenseIntElementsAttr>())
+    return llvm::to_vector(elements.getValues<int64_t>());
+  if (auto array = attr.dyn_cast<DenseI64ArrayAttr>())
+    return llvm::to_vector(array.asArrayRef());
+  llvm::report_fatal_error(
+      "called i64ArrayOrElementsValues on Attribute that was neither a "
+      "DenseIntElementsAttr or a DenseI64ArrayAttr",
+      false);
 }
 
 }  // namespace hlo

--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -600,5 +600,23 @@ ShapedType createShapedType(ShapedTypeComponents components) {
   return UnrankedTensorType::get(components.getElementType());
 }
 
+// TODO(#1578): Remove this code once all uses of I64DenseArrayOrElements1DAttr
+// have been removed.
+SmallVector<int64_t> i64ArrayOrElementsValues(Attribute attr) {
+  SmallVector<int64_t> vec;
+  if (!attr) return vec;
+  if (auto elements = dyn_cast_or_null<DenseIntElementsAttr>(attr)) {
+    vec = llvm::to_vector(elements.getValues<int64_t>());
+  } else if (auto array = dyn_cast_or_null<DenseI64ArrayAttr>(attr)) {
+    vec = llvm::to_vector(array.asArrayRef());
+  } else {
+    llvm::report_fatal_error(
+        "called i64ArrayOrElementsValues on Attribute that was neither a "
+        "DenseIntElementsAttr or a DenseI64ArrayAttr",
+        false);
+  }
+  return vec;
+}
+
 }  // namespace hlo
 }  // namespace mlir

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -56,7 +56,7 @@ inline static bool isStaticDimSize(int64_t val) {
   return !isDynamicDimSize(val);
 }
 
-SmallVector<int64_t> i64ArrayOrElementsValues(Attribute);
+SmallVector<int64_t> getI64Array(Attribute);
 
 //  Verifies that the two types have compatible shape with bounds but allows
 //  different element types.

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -56,6 +56,8 @@ inline static bool isStaticDimSize(int64_t val) {
   return !isDynamicDimSize(val);
 }
 
+SmallVector<int64_t> i64ArrayOrElementsValues(Attribute);
+
 //  Verifies that the two types have compatible shape with bounds but allows
 //  different element types.
 LogicalResult verifyCompatibleShapeWithBounds(Type type1, Type type2);

--- a/stablehlo/dialect/Base.td
+++ b/stablehlo/dialect/Base.td
@@ -236,4 +236,24 @@ def HLO_BoundedAttrInterface : AttrInterface<"BoundedAttrInterface"> {
   >];
 }
 
+//===----------------------------------------------------------------------===//
+// Common attrs.
+//===----------------------------------------------------------------------===//
+
+def I64Elements1D : And<[I64ElementsAttr.predicate,  CPred<"$_self.cast<DenseIntElementsAttr>().getType().getRank() == 1">]>;
+
+// TODO(#1578) migrate uses to DenseI64ArrayAttr and delete this attr
+def I64DenseArrayOrElements1DAttr : Attr<Or<[DenseI64ArrayAttr.predicate, I64Elements1D]>, "either a DenseI64ArrayAttr or a 1-dimensional I64ElementsAttr."> {
+  let storageType = "Attribute";
+  let returnType = "SmallVector<int64_t>";
+  let convertFromStorage = [{
+    [&]() -> SmallVector<int64_t> {
+      if (auto elems = $_self.dyn_cast<DenseIntElementsAttr>()) {
+        return llvm::to_vector(elems.getValues<int64_t>());
+      }
+      return llvm::to_vector($_self.cast<DenseI64ArrayAttr>().asArrayRef());
+    }()
+  }];
+}
+
 #endif // STABLEHLO_DIALECT_BASE

--- a/stablehlo/dialect/Base.td
+++ b/stablehlo/dialect/Base.td
@@ -246,11 +246,7 @@ def I64Elements1D : And<[I64ElementsAttr.predicate,  CPred<"$_self.cast<DenseInt
 def I64DenseArrayOrElements1DAttr : Attr<Or<[DenseI64ArrayAttr.predicate, I64Elements1D]>, "either a DenseI64ArrayAttr or a 1-dimensional I64ElementsAttr."> {
   let storageType = "Attribute";
   let returnType = "SmallVector<int64_t>";
-  let convertFromStorage = [{
-    [&]() -> SmallVector<int64_t> {
-      return hlo::getI64Array($_self);
-    }()
-  }];
+  let convertFromStorage = "hlo::getI64Array($_self)";
 }
 
 #endif // STABLEHLO_DIALECT_BASE

--- a/stablehlo/dialect/Base.td
+++ b/stablehlo/dialect/Base.td
@@ -248,10 +248,7 @@ def I64DenseArrayOrElements1DAttr : Attr<Or<[DenseI64ArrayAttr.predicate, I64Ele
   let returnType = "SmallVector<int64_t>";
   let convertFromStorage = [{
     [&]() -> SmallVector<int64_t> {
-      if (auto elems = $_self.dyn_cast<DenseIntElementsAttr>()) {
-        return llvm::to_vector(elems.getValues<int64_t>());
-      }
-      return llvm::to_vector($_self.cast<DenseI64ArrayAttr>().asArrayRef());
+      return hlo::getI64Array($_self);
     }()
   }];
 }

--- a/stablehlo/dialect/BroadcastUtils.cpp
+++ b/stablehlo/dialect/BroadcastUtils.cpp
@@ -28,10 +28,7 @@ namespace mlir {
 namespace hlo {
 
 bool isLegalNumpyRankedBroadcast(Value lhs, Value rhs,
-                                 Attribute broadcastDimensionsAttr) {
-  auto broadcastDimensions =
-      hlo::i64ArrayOrElementsValues(broadcastDimensionsAttr);
-
+                                 ArrayRef<int64_t> broadcastDimensions) {
   RankedTensorType lhsType = lhs.getType().dyn_cast<RankedTensorType>();
   RankedTensorType rhsType = rhs.getType().dyn_cast<RankedTensorType>();
   if (!lhsType || !rhsType) return false;

--- a/stablehlo/dialect/BroadcastUtils.cpp
+++ b/stablehlo/dialect/BroadcastUtils.cpp
@@ -27,7 +27,7 @@ namespace mlir {
 namespace hlo {
 
 bool isLegalNumpyRankedBroadcast(Value lhs, Value rhs,
-                                 DenseIntElementsAttr broadcastDims) {
+                                 ArrayRef<int64_t> broadcastDims) {
   RankedTensorType lhsType = lhs.getType().dyn_cast<RankedTensorType>();
   RankedTensorType rhsType = rhs.getType().dyn_cast<RankedTensorType>();
   if (!lhsType || !rhsType) return false;
@@ -37,11 +37,11 @@ bool isLegalNumpyRankedBroadcast(Value lhs, Value rhs,
   auto smallerRank = std::min(lhsType.getRank(), rhsType.getRank());
   auto largerRank = std::max(lhsType.getRank(), rhsType.getRank());
 
-  if (smallerRank != broadcastDims.getNumElements()) return false;
+  if (smallerRank != static_cast<int64_t>(broadcastDims.size())) return false;
   auto expectedExtents =
       llvm::seq<int64_t>(largerRank - smallerRank, largerRank);
   return std::equal(expectedExtents.begin(), expectedExtents.end(),
-                    broadcastDims.value_begin<APInt>());
+                    broadcastDims.begin());
 }
 
 Value computeBinaryElementwiseBroadcastingResultExtents(Location loc, Value lhs,

--- a/stablehlo/dialect/BroadcastUtils.cpp
+++ b/stablehlo/dialect/BroadcastUtils.cpp
@@ -27,7 +27,21 @@ namespace mlir {
 namespace hlo {
 
 bool isLegalNumpyRankedBroadcast(Value lhs, Value rhs,
-                                 ArrayRef<int64_t> broadcastDims) {
+                                 Attribute broadcastDimensionsAttr) {
+  // TODO(#1578): Simplify this code once broadcast_dimensions uses
+  // DenseI64ArrayAttr (instead of I64DenseArrayOrElements1DAttr).
+  std::optional<SmallVector<int64_t>> broadcastDimensions;
+  if (auto attr =
+          dyn_cast_or_null<DenseIntElementsAttr>(broadcastDimensionsAttr)) {
+    broadcastDimensions = llvm::to_vector(attr.getValues<int64_t>());
+  } else if (auto attr =
+                 dyn_cast_or_null<DenseI64ArrayAttr>(broadcastDimensionsAttr)) {
+    broadcastDimensions = llvm::to_vector(attr.asArrayRef());
+  }
+  if (!broadcastDimensions) {
+    return false;
+  }
+
   RankedTensorType lhsType = lhs.getType().dyn_cast<RankedTensorType>();
   RankedTensorType rhsType = rhs.getType().dyn_cast<RankedTensorType>();
   if (!lhsType || !rhsType) return false;
@@ -37,11 +51,12 @@ bool isLegalNumpyRankedBroadcast(Value lhs, Value rhs,
   auto smallerRank = std::min(lhsType.getRank(), rhsType.getRank());
   auto largerRank = std::max(lhsType.getRank(), rhsType.getRank());
 
-  if (smallerRank != static_cast<int64_t>(broadcastDims.size())) return false;
+  if (smallerRank != static_cast<int64_t>(broadcastDimensions->size()))
+    return false;
   auto expectedExtents =
       llvm::seq<int64_t>(largerRank - smallerRank, largerRank);
   return std::equal(expectedExtents.begin(), expectedExtents.end(),
-                    broadcastDims.begin());
+                    broadcastDimensions->begin());
 }
 
 Value computeBinaryElementwiseBroadcastingResultExtents(Location loc, Value lhs,

--- a/stablehlo/dialect/BroadcastUtils.h
+++ b/stablehlo/dialect/BroadcastUtils.h
@@ -34,7 +34,7 @@ namespace hlo {
 // to the smaller ranked operand until it is of the same rank as the larger).
 // See: https://docs.scipy.org/doc/numpy/reference/ufuncs.html
 bool isLegalNumpyRankedBroadcast(Value lhs, Value rhs,
-                                 DenseIntElementsAttr broadcastDims);
+                                 ArrayRef<int64_t> broadcastDims);
 
 // Emits shape dialect ops to compute the result shape for a broadcasting
 // binary/n-ary elementwise op which broadcasts according to "numpy" semantics

--- a/stablehlo/dialect/BroadcastUtils.h
+++ b/stablehlo/dialect/BroadcastUtils.h
@@ -33,7 +33,8 @@ namespace hlo {
 // legal combination for "numpy" style broadcasting (where 1-dims are prepended
 // to the smaller ranked operand until it is of the same rank as the larger).
 // See: https://docs.scipy.org/doc/numpy/reference/ufuncs.html
-bool isLegalNumpyRankedBroadcast(Value lhs, Value rhs, Attribute broadcastDims);
+bool isLegalNumpyRankedBroadcast(Value lhs, Value rhs,
+                                 ArrayRef<int64_t> broadcastDims);
 
 // Emits shape dialect ops to compute the result shape for a broadcasting
 // binary/n-ary elementwise op which broadcasts according to "numpy" semantics

--- a/stablehlo/dialect/BroadcastUtils.h
+++ b/stablehlo/dialect/BroadcastUtils.h
@@ -33,8 +33,7 @@ namespace hlo {
 // legal combination for "numpy" style broadcasting (where 1-dims are prepended
 // to the smaller ranked operand until it is of the same rank as the larger).
 // See: https://docs.scipy.org/doc/numpy/reference/ufuncs.html
-bool isLegalNumpyRankedBroadcast(Value lhs, Value rhs,
-                                 ArrayRef<int64_t> broadcastDims);
+bool isLegalNumpyRankedBroadcast(Value lhs, Value rhs, Attribute broadcastDims);
 
 // Emits shape dialect ops to compute the result shape for a broadcasting
 // binary/n-ary elementwise op which broadcasts according to "numpy" semantics

--- a/stablehlo/dialect/ChloOps.cpp
+++ b/stablehlo/dialect/ChloOps.cpp
@@ -164,7 +164,8 @@ LogicalResult ReifyBroadcastBinaryOpReturnTypeShapes(
   // Check for "numpy"-style rank broadcast.
   auto broadcastDimensionsAttr = op->getAttr("broadcast_dimensions");
   if (broadcastDimensionsAttr &&
-      !hlo::isLegalNumpyRankedBroadcast(lhs, rhs, broadcastDimensionsAttr)) {
+      !hlo::isLegalNumpyRankedBroadcast(
+          lhs, rhs, hlo::getI64Array(broadcastDimensionsAttr))) {
     // Note: It is unclear whether the general specification of explicit
     // broadcast_dimensions on binary ops is a feature we want to carry
     // forward. While it can technically be implemented for ranked-dynamic,

--- a/stablehlo/dialect/ChloOps.cpp
+++ b/stablehlo/dialect/ChloOps.cpp
@@ -162,19 +162,9 @@ LogicalResult ReifyBroadcastBinaryOpReturnTypeShapes(
   auto rhs = operands[1];
 
   // Check for "numpy"-style rank broadcast.
-  // TODO(#1578): Simplify this code once broadcast_dimensions uses
-  // DenseI64ArrayAttr (instead of I64DenseArrayOrElements1DAttr).
   auto broadcastDimensionsAttr = op->getAttr("broadcast_dimensions");
-  std::optional<SmallVector<int64_t>> broadcastDimensions;
-  if (auto attr =
-          dyn_cast_or_null<DenseIntElementsAttr>(broadcastDimensionsAttr)) {
-    broadcastDimensions = llvm::to_vector(attr.getValues<int64_t>());
-  } else if (auto attr =
-                 dyn_cast_or_null<DenseI64ArrayAttr>(broadcastDimensionsAttr)) {
-    broadcastDimensions = llvm::to_vector(attr.asArrayRef());
-  }
-  if (broadcastDimensions &&
-      !hlo::isLegalNumpyRankedBroadcast(lhs, rhs, *broadcastDimensions)) {
+  if (broadcastDimensionsAttr &&
+      !hlo::isLegalNumpyRankedBroadcast(lhs, rhs, broadcastDimensionsAttr)) {
     // Note: It is unclear whether the general specification of explicit
     // broadcast_dimensions on binary ops is a feature we want to carry
     // forward. While it can technically be implemented for ranked-dynamic,

--- a/stablehlo/dialect/ChloOps.td
+++ b/stablehlo/dialect/ChloOps.td
@@ -101,7 +101,7 @@ class CHLO_BroadcastBinaryElementwiseOp<
     HLO_Tensor:$rhs,
     // Explicit rank-broadcast dimension mappings. Defaults to "numpy" prefix
     // padded rank-broadcast semantics if omitted.
-    OptionalAttr<BroadcastDimAttr>:$broadcast_dimensions
+    OptionalAttr<I64DenseArrayOrElements1DAttr>:$broadcast_dimensions
   );
 
   let results = (outs HLO_Tensor);
@@ -313,7 +313,7 @@ def CHLO_BroadcastZetaOp : CHLO_BroadcastBinaryElementwiseOp<
     HLO_FpTensor:$rhs,
     // Explicit rank-broadcast dimension mappings. Defaults to "numpy" prefix
     // padded rank-broadcast semantics if omitted.
-    OptionalAttr<BroadcastDimAttr>:$broadcast_dimensions
+    OptionalAttr<I64DenseArrayOrElements1DAttr>:$broadcast_dimensions
   );
   let results = (outs HLO_FpTensor);
 }
@@ -331,7 +331,7 @@ class CHLO_BroadcastBinaryLogicalElementwiseOp<string mnemonic> :
     HLO_PredOrIntTensor:$rhs,
     // Explicit rank-broadcast dimension mappings. Defaults to "numpy" prefix
     // padded rank-broadcast semantics if omitted.
-    OptionalAttr<BroadcastDimAttr>:$broadcast_dimensions
+    OptionalAttr<I64DenseArrayOrElements1DAttr>:$broadcast_dimensions
   );
 }
 
@@ -448,7 +448,7 @@ def CHLO_BroadcastComplexOp : CHLO_BroadcastBinaryElementwiseOp<
     HLO_FpTensor:$rhs,
     // Explicit rank-broadcast dimension mappings. Defaults to "numpy" prefix
     // padded rank-broadcast semantics if omitted.
-    OptionalAttr<BroadcastDimAttr>:$broadcast_dimensions
+    OptionalAttr<I64DenseArrayOrElements1DAttr>:$broadcast_dimensions
   );
   let results = (outs HLO_ComplexTensor);
 }
@@ -755,7 +755,7 @@ def CHLO_BroadcastCompareOp : CHLO_BroadcastBinaryElementwiseOp<
   let arguments = (ins
     HLO_Tensor:$lhs,
     HLO_Tensor:$rhs,
-    OptionalAttr<BroadcastDimAttr>:$broadcast_dimensions,
+    OptionalAttr<I64DenseArrayOrElements1DAttr>:$broadcast_dimensions,
     CHLO_ComparisonDirectionAttr:$comparison_direction,
     OptionalAttr<CHLO_ComparisonTypeAttr>:$compare_type
   );
@@ -763,7 +763,7 @@ def CHLO_BroadcastCompareOp : CHLO_BroadcastBinaryElementwiseOp<
 
   let builders = [
     OpBuilder<(ins "Value":$lhs, "Value":$rhs,
-      "DenseIntElementsAttr":$broadcast_dimensions,
+      "Attribute":$broadcast_dimensions,
       "::mlir::chlo::ComparisonDirection":$comparison_direction,
       CArg<"::mlir::chlo::ComparisonType",
       "::mlir::chlo::ComparisonType::NOTYPE">:$compare_type)>,

--- a/stablehlo/dialect/StablehloAttrs.td
+++ b/stablehlo/dialect/StablehloAttrs.td
@@ -105,7 +105,7 @@ def StableHLO_OutputOperandAlias : AttrDef<StableHLO_Dialect, "OutputOperandAlia
 }
 
 // Represents a unique identifier for each Send/Recv instruction pair or
-// optionally for collective instructions (AllToAll, AllReduce, 
+// optionally for collective instructions (AllToAll, AllReduce,
 // CollectiveBroadcast, and CollectivePermute). Non-positive channel_id
 // handle is equivalent to no channel id.
 def StableHLO_ChannelHandle : AttrDef<StableHLO_Dialect, "ChannelHandle"> {

--- a/stablehlo/dialect/StablehloAttrs.td
+++ b/stablehlo/dialect/StablehloAttrs.td
@@ -209,20 +209,4 @@ def StableHLO_ConvolutionAttributes {
   );
 }
 
-def I64Elements1D : And<[I64ElementsAttr.predicate,  CPred<"$_self.cast<DenseIntElementsAttr>().getType().getRank() == 1">]>;
-
-// TODO(#1578) migrate uses to DenseI64ArrayAttr and delete this attr
-def I64DenseArrayOrElements1DAttr : Attr<Or<[DenseI64ArrayAttr.predicate, I64Elements1D]>, "either a DenseI64ArrayAttr or a 1-dimensional I64ElementsAttr."> {
-  let storageType = "Attribute";
-  let returnType = "SmallVector<int64_t>";
-  let convertFromStorage = [{
-    [&]() -> SmallVector<int64_t> {
-      if (auto elems = $_self.dyn_cast<DenseIntElementsAttr>()) {
-        return llvm::to_vector(elems.getValues<int64_t>());
-      }
-      return llvm::to_vector($_self.cast<DenseI64ArrayAttr>().asArrayRef());
-    }()
-  }];
-}
-
 #endif // STABLEHLO_DIALECT_STABLEHLO_ATTRS

--- a/stablehlo/tests/infer_chlo.mlir
+++ b/stablehlo/tests/infer_chlo.mlir
@@ -18,7 +18,7 @@ func.func @broadcast_add_reify(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> te
 // -----
 // CHECK-LABEL: @broadcast_add_different_operand_size
 func.func @broadcast_add_different_operand_size(%arg1: tensor<1xi32>, %arg2: tensor<1x2xi32>) -> tensor<1x2xi32> {
-  %0 = "chlo.broadcast_add"(%arg1, %arg2) {broadcast_dimensions = dense<1> : tensor<i64>} : (tensor<1xi32>, tensor<1x2xi32>) -> tensor<1x2xi32>
+  %0 = "chlo.broadcast_add"(%arg1, %arg2) {broadcast_dimensions = array<i64: 1>} : (tensor<1xi32>, tensor<1x2xi32>) -> tensor<1x2xi32>
   // CHECK: types0 = tensor<1x2xi32>
   %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<1x2xi32>) -> tensor<1x2xi32>
   return %1: tensor<1x2xi32>
@@ -65,8 +65,8 @@ func.func @broadcast_compare_ranked_components(%arg0: tensor<?xf32>, %arg1: tens
 // -----
 // CHECK-LABEL: @broadcast_compare_unranked_reify
 func.func @broadcast_compare_unranked_reify(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<?xindex> {
-  // expected-warning @+1 {{unsupported non prefix-padded dynamic rank broadcast_dimensions = dense<1> : tensor<1xi64>}}
-  %0 = chlo.broadcast_compare %arg0, %arg1 {broadcast_dimensions = dense<1> : tensor<1xi64>, comparison_direction = #chlo<comparison_direction EQ>} : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xi1>
+  // expected-warning @+1 {{unsupported non prefix-padded dynamic rank broadcast_dimensions = array<i64: 1>}}
+  %0 = chlo.broadcast_compare %arg0, %arg1 {broadcast_dimensions = array<i64: 1>, comparison_direction = #chlo<comparison_direction EQ>} : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xi1>
   %1 = "hlo_test_infer.reify_return_type_shapes"(%0) : (tensor<*xi1>) -> tensor<?xindex>
   func.return %1 : tensor<?xindex>
 }

--- a/stablehlo/tests/ops_chlo_roundtrip.mlir
+++ b/stablehlo/tests/ops_chlo_roundtrip.mlir
@@ -367,12 +367,12 @@ func.func @chlo_broadcast_complex(%arg0: tensor<2x3x4xf64>, %arg1: tensor<2x3x4x
 // CHECK-SAME:  %[[A1:.*]]: tensor<2x3x4xf64>
 // CHECK:       %[[T0:.*]] = chlo.broadcast_compare %[[A0]], %[[A1]] {comparison_direction = #chlo<comparison_direction LT>} : (tensor<2x3x4xf64>, tensor<2x3x4xf64>) -> tensor<2x3x4xi1>
 // CHECK:       %[[T1:.*]] = chlo.broadcast_compare %[[A0]], %[[A1]] {compare_type = #chlo<comparison_type TOTALORDER>, comparison_direction = #chlo<comparison_direction LT>} : (tensor<2x3x4xf64>, tensor<2x3x4xf64>) -> tensor<2x3x4xi1>
-// CHECK:       %[[T2:.*]] = chlo.broadcast_compare %[[A0]], %[[A1]] {broadcast_dimensions = dense<1> : tensor<1xi64>, comparison_direction = #chlo<comparison_direction LT>} : (tensor<2x3x4xf64>, tensor<2x3x4xf64>) -> tensor<2x3x4xi1>
+// CHECK:       %[[T2:.*]] = chlo.broadcast_compare %[[A0]], %[[A1]] {broadcast_dimensions = array<i64: 1>, comparison_direction = #chlo<comparison_direction LT>} : (tensor<2x3x4xf64>, tensor<2x3x4xf64>) -> tensor<2x3x4xi1>
 // CHECK:       return %[[T0]] : tensor<2x3x4xi1>
 func.func @chlo_broadcast_compare(%arg0: tensor<2x3x4xf64>, %arg1: tensor<2x3x4xf64>) -> tensor<2x3x4xi1> {
   %0 = chlo.broadcast_compare %arg0, %arg1 {comparison_direction = #chlo<comparison_direction LT>} : (tensor<2x3x4xf64>, tensor<2x3x4xf64>) -> tensor<2x3x4xi1>
   %1 = chlo.broadcast_compare %arg0, %arg1 {comparison_direction = #chlo<comparison_direction LT>, compare_type = #chlo<comparison_type TOTALORDER>} : (tensor<2x3x4xf64>, tensor<2x3x4xf64>) -> tensor<2x3x4xi1>
-  %2 = chlo.broadcast_compare %arg0, %arg1 {comparison_direction = #chlo<comparison_direction LT>, broadcast_dimensions = dense<1> : tensor<1xi64>} : (tensor<2x3x4xf64>, tensor<2x3x4xf64>) -> tensor<2x3x4xi1>
+  %2 = chlo.broadcast_compare %arg0, %arg1 {comparison_direction = #chlo<comparison_direction LT>, broadcast_dimensions = array<i64: 1>} : (tensor<2x3x4xf64>, tensor<2x3x4xf64>) -> tensor<2x3x4xi1>
   return %0 : tensor<2x3x4xi1>
 }
 


### PR DESCRIPTION
This is an intermediate step in the migration to `DenseI64ArrayAttr`.

I had to move the definition for the attr to `Base.td` because it's now used in `ChloOps.td` as well as `StablehloOps.td`.

I also had to do some shenanigans to support checking if the `broadcast_dimensions` are legal in
`ReifyBroadcastBinaryOpReturnTypeShapes`. Because the attr is obtained through generic means (`op->getAttr("broadcast_dimensions")`); it doesn't go through the conversion from storage (e.g. when doing `op.getBroadcastDimensions`, which returns `SmallVector<int64_t>`), so both `DenseIntElementsAttr` and `DenseI64ArrayAttr` have to be handled.

Ideally, I would be able to do `dyn_cast<I64DenseArrayOrElements1DAttr>` and use a custom method on the attr to get the integers, but I see no way to define a custom method on an attr. If we end up needing to do this in more than one place I'll extract a function for it.

https://github.com/openxla/stablehlo/issues/1578