### PR TITLE
Fully qualify storage types of ArrayOrElements attrs

### DIFF
--- a/stablehlo/dialect/Base.td
+++ b/stablehlo/dialect/Base.td
@@ -238,7 +238,7 @@ def I64Elements1D : And<[I64ElementsAttr.predicate,  CPred<"$_self.cast<DenseInt
 
 // TODO(#1578) migrate uses to DenseI64ArrayAttr and delete this attr
 def I64DenseArrayOrElements1DAttr : Attr<Or<[DenseI64ArrayAttr.predicate, I64Elements1D]>, "either a DenseI64ArrayAttr or a 1-dimensional I64ElementsAttr."> {
-  let storageType = "Attribute";
+  let storageType = "mlir::Attribute";
   let returnType = "SmallVector<int64_t>";
   let convertFromStorage = "hlo::getI64Array($_self)";
 }

--- a/stablehlo/dialect/StablehloAttrs.td
+++ b/stablehlo/dialect/StablehloAttrs.td
@@ -191,7 +191,7 @@ def StableHLO_BoolElementsAttr :
 }
 
 def BoolDenseArrayOrElementsAttr : Attr<Or<[DenseBoolArrayAttr.predicate, StableHLO_BoolElementsAttr.predicate]>, "either a DenseBoolArrayAttr or a StableHLO_BoolElementsAttr"> {
-  let storageType = "Attribute";
+  let storageType = "mlir::Attribute";
   let returnType = "SmallVector<bool>";
   let convertFromStorage = "hlo::getBoolArray($_self)";
 }


### PR DESCRIPTION
There is no guarantee that users of the generated .inc files are working in an `mlir` namespace, so we need to include the explicit `mlir::` prefix.

I discovered this because in some (out of repo) generated code an unqualified `Attribute` caused compilation failures.