### PR TITLE
Use ArrayRef where SmallVector is not needed

### DIFF
--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -4153,8 +4153,8 @@ LogicalResult verifyScatterOp(std::optional<Location> location,
 //   P5. Check if the result type of window operation matches the source type.
 LogicalResult verifySelectAndScatterOp(
     std::optional<Location> location, Value operand, Value source,
-    Value initValue, std::optional<SmallVector<int64_t>> windowDimensionsOpt,
-    std::optional<SmallVector<int64_t>> windowStridesOpt,
+    Value initValue, std::optional<ArrayRef<int64_t>> windowDimensionsOpt,
+    std::optional<ArrayRef<int64_t>> windowStridesOpt,
     std::optional<DenseIntElementsAttr> padding, Region& select,
     Region& scatter) {
   auto operandType = operand.getType().cast<ShapedType>();

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -501,8 +501,8 @@ LogicalResult verifyScatterOp(std::optional<Location> location,
 
 LogicalResult verifySelectAndScatterOp(
     std::optional<Location> location, Value operand, Value source,
-    Value initValue, std::optional<SmallVector<int64_t>> windowDimensions,
-    std::optional<SmallVector<int64_t>> windowStrides,
+    Value initValue, std::optional<ArrayRef<int64_t>> windowDimensions,
+    std::optional<ArrayRef<int64_t>> windowStrides,
     std::optional<DenseIntElementsAttr> padding, Region& select,
     Region& scatter);
 


### PR DESCRIPTION
For some reason while porting SelectAndScatter I used SmallVector for its verify function, and I used ArrayRef everywhere else. ArrayRef is a slightly better fit as it is more efficient and meant for reading only.

https://github.com/openxla/stablehlo/issues/1578