### PR TITLE
Delete BroadcastDimAttr (no longer used)

### DIFF
--- a/stablehlo/dialect/Base.td
+++ b/stablehlo/dialect/Base.td
@@ -95,12 +95,6 @@ def HLO_QuantizedUnsignedInt : StableHLO_UniformQuantizedUnsignedIntOfWidths<[4,
 def HLO_QuantizedInt :
     AnyTypeOf<[HLO_QuantizedSignedInt, HLO_QuantizedUnsignedInt]>;
 
-// The broadcasting dimensions correspond to a tuple that describes how a
-// smaller rank shape is broadcast into a larger rank shape. For example,
-// given a 2x3x4 cuboid and a 3x4 matrix, a broadcasting tuple (1,2) means
-// matching the matrix to dimensions 1 and 2 of the cuboid.
-defvar BroadcastDimAttr = I64ElementsAttr;
-
 // Token type.
 def HLO_Token : Type<CPred<"$_self.isa<TokenType>()">, "token">;
 


### PR DESCRIPTION
Uses were removed in the following PRs:
https://github.com/openxla/stablehlo/pull/1887/files#diff-c20bffbe3bc2037741cb7cf73b71ebf259fc419c15c2a6d3c39d6952ae59f89c https://github.com/openxla/stablehlo/pull/1893/files#diff-c20bffbe3bc2037741cb7cf73b71ebf259fc419c15c2a6d3c39d6952ae59f89c https://github.com/openxla/stablehlo/pull/1891/files#diff-8d62a195e9ed8776265bc22a7b8300534d4661e1c6bd659a21f27143311745dc