### PR TITLE
build: add missing dependency on InterpreterOps

### DIFF
--- a/stablehlo/transforms/CMakeLists.txt
+++ b/stablehlo/transforms/CMakeLists.txt
@@ -31,6 +31,7 @@ add_mlir_dialect_library(StablehloPasses
 
   LINK_LIBS PUBLIC
   ChloOps
+  InterpreterOps
   MLIRFuncDialect
   MLIRIR
   MLIRInferTypeOpInterface


### PR DESCRIPTION
Commit afd8f5bd6 introduced a file (StablehloInstrumentWithProbe.cpp)
that references `interpreter::ProbeOp` (defined in the InterpreterOps
library target), but this dependency was not added to the CMake build
rules for building the StablehloPasses target, which includes code from
StablehloInstrumentWithProbe.cpp.  As a result, builds (sometime) fail
with the following error:

```
Linking CXX shared library lib/libStablehloPasses.so
CMakeFiles/obj.StablehloPasses.dir/StablehloInstrumentWithProbe.cpp.o:
...
undefined reference to `mlir::stablehlo::interpreter::ProbeOp::build
...
```

This patch fixes the CMake build error by adding InterpreterOps as a
library dependency of the StablehloPasses target.

Credit to @hamptonm1 for discovering the problem.