### PR TITLE
Disallow reusing variables across CHECK-LABEL directives

### DIFF
--- a/stablehlo/conversions/linalg/tests/lit.cfg.py
+++ b/stablehlo/conversions/linalg/tests/lit.cfg.py
@@ -26,6 +26,10 @@ config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 config.suffixes = ['.mlir']
 config.test_source_root = os.path.dirname(__file__)
 
+# Disallow reusing variables across CHECK-LABEL matches.
+# A variable can eschew this (be made "global") by prefixing its name with $.
+config.environment["FILECHECK_OPTS"] = "-enable-var-scope"
+
 # Make LLVM and StableHLO tools available in RUN directives
 tools = [
   'stablehlo-opt',

--- a/stablehlo/conversions/tosa/tests/lit.cfg.py
+++ b/stablehlo/conversions/tosa/tests/lit.cfg.py
@@ -26,6 +26,10 @@ config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 config.suffixes = ['.mlir']
 config.test_source_root = os.path.dirname(__file__)
 
+# Disallow reusing variables across CHECK-LABEL matches.
+# A variable can eschew this (be made "global") by prefixing its name with $.
+config.environment["FILECHECK_OPTS"] = "-enable-var-scope"
+
 # Make LLVM and StableHLO tools available in RUN directives
 tools = [
   'stablehlo-opt',

--- a/stablehlo/testdata/lit.cfg.py
+++ b/stablehlo/testdata/lit.cfg.py
@@ -28,6 +28,10 @@ config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 config.suffixes = ['.mlir']
 config.test_source_root = os.path.dirname(__file__)
 
+# Disallow reusing variables across CHECK-LABEL matches.
+# A variable can eschew this (be made "global") by prefixing its name with $.
+config.environment["FILECHECK_OPTS"] = "-enable-var-scope"
+
 # Make LLVM and StableHLO tools available in RUN directives
 tools = [
   'FileCheck',

--- a/stablehlo/tests/lit.cfg.py
+++ b/stablehlo/tests/lit.cfg.py
@@ -28,6 +28,10 @@ config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 config.suffixes = ['.mlir']
 config.test_source_root = os.path.dirname(__file__)
 
+# Disallow reusing variables across CHECK-LABEL matches.
+# A variable can eschew this (be made "global") by prefixing its name with $.
+config.environment["FILECHECK_OPTS"] = "-enable-var-scope"
+
 # Make LLVM and StableHLO tools available in RUN directives
 tools = [
   'FileCheck',

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.0_17_0.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.0_17_0.mlir
@@ -1955,7 +1955,8 @@ func.func @op_select_and_scatter(%arg0: tensor<10x24x24x64xf32>, %arg1: tensor<1
 func.func @op_select_and_scatter_with_promotable_types(%arg0: tensor<10x24x24x64xf32>, %arg1: tensor<12x13x13x66xf32>, %arg2: tensor<f32>) -> tensor<10x24x24x64xf64> {
   // CHECK: "vhlo.select_and_scatter_v1"(%arg0, %arg1, %arg2)
   // CHECK:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor_v1<!vhlo.f64_v1>, %[[ARG2:arg.*]]: !vhlo.tensor_v1<!vhlo.f64_v1>):
-  // CHECK:     "vhlo.return_v1"(%[[VAL12]]) : (!vhlo.tensor_v1<!vhlo.f64_v1>) -> ()
+  // CHECK:     %[[VAL:.*]] = "vhlo.add_v1"(%[[ARG1]], %[[ARG2]]) : (!vhlo.tensor_v1<!vhlo.f64_v1>, !vhlo.tensor_v1<!vhlo.f64_v1>) -> !vhlo.tensor_v1<!vhlo.f64_v1>
+  // CHECK:     "vhlo.return_v1"(%[[VAL]]) : (!vhlo.tensor_v1<!vhlo.f64_v1>) -> ()
   // CHECK: }) : (!vhlo.tensor_v1<10x24x24x64x!vhlo.f32_v1>, !vhlo.tensor_v1<12x13x13x66x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<10x24x24x64x!vhlo.f64_v1>
   %0 = "stablehlo.select_and_scatter"(%arg0, %arg1, %arg2) ({
     ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):

--- a/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
+++ b/stablehlo/tests/stablehlo_legalize_to_vhlo.mlir
@@ -1960,7 +1960,8 @@ func.func @op_select_and_scatter(%arg0: tensor<10x24x24x64xf32>, %arg1: tensor<1
 func.func @op_select_and_scatter_with_promotable_types(%arg0: tensor<10x24x24x64xf32>, %arg1: tensor<12x13x13x66xf32>, %arg2: tensor<f32>) -> tensor<10x24x24x64xf64> {
   // CHECK: "vhlo.select_and_scatter_v1"(%arg0, %arg1, %arg2)
   // CHECK:   ^[[BB:bb.*]](%[[ARG1:arg.*]]: !vhlo.tensor_v1<!vhlo.f64_v1>, %[[ARG2:arg.*]]: !vhlo.tensor_v1<!vhlo.f64_v1>):
-  // CHECK:     "vhlo.return_v1"(%[[VAL12]]) : (!vhlo.tensor_v1<!vhlo.f64_v1>) -> ()
+  // CHECK:     %[[VAL:.*]] = "vhlo.add_v1"(%[[ARG1]], %[[ARG2]]) : (!vhlo.tensor_v1<!vhlo.f64_v1>, !vhlo.tensor_v1<!vhlo.f64_v1>) -> !vhlo.tensor_v1<!vhlo.f64_v1>
+  // CHECK:     "vhlo.return_v1"(%[[VAL]]) : (!vhlo.tensor_v1<!vhlo.f64_v1>) -> ()
   // CHECK: }) : (!vhlo.tensor_v1<10x24x24x64x!vhlo.f32_v1>, !vhlo.tensor_v1<12x13x13x66x!vhlo.f32_v1>, !vhlo.tensor_v1<!vhlo.f32_v1>) -> !vhlo.tensor_v1<10x24x24x64x!vhlo.f64_v1>
   %0 = "stablehlo.select_and_scatter"(%arg0, %arg1, %arg2) ({
     ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):


### PR DESCRIPTION
Ran into this while integrating: internal configuration sets `--enable-var-scope`, but we don't, so some tests failed internally but not here. I think in general this is a good setting to use: it's easier to understand a test if the only variables in scope are the variables defined by that test.