### PR TITLE
Use distinct, more specific name for testdata suite

### DIFF
--- a/stablehlo/testdata/lit.cfg.py
+++ b/stablehlo/testdata/lit.cfg.py
@@ -23,7 +23,7 @@ from lit.llvm import llvm_config
 
 # Populate Lit configuration with the minimal required metadata.
 # Some metadata is populated in lit.site.cfg.py.in.
-config.name = 'STABLEHLO_TESTS_SUITE'
+config.name = 'STABLEHLO_TESTDATA_SUITE'
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 config.suffixes = ['.mlir']
 config.test_source_root = os.path.dirname(__file__)


### PR DESCRIPTION
The name seems to have been copied from the tests suite. Sharing the name makes it a bit confusing which is which when listing tests, since tests under tests/ and testdata/ will be prefixed with the same name, e.g.

```
STABLEHLO_TESTS_SUITE :: infer_chlo.mlir
...
STABLEHLO_TESTS_SUITE :: zeros_like_shape_uint8_3_4_5.mlir
```