### PR TITLE
Add missing copyright message

### DIFF
--- a/docs/_toc.yaml
+++ b/docs/_toc.yaml
@@ -1,3 +1,16 @@
+# Copyright 2024 The StableHLO Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 toc:
 - heading: StableHLO developer guide
 - title: Overview


### PR DESCRIPTION
The copyright message was missing `docs/_toc.yaml`.