### PR TITLE
Remove location constraint on compact printing of ReduceOpt

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1492,9 +1492,7 @@ bool hasSameOperandAndResultTypes(Operation& op) {
 //     first input-operand.
 // E4. The  arguments of the region's only basic block are forwarded perfectly
 //     to inner-op's operands.
-// E5. The reduce-op, inner-op, blocks arguments, and the return-op all have the
-//     same location.
-// E6. The single operation result is perfectly forwarded to the reduce op
+// E5. The single operation result is perfectly forwarded to the reduce op
 //     return.
 static bool isEligibleForCompactPrint(ReduceOp op) {
   // Check E1.
@@ -1528,14 +1526,6 @@ static bool isEligibleForCompactPrint(ReduceOp op) {
   auto retOp = dyn_cast<ReturnOp>(block.getTerminator());
   if (!retOp) return false;
 
-  auto blockArgLoc = block.getArgument(0).getLoc();
-  if (blockArgLoc != block.getArgument(1).getLoc()) return false;
-
-  if (innerOp.getLoc() != op.getLoc() || retOp.getLoc() != op.getLoc() ||
-      blockArgLoc != op.getLoc())
-    return false;
-
-  // Check E6.
   return llvm::equal(innerOp.getResults(), retOp.getOperands());
 }
 

--- a/stablehlo/tests/ops_sparse.mlir
+++ b/stablehlo/tests/ops_sparse.mlir
@@ -259,7 +259,7 @@ func.func @dot3(%arg0: tensor<4xf64, #SV>,
 // CHECK-LABEL: func @sparse_reduce(
 //  CHECK-SAME: %[[A:.*]]: tensor<10xi64, #{{.*}}>) -> tensor<i64> {
 //       CHECK: %[[C:.*]] = stablehlo.constant dense<0> : tensor<i64>
-//       CHECK: %[[T:.*]] = stablehlo.reduce(%[[A]] init: %[[C]])  across dimensions = [0] : (tensor<10xi64, #{{.*}}>) -> tensor<i64>
+//       CHECK: %[[T:.*]] = stablehlo.reduce(%[[A]] init: %[[C]]) applies stablehlo.add across dimensions = [0] : (tensor<10xi64, #{{.*}}>) -> tensor<i64>
 //       CHECK: return %[[T]] : tensor<i64>
 func.func @sparse_reduce(%arg0: tensor<10xi64, #SV>) -> tensor<i64> {
   %0 = stablehlo.constant dense<0> : tensor<i64>

--- a/stablehlo/tests/print_reduce.mlir
+++ b/stablehlo/tests/print_reduce.mlir
@@ -25,17 +25,11 @@ func.func @reduce_one_op_all_locs_same(%arg0: tensor<?x?xf32>, %arg1 : tensor<f3
   func.return %0: tensor<?xf32>
 }
 
-// The test case is not eligible for pretty-printing reduce-op. The location of
+// The test case is eligible for pretty-printing reduce-op. The location of
 // reduce-op is different.
 
 // CHECK-LABEL:  func @reduce_one_op_all_locs_not_same_1
-// CHECK-NEXT:     stablehlo.reduce(%arg0 init: %arg1)
-// CHECK-SAME:       across dimensions = [1] {foo = "bar"}
-// CHECK-SAME:      : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32>
-// CHECK-NEXT:     reducer(%arg[[x:.+]]: tensor<f32> loc("foo"), %arg[[y:.+]]: tensor<f32> loc("foo"))
-// CHECK-NEXT:       stablehlo.add %arg[[x]], %arg[[y]] : tensor<f32> loc("foo")
-// CHECK-NEXT:       stablehlo.return %{{[0-9]+}} : tensor<f32> loc("foo")
-// CHECK-NEXT:     loc("not_foo")
+// CHECK-NEXT:     %0 = stablehlo.reduce(%arg0 init: %arg1) applies stablehlo.add across dimensions = [1] {foo = "bar"} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32> loc("not_foo")
 
 func.func @reduce_one_op_all_locs_not_same_1(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>) -> (tensor<?xf32>) {
   %0 = "stablehlo.reduce"(%arg0, %arg1) ({
@@ -47,11 +41,11 @@ func.func @reduce_one_op_all_locs_not_same_1(%arg0: tensor<?x?xf32>, %arg1 : ten
   func.return %0: tensor<?xf32>
 }
 
-// The test case is not eligible for pretty-printing reduce-op. The location of
+// The test case is eligible for pretty-printing reduce-op. The location of
 // block-arguments are different.
 
 // CHECK-LABEL:  func @reduce_one_op_all_locs_not_same_2
-// CHECK-NOT:     applies
+// CHECK-NEXT:     %0 = stablehlo.reduce(%arg0 init: %arg1) applies stablehlo.add across dimensions = [1] : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32> loc("foo")
 
 func.func @reduce_one_op_all_locs_not_same_2(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>) -> (tensor<?xf32>) {
   %0 = "stablehlo.reduce"(%arg0, %arg1) ({


### PR DESCRIPTION
During discussion of #1523 we came to the conclusion that it's impossible to continously guarantee that location information is kept forwrad and backwards through transformations.

There is already precendent in other transformations that location information may be ellided.

Remove the constraint for the compact pretty printing of ReduceOpt that requires the locations be the same. Update the tests as necessary.