### PR TITLE
Updates to shape functions enabling reuse from MHLO

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1779,7 +1779,6 @@ LogicalResult ReduceOp::inferReturnTypeComponents(
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   ReduceOp::Adaptor adaptor(operands, attributes, properties, regions);
   return hlo::inferReduceOp(location, adaptor.getInputs().getTypes(),
-                            adaptor.getInitValues().getTypes(),
                             adaptor.getDimensions(), adaptor.getBody(),
                             inferredReturnShapes);
 }
@@ -2293,8 +2292,9 @@ LogicalResult SelectAndScatterOp::inferReturnTypes(
     SmallVectorImpl<Type>& inferredReturnTypes) {
   SelectAndScatterOp::Adaptor adaptor(operands, attributes, properties,
                                       regions);
-  return hlo::inferSelectAndScatterOp(
-      adaptor.getOperand(), adaptor.getScatter(), inferredReturnTypes);
+  return hlo::inferSelectAndScatterOp(location, adaptor.getOperand(),
+                                      adaptor.getScatter(),
+                                      inferredReturnTypes);
 }
 
 LogicalResult SelectAndScatterOp::verify() {

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -121,7 +121,7 @@ LogicalResult inferAllToAllOp(
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferAllReduceOp(
-    std::optional<Location> location, Value operand, Region& computation,
+    std::optional<Location> location, ValueRange operands, Region& computation,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferBatchNormGradOp(
@@ -284,7 +284,7 @@ LogicalResult inferRealOp(std::optional<Location> location, Value operand,
 
 LogicalResult inferReduceOp(
     std::optional<Location> location, TypeRange inputTypes,
-    TypeRange initValueTypes, ArrayRef<int64_t> dimensions, Region& body,
+    ArrayRef<int64_t> dimensions, Region& body,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferReduceWindowOp(
@@ -317,7 +317,8 @@ LogicalResult inferSelectOp(
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferSelectAndScatterOp(
-    Value operand, Region& scatter, SmallVectorImpl<Type>& inferredReturnTypes);
+    std::optional<Location> location, Value operand, Region& scatter,
+    SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferSendOp(HloDialectInterface* dialect,
                           std::optional<Location> location,
@@ -462,6 +463,11 @@ LogicalResult verifyRecvOp(HloDialectInterface* dialect,
 LogicalResult verifyReduceOp(std::optional<Location> location,
                              ValueRange inputs, ValueRange initValues,
                              ArrayRef<int64_t> dimensions, Region& body);
+
+LogicalResult verifyReduceOpInputsAndInferShape(
+    std::optional<Location> location, SmallVector<ShapedType> inputTypes,
+    ArrayRef<int64_t> dimensions, SmallVector<int64_t>& newDimensions,
+    Attribute& encoding);
 
 LogicalResult verifyReducePrecisionOp(std::optional<Location> location,
                                       int32_t exponentBits,

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -81,8 +81,7 @@ SmallVector<Tensor> evalReduceOp(ArrayRef<Tensor> inputs,
   SmallVector<ShapedTypeComponents> inferredReduceTypes;
   Builder builder(inputs[0].getType().getContext());
   auto reduceStatus = hlo::inferReduceOp(
-      /*location=*/{}, inputTypes, initValueTypes, dimensions, body,
-      inferredReduceTypes);
+      /*location=*/{}, inputTypes, dimensions, body, inferredReduceTypes);
   if (failed(reduceStatus))
     report_fatal_error(
         invalidArgument("Could not infer ReduceOp's return type"));


### PR DESCRIPTION
The upstream change https://github.com/openxla/stablehlo/pull/1869 in StableHLO updates various API related to shape inference. MHLO shape inference functions in [hlo_ops.cc](https://github.com/openxla/xla/blob/main/xla/mlir_hlo/mhlo/IR/hlo_ops.cc) uses those APIs. The PR updates the visibility and signature of those API for a clearer integration.

Specifically, the PR does the followings:
1. **updates `getAccumulatorTypes` to return a error status when the input regions is empty**: This function is used in type inference of various reduction based operations ([eg](https://github.com/openxla/stablehlo/blob/d5b464925371092095ac934b46ba93ebd4284223/stablehlo/dialect/TypeInference.cpp#L2589)). This functions enables infering type based on the reduction block of the operation, which is something proposed in  [RFC](https://github.com/openxla/stablehlo/pull/1664). However, there could be [instances](https://github.com/openxla/xla/blob/a91877b9c9aa1edf307c5927782111b1a81cd81d/xla/mlir_hlo/mhlo/transforms/group_reduction_dimensions/group_reduction_dimensions.cc#L228) when type inference can be called with empty region in which case we would like to report a meaningful diagnostic message. 

2. **Allow `hlo::inferAllReduceOp`  to accept multiple operands information**: In stableHLO, `all_reduce` op  have a single operand ([e.g.](https://github.com/openxla/stablehlo/blob/d5b464925371092095ac934b46ba93ebd4284223/stablehlo/dialect/StablehloOps.td#L1355)), whereas in MHLO the op can take multiple operand ([e.g.](https://github.com/openxla/xla/blob/79aba0801ef75c1c2dffbb4ecc506a0d8144c9ac/xla/mlir_hlo/mhlo/IR/hlo_ops.td#L1528). The `hlo::inferAllReduceOp` signature is updated to accommodate both cases. 

3. Remove unused arguments to functions `verifyReduceOpInputsAndInferShape` and `inferReduceOp`.