### PR TITLE
Add a _toc.yaml file to specify doc nav

### DIFF
--- a/docs/_toc.yaml
+++ b/docs/_toc.yaml
@@ -1,0 +1,26 @@
+toc:
+- heading: StableHLO developer guide
+- title: Overview
+  path: /stablehlo
+- title: Bytecode
+  path: /stablehlo/bytecode
+- title: Compatibility
+  path: /stablehlo/compatibility
+- title: Governance
+  path: /stablehlo/governance
+- title: Interpreter Design
+  path: /stablehlo/reference
+- title: Interpreter Checklist
+  path: /stablehlo/reference_checklist
+- title: Roadmap
+  path: /stablehlo/roadmap
+- title: Specification
+  path: /stablehlo/spec
+- title: Specification Checklist
+  path: /stablehlo/spec_checklist
+- title: Status
+  path: /stablehlo/status
+- title: Type Inference
+  path: /stablehlo/type_inference
+- title: The VHLO Dialect
+  path: /stablehlo/vhlo


### PR DESCRIPTION
This is needed for integration with internal publishing tools.