### PR TITLE
Add licensecheck lint to CI and add missing licenses

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,3 +1,16 @@
+# Copyright 2024 The StableHLO Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: 🐞 Bug Report
 description: Report an issue
 body:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,16 @@
+# Copyright 2024 The StableHLO Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 blank_issues_enabled: true
 contact_links:
   - name: 📄 Blank Issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,3 +1,16 @@
+# Copyright 2024 The StableHLO Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: ➕ Feature Request
 description: Ask for a new feature to be added
 body:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -82,17 +82,17 @@ jobs:
         run: ./build_tools/github_actions/lint_buildifier.sh
 
   license-check:
-  if: "github.event_name == 'pull_request'"
-  runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-22.04'  }}
-  defaults:
-    run:
-      shell: bash
-  steps:
-    - name: Checking out repository
-      uses: actions/checkout@v4
+    if: "github.event_name == 'pull_request'"
+    runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-22.04'  }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checking out repository
+        uses: actions/checkout@v4
 
-    - name: Install addlicense
-      run: go install github.com/google/addlicense@latest
+      - name: Install addlicense
+        run: go install github.com/google/addlicense@latest
 
-    - name: Run license checks
-      run: addlicense -check -ignore '.git/**' -ignore 'build/**' -ignore 'llvm*/**' .
+      - name: Run license checks
+        run: addlicense -check -ignore '.git/**' -ignore 'build/**' -ignore 'llvm*/**' .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -80,3 +80,19 @@ jobs:
 
       - name: Run buildifier checks
         run: ./build_tools/github_actions/lint_buildifier.sh
+
+  license-check:
+  if: "github.event_name == 'pull_request'"
+  runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-22.04'  }}
+  defaults:
+    run:
+      shell: bash
+  steps:
+    - name: Checking out repository
+      uses: actions/checkout@v4
+
+    - name: Install addlicense
+      run: go install github.com/google/addlicense@latest
+
+    - name: Run license checks
+      run: addlicense -check -ignore '.git/**' -ignore 'build/**' -ignore 'llvm*/**' .

--- a/stablehlo/conversions/CMakeLists.txt
+++ b/stablehlo/conversions/CMakeLists.txt
@@ -1,2 +1,15 @@
+# Copyright 2024 The StableHLO Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 add_subdirectory(linalg)
 add_subdirectory(tosa)

--- a/stablehlo/conversions/linalg/CMakeLists.txt
+++ b/stablehlo/conversions/linalg/CMakeLists.txt
@@ -1,2 +1,15 @@
+# Copyright 2024 The StableHLO Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 add_subdirectory(tests)
 add_subdirectory(transforms)

--- a/stablehlo/conversions/linalg/transforms/CMakeLists.txt
+++ b/stablehlo/conversions/linalg/transforms/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Copyright 2024 The StableHLO Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls -name StablehloLinalgTransforms)
 add_public_tablegen_target(StablehloLinalgTransformsPassIncGen)


### PR DESCRIPTION
For the most part, `addlicense` handles the file types that we care about. It also doesn't handle some files that we (AFAICT) don't want license headers in: `.md` and `.mlir` files, e.g. However, it doesn't handle some files for which we may want license headers: `.bazel`, some `.in` files, `.pdll` and `.td`. I think it's debatable whether or not we want license headers in the following: `.bazelignore`, `.bazelrc`, `.bazelversion`, `.gitignore`, `.clang-format`, and these are also not handled by `addlicense`.

For `.bazel`, `.pdll` and `.td`, I will see if I can contribute to `addlicense` to handle those. For `.in` files (e.g. `lit.site.cfg.py.in`), I think whether or not we want a license actually depends on what the "true" type of the file is (e.g. `.py`). Supporting that would likely require additional changes to `addlicense`. Actually, I think it would be great if `addlicense` had some kind of extensibility mechanism (https://github.com/google/addlicense/issues/50).

Anyway, although imperfect I think on the whole this should help us catch missing licenses in a lot of cases we care about.

Inspired by https://github.com/openxla/stablehlo/pull/1928