### PR TITLE
Bump action versions to silence node12 warning

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -27,7 +27,7 @@ runs:
 
   steps:
   # Checkout llvm at version specified in input argument.
-  - uses: actions/checkout@v2
+  - uses: actions/checkout@v4
     with:
       repository: llvm/llvm-project
       ref: ${{ inputs.llvm-version }}
@@ -36,7 +36,7 @@ runs:
 
   # Get ninja for cmake build.
   - name: Install Ninja
-    uses: llvm/actions/install-ninja@55d844821959226fab4911f96f37071c1d4c3268
+    uses: llvm/actions/install-ninja@6a57890d0e3f9f35dfc72e7e48bc5e1e527cdd6c
 
   # Get LLD - Improves build speed on Linux
   - name: Install LLD

--- a/.github/workflows/buildAndTestBazel.yml
+++ b/.github/workflows/buildAndTestBazel.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
     - name: Checkout StableHLO
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Validate LLVM Commit
       run: |

--- a/.github/workflows/buildAndTestCMake.yml
+++ b/.github/workflows/buildAndTestCMake.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
     - name: Checkout StableHLO
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Get LLVM Version
       id: llvm-version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-22.04'  }}
     steps:
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run clang-format
         run: |
@@ -45,7 +45,7 @@ jobs:
     runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-22.04'  }}
     steps:
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run Whitespace Checks
         run: |
@@ -57,7 +57,7 @@ jobs:
     runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-22.04'  }}
     steps:
       - name: Checking out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run Version Checks
         run: |

--- a/.github/workflows/markdown_lint.yml
+++ b/.github/workflows/markdown_lint.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-22.04'  }}
     steps:
     - name: Checking out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Running markdownlint
       run: |
         ./build_tools/github_actions/lint_markdown.sh "./**/*.md"


### PR DESCRIPTION
I noticed that some of our actions produce a warning when they run, e.g.:

```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, llvm/actions/install-ninja@55d844821959226fab4911f96f37071c1d4c3268. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

This isn't a huge deal but it's unnecessary noise and it's probably best to use more recent versions of the actions we use anyway.

So I'm bumping the `checkout` action (which is developed by GitHub) to the latest version (v4), and I'm bumping the LLVM `install-ninja` action to [the commit](https://github.com/llvm/actions/commit/6a57890d0e3f9f35dfc72e7e48bc5e1e527cdd6c) where the `node` version was bumped to 16.