### PR TITLE
Use array literals where possible in MLIR source

### DIFF
--- a/stablehlo/conversions/linalg/tests/convolution.mlir
+++ b/stablehlo/conversions/linalg/tests/convolution.mlir
@@ -37,8 +37,8 @@ func.func @linalg.conv_1d_nwc(%arg0: tensor<?x8x?xf32>, %arg1: tensor<2x?x?xf32>
     >,
     feature_group_count = 1 : i64,
     padding = dense<[[0, 0]]> : tensor<1x2xi64>,
-    rhs_dilation = dense<1> : tensor<1xi64>,
-    window_strides = dense<1> : tensor<1xi64>,
+    rhs_dilation = array<i64: 1>,
+    window_strides = array<i64: 1>,
     someattr
   } : (tensor<?x8x?xf32>, tensor<2x?x?xf32>) -> tensor<?x7x?xf32>
   func.return %0 : tensor<?x7x?xf32>
@@ -80,8 +80,8 @@ func.func @conv_2d_nhwc_hwcf(%arg0: tensor<?x4x5x?xf32>, %arg1: tensor<3x2x?x?xf
     >,
     feature_group_count = 1 : i64,
     padding = dense<[[0, 0], [0, 0]]> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
+    rhs_dilation = array<i64: 1, 1>,
+    window_strides = array<i64: 1, 1>
   } : (tensor<?x4x5x?xf32>, tensor<3x2x?x?xf32>) -> tensor<?x2x4x?xf32>
   func.return %0 : tensor<?x2x4x?xf32>
 }
@@ -223,8 +223,8 @@ func.func @conv_3d_ndhwc_dhwcf(%arg0: tensor<?x8x8x8x?xf32>, %arg1: tensor<2x2x2
     >,
     feature_group_count = 1 : i64,
     padding = dense<[[0, 0], [0, 0], [0, 0]]> : tensor<3x2xi64>,
-    rhs_dilation = dense<1> : tensor<3xi64>,
-    window_strides = dense<1> : tensor<3xi64>
+    rhs_dilation = array<i64: 1, 1, 1>,
+    window_strides = array<i64: 1, 1, 1>
   } : (tensor<?x8x8x8x?xf32>, tensor<2x2x2x?x?xf32>) -> tensor<?x7x7x7x?xf32>
   func.return %0 : tensor<?x7x7x7x?xf32>
 }
@@ -263,8 +263,8 @@ func.func @conv2d_1452x2223_dilated_valid(%arg0: tensor<1x4x5x2xf32>, %arg1: ten
     >,
     feature_group_count = 1 : i64,
     padding = dense<0> : tensor<2x2xi64>,
-    rhs_dilation = dense<[2, 1]> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
+    rhs_dilation = array<i64: 2, 1>,
+    window_strides = array<i64: 1, 1>
   } : (tensor<1x4x5x2xf32>, tensor<2x2x2x3xf32>) -> tensor<1x2x4x3xf32>
   func.return %0 : tensor<1x2x4x3xf32>
 }
@@ -349,8 +349,8 @@ func.func @depthwise_conv(%arg0: tensor<2x4x5x2xf32>,
     >,
     feature_group_count = 2 : i64,
     padding = dense<0> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>,
+    rhs_dilation = array<i64: 1, 1>,
+    window_strides = array<i64: 1, 1>,
     someattr} : (tensor<2x4x5x2xf32>, tensor<2x2x1x6xf32>) -> tensor<2x3x4x6xf32>
   func.return %0 : tensor<2x3x4x6xf32>
 }
@@ -390,8 +390,8 @@ func.func @depthwise_conv_with_padding(
     >,
     feature_group_count = 2 : i64,
     padding = dense<[[0, 0], [1, 1]]> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>,
+    rhs_dilation = array<i64: 1, 1>,
+    window_strides = array<i64: 1, 1>,
     someattr} : (tensor<2x4x5x2xf32>, tensor<2x2x1x4xf32>) -> tensor<2x3x6x4xf32>
   func.return %0 : tensor<2x3x6x4xf32>
 }
@@ -438,8 +438,8 @@ func.func @depthwise_conv_multiplier_1(%arg0: tensor<1x113x113x96xf32>,
     >,
     feature_group_count = 96 : i64,
     padding = dense<0> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<2> : tensor<2xi64>} : (tensor<1x113x113x96xf32>, tensor<3x3x1x96xf32>) -> tensor<1x56x56x96xf32>
+    rhs_dilation = array<i64: 1, 1>,
+    window_strides = array<i64: 2, 2>} : (tensor<1x113x113x96xf32>, tensor<3x3x1x96xf32>) -> tensor<1x56x56x96xf32>
   func.return %0 : tensor<1x56x56x96xf32>
 }
 // CHECK-DAG:     %[[CST:.+]] = arith.constant 0.000000e+00 : f32
@@ -476,8 +476,8 @@ func.func @depthwise_conv_multiplier_1_with_padding(
     >,
     feature_group_count = 96 : i64,
     padding = dense<[[1, 1], [2, 2]]> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<2> : tensor<2xi64>} : (tensor<1x113x113x96xf32>, tensor<3x3x1x96xf32>) -> tensor<1x57x58x96xf32>
+    rhs_dilation = array<i64: 1, 1>,
+    window_strides = array<i64: 2, 2>} : (tensor<1x113x113x96xf32>, tensor<3x3x1x96xf32>) -> tensor<1x57x58x96xf32>
   func.return %0 : tensor<1x57x58x96xf32>
 }
 // CHECK-DAG:     %[[ZERO:.*]] = arith.constant 0.000000e+00 : f32

--- a/stablehlo/conversions/linalg/tests/gather.mlir
+++ b/stablehlo/conversions/linalg/tests/gather.mlir
@@ -14,7 +14,7 @@ func.func @gather(%operand : tensor<1x4x8xi32>, %start_indices : tensor<1x8x2xi3
       start_index_map = [0, 1]
     >,
     indices_are_sorted = false,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     someattr
   } : (tensor<1x4x8xi32>, tensor<1x8x2xi32>) -> tensor<1x8x8xi32>
   func.return %res : tensor<1x8x8xi32>
@@ -59,7 +59,7 @@ func.func @gather_unsigned_index(
       start_index_map = [0, 1]
     >,
     indices_are_sorted = false,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     someattr
   } : (tensor<1x4x8xi32>, tensor<1x8x2xui32>) -> tensor<1x8x8xi32>
   func.return %res : tensor<1x8x8xi32>
@@ -84,7 +84,7 @@ func.func @gather_unsigned(%operand : tensor<1x4x8xui32>, %start_indices : tenso
       start_index_map = [0, 1]
     >,
     indices_are_sorted = false,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>
+    slice_sizes = array<i64: 1, 1, 8>
   } : (tensor<1x4x8xui32>, tensor<1x8x2xi32>) -> tensor<1x8x8xui32>
   func.return %res : tensor<1x8x8xui32>
 }
@@ -107,7 +107,7 @@ func.func @gather_no_collapse(%operand : tensor<6x3xi32>, %start_indices : tenso
       start_index_map = [0, 1]
     >,
     indices_are_sorted = false,
-    slice_sizes = dense<[4, 2]> : tensor<2xi64>
+    slice_sizes = array<i64: 4, 2>
   } : (tensor<6x3xi32>, tensor<5x2xi32>) -> tensor<5x4x2xi32>
   func.return %res : tensor<5x4x2xi32>
 }
@@ -148,7 +148,7 @@ func.func @gather_max_offset(%operand : tensor<?x?x?xi32>, %start_indices : tens
       start_index_map = [0, 1]
     >,
     indices_are_sorted = false,
-    slice_sizes = dense<[2, 3, 4]> : tensor<3xi64>
+    slice_sizes = array<i64: 2, 3, 4>
   } : (tensor<?x?x?xi32>, tensor<5x2xi32>) -> tensor<2x3x4x5xi32>
   func.return %res : tensor<2x3x4x5xi32>
 }
@@ -198,7 +198,7 @@ func.func @gather_reorder_start_index(%operand : tensor<6x3x2x7xi32>, %start_ind
       start_index_map = [3, 1, 2, 0]
     >,
     indices_are_sorted = false,
-    slice_sizes = dense<[1, 2, 1, 4]> : tensor<4xi64>
+    slice_sizes = array<i64: 1, 2, 1, 4>
   } : (tensor<6x3x2x7xi32>, tensor<5x4xi32>) -> tensor<5x2x4xi32>
   func.return %res : tensor<5x2x4xi32>
 }
@@ -256,7 +256,7 @@ func.func @gather_implicit_trailing_dim(%operand : tensor<?x?xi32>, %start_indic
       start_index_map = [0]
     >,
     indices_are_sorted = false,
-    slice_sizes = dense<[3, 4]> : tensor<2xi64>
+    slice_sizes = array<i64: 3, 4>
   } : (tensor<?x?xi32>, tensor<5x2xi32>) -> tensor<3x4x5x2xi32>
   func.return %res : tensor<3x4x5x2xi32>
 }
@@ -297,7 +297,7 @@ func.func @gather_non_static(%operand : tensor<?x?xi32>, %start_indices : tensor
       start_index_map = [0]
     >,
     indices_are_sorted = false,
-    slice_sizes = dense<[3, 4]> : tensor<2xi64>
+    slice_sizes = array<i64: 3, 4>
   } : (tensor<?x?xi32>, tensor<?x?xi32>) -> tensor<3x4x?xi32>
   func.return %res : tensor<3x4x?xi32>
 }
@@ -338,7 +338,7 @@ func.func @gather_unranked(%operand : tensor<*xi32>, %start_indices : tensor<?x?
       start_index_map = [0]
     >,
     indices_are_sorted = false,
-    slice_sizes = dense<[3, 4]> : tensor<2xi64>
+    slice_sizes = array<i64: 3, 4>
   } : (tensor<*xi32>, tensor<?x?xi32>) -> tensor<?x?x?xi32>
   func.return %res : tensor<?x?x?xi32>
 }

--- a/stablehlo/conversions/linalg/tests/miscellaneous.mlir
+++ b/stablehlo/conversions/linalg/tests/miscellaneous.mlir
@@ -651,7 +651,7 @@ func.func @map_mixed(%arg0: tensor<?xf32>,
   ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
     %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {dimensions = dense<0> : tensor<1xi64>}
+  }) {dimensions = array<i64: 0>}
   : (tensor<?xf32>, tensor<4xf32>) -> tensor<?xf32>
   func.return %0 : tensor<?xf32>
 }
@@ -671,7 +671,7 @@ func.func @map_one_arg(%arg0: tensor<?xf32>) -> tensor<?xf32> {
   ^bb0(%arg2: tensor<f32>):
     %1 = stablehlo.add %arg2, %arg2 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {dimensions = dense<0> : tensor<1xi64>}
+  }) {dimensions = array<i64: 0>}
   : (tensor<?xf32>) -> tensor<?xf32>
   func.return %0 : tensor<?xf32>
 }
@@ -702,7 +702,7 @@ func.func @map_compare(%arg0: tensor<?xcomplex<f32>>,
        {comparison_direction = #stablehlo<comparison_direction EQ>}
        : (tensor<f32>, tensor<f32>) -> tensor<i1>
     "stablehlo.return"(%3) : (tensor<i1>) -> ()
-  }) {dimensions = dense<0> : tensor<1xi64>}
+  }) {dimensions = array<i64: 0>}
   : (tensor<?xcomplex<f32>>, tensor<?xcomplex<f32>>) -> tensor<?xi1>
   func.return %0 : tensor<?xi1>
 }
@@ -1089,8 +1089,8 @@ func.func @select_and_scatter(%arg0 : tensor<2x8x8x1xf32>, %arg1 : tensor<2x4x4x
     stablehlo.return %9 : tensor<f32>
   }) {
     padding = dense<0> : tensor<4x2xi64>,
-    window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-    window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>
+    window_dimensions = array<i64: 1, 2, 2, 1>,
+    window_strides = array<i64: 1, 2, 2, 1>
   } : (tensor<2x8x8x1xf32>, tensor<2x4x4x1xf32>, tensor<f32>) -> tensor<2x8x8x1xf32>
 
   return %0 : tensor<2x8x8x1xf32>

--- a/stablehlo/conversions/linalg/tests/reduce.mlir
+++ b/stablehlo/conversions/linalg/tests/reduce.mlir
@@ -10,7 +10,7 @@ func.func @reduce_add(%arg0: tensor<5x4xi32>, %arg1: tensor<i32>) -> tensor<5xi3
   ^bb0(%arg3: tensor<i32>, %arg4 : tensor<i32>):
     %1 = stablehlo.add %arg3, %arg4 : tensor<i32>
     "stablehlo.return"(%1) : (tensor<i32>) -> ()
-  }) {dimensions = dense<1> : tensor<1xi64>, someattr} : (tensor<5x4xi32>, tensor<i32>) -> tensor<5xi32>
+  }) {dimensions = array<i64: 1>, someattr} : (tensor<5x4xi32>, tensor<i32>) -> tensor<5xi32>
   func.return %0 : tensor<5xi32>
 }
 // CHECK-DAG: %[[INIT:.*]] = tensor.extract %{{.*}} : tensor<i32>
@@ -43,7 +43,7 @@ func.func @reduce_add_unranked(%arg0: tensor<*xi32>, %arg1: tensor<i32>) -> tens
   ^bb0(%arg3: tensor<i32>, %arg4 : tensor<i32>):
     %1 = stablehlo.add %arg3, %arg4 : tensor<i32>
     "stablehlo.return"(%1) : (tensor<i32>) -> ()
-  }) {dimensions = dense<1> : tensor<1xi64>, someattr} : (tensor<*xi32>, tensor<i32>) -> tensor<*xi32>
+  }) {dimensions = array<i64: 1>, someattr} : (tensor<*xi32>, tensor<i32>) -> tensor<*xi32>
   func.return %0 : tensor<*xi32>
 }
 // CHECK: stablehlo.reduce
@@ -60,7 +60,7 @@ func.func @reduce_dim0(%arg0: tensor<5x4xi32>, %arg1: tensor<i32>) -> tensor<4xi
   ^bb0(%arg3: tensor<i32>, %arg4 : tensor<i32>):
     %1 = stablehlo.maximum %arg3, %arg4 : tensor<i32>
     "stablehlo.return"(%1) : (tensor<i32>) -> ()
-  }) {dimensions = dense<0> : tensor<1xi64>} : (tensor<5x4xi32>, tensor<i32>) -> tensor<4xi32>
+  }) {dimensions = array<i64: 0>} : (tensor<5x4xi32>, tensor<i32>) -> tensor<4xi32>
   func.return %0 : tensor<4xi32>
 }
 // CHECK-DAG: %[[INIT:.*]] = tensor.extract %{{.*}} : tensor<i32>
@@ -90,7 +90,7 @@ func.func @reduce_dynamic_output(%arg0: tensor<5x4xi32>, %arg1: tensor<i32>) -> 
   ^bb0(%arg3: tensor<i32>, %arg4 : tensor<i32>):
     %1 = stablehlo.maximum %arg3, %arg4 : tensor<i32>
     "stablehlo.return"(%1) : (tensor<i32>) -> ()
-  }) {dimensions = dense<0> : tensor<1xi64>} : (tensor<5x4xi32>, tensor<i32>) -> tensor<?xi32>
+  }) {dimensions = array<i64: 0>} : (tensor<5x4xi32>, tensor<i32>) -> tensor<?xi32>
   func.return %0 : tensor<?xi32>
 }
 
@@ -112,7 +112,7 @@ func.func @reduce_init_const(%arg0: tensor<1x10xf32>) -> tensor<1xf32> {
   ^bb0(%arg1: tensor<f32>, %arg2: tensor<f32>):
     %1 = stablehlo.add %arg1, %arg2 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {dimensions = dense<1> : tensor<1xi64>} : (tensor<1x10xf32>, tensor<f32>) -> tensor<1xf32>
+  }) {dimensions = array<i64: 1>} : (tensor<1x10xf32>, tensor<f32>) -> tensor<1xf32>
   func.return %0 : tensor<1xf32>
 }
 // CHECK-DAG: %[[INIT_TENSOR:.*]] = tensor.empty()
@@ -137,7 +137,7 @@ func.func @reduce_multi_dimensions(%arg0: tensor<5x4x3xi32>,
   ^bb0(%arg2: tensor<i32>, %arg3: tensor<i32>):
     %1 = stablehlo.add %arg2, %arg3 : tensor<i32>
     "stablehlo.return"(%1) : (tensor<i32>) -> ()
-  }) {dimensions = dense<[0, 2]> : tensor<2xi64>} : (tensor<5x4x3xi32>, tensor<i32>) -> tensor<4xi32>
+  }) {dimensions = array<i64: 0, 2>} : (tensor<5x4x3xi32>, tensor<i32>) -> tensor<4xi32>
   func.return %0 : tensor<4xi32>
 }
 // CHECK-DAG: %[[INIT:.*]] = tensor.extract %{{.*}} : tensor<i32>
@@ -216,7 +216,7 @@ func.func @reduce_dynamic(%arg0: tensor<?x?xi32>, %arg1: tensor<i32>) -> tensor<
   ^bb0(%arg3: tensor<i32>, %arg4 : tensor<i32>):
     %1 = stablehlo.add %arg3, %arg4 : tensor<i32>
     "stablehlo.return"(%1) : (tensor<i32>) -> ()
-  }) {dimensions = dense<1> : tensor<1xi64>} : (tensor<?x?xi32>, tensor<i32>) -> tensor<?xi32>
+  }) {dimensions = array<i64: 1>} : (tensor<?x?xi32>, tensor<i32>) -> tensor<?xi32>
   func.return %0 : tensor<?xi32>
 }
 // CHECK-DAG: %[[INIT:.*]] = tensor.extract %{{.*}} : tensor<i32>
@@ -255,7 +255,7 @@ func.func @variadic_reduce(%arg0: tensor<9x2xi32>, %arg1: tensor<9x2xi32>) -> (t
     %673 = "stablehlo.select"(%669, %arg3, %arg16) : (tensor<i1>, tensor<i32>, tensor<i32>) -> tensor<i32>
     %674 = "stablehlo.select"(%671, %672, %673) : (tensor<i1>, tensor<i32>, tensor<i32>) -> tensor<i32>
     "stablehlo.return"(%670, %674) : (tensor<i32>, tensor<i32>) -> ()
-  }) {dimensions = dense<0> : tensor<1xi64>} : (tensor<9x2xi32>, tensor<9x2xi32>, tensor<i32>, tensor<i32>) -> (tensor<2xi32>, tensor<2xi32>)
+  }) {dimensions = array<i64: 0>} : (tensor<9x2xi32>, tensor<9x2xi32>, tensor<i32>, tensor<i32>) -> (tensor<2xi32>, tensor<2xi32>)
   func.return %res0, %res1 : tensor<2xi32>, tensor<2xi32>
 }
 // CHECK-DAG:    %[[CST0:.*]] = arith.constant -2147483648 : i32
@@ -316,7 +316,7 @@ func.func @variadic_diff_type_reduce(%arg0: tensor<128x10xf32>, %arg1: tensor<12
     %1 = "stablehlo.select"(%0, %arg7, %arg9) : (tensor<i1>, tensor<f32>, tensor<f32>) -> tensor<f32>
     %2 = "stablehlo.select"(%0, %arg8, %arg10) : (tensor<i1>, tensor<i32>, tensor<i32>) -> tensor<i32>
     "stablehlo.return"(%1, %2) : (tensor<f32>, tensor<i32>) -> ()
-  }) {dimensions = dense<1> : tensor<1xi64>} : (tensor<128x10xf32>, tensor<128x10xi32>, tensor<f32>, tensor<i32>) ->(tensor<128xf32>, tensor<128xi32>)
+  }) {dimensions = array<i64: 1>} : (tensor<128x10xf32>, tensor<128x10xi32>, tensor<f32>, tensor<i32>) ->(tensor<128xf32>, tensor<128xi32>)
   func.return %res0, %res1 : tensor<128xf32>, tensor<128xi32>
 }
 // CHECK-DAG:        %[[CST0:.*]] = arith.constant 1.000000e+00 : f32
@@ -399,8 +399,8 @@ func.func @reduce_window_min_nhwc(%arg0: tensor<1x17x17x64xf32>,
   ^bb0(%arg2: tensor<f32>, %arg3 : tensor<f32>):
     %1 = stablehlo.minimum %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {window_dimensions = dense<[1, 3, 3, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>,
+  }) {window_dimensions = array<i64: 1, 3, 3, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>,
       someattr} : (tensor<1x17x17x64xf32>, tensor<f32>) -> tensor<1x8x8x64xf32>
   func.return %0 : tensor<1x8x8x64xf32>
 }
@@ -426,8 +426,8 @@ func.func @reduce_window_max_nhwc(%arg0: tensor<1x17x17x64xf32>,
   ^bb0(%arg2: tensor<f32>, %arg3 : tensor<f32>):
     %1 = stablehlo.maximum %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {window_dimensions = dense<[1, 3, 3, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>} : (tensor<1x17x17x64xf32>, tensor<f32>) -> tensor<1x8x8x64xf32>
+  }) {window_dimensions = array<i64: 1, 3, 3, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>} : (tensor<1x17x17x64xf32>, tensor<f32>) -> tensor<1x8x8x64xf32>
   func.return %0 : tensor<1x8x8x64xf32>
 }
 // CHECK:         %[[WINDOW:.+]] = tensor.empty() : tensor<3x3xf32>
@@ -451,8 +451,8 @@ func.func @reduce_window_sum_nhwc(%arg0: tensor<1x17x17x64xf32>,
   ^bb0(%arg2: tensor<f32>, %arg3 : tensor<f32>):
     %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {window_dimensions = dense<[1, 3, 3, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>} : (tensor<1x17x17x64xf32>, tensor<f32>) -> tensor<1x8x8x64xf32>
+  }) {window_dimensions = array<i64: 1, 3, 3, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>} : (tensor<1x17x17x64xf32>, tensor<f32>) -> tensor<1x8x8x64xf32>
   func.return %0 : tensor<1x8x8x64xf32>
 }
 // CHECK:         %[[WINDOW:.+]] = tensor.empty() : tensor<3x3xf32>
@@ -475,8 +475,8 @@ func.func @reduce_window_max_nhwc_with_cst(%arg0: tensor<1x17x17x64xf32>) -> ten
   ^bb0(%arg1: tensor<f32>, %arg2 : tensor<f32>):
     %2 = stablehlo.maximum %arg1, %arg2 : tensor<f32>
     "stablehlo.return"(%2) : (tensor<f32>) -> ()
-  }) {window_dimensions = dense<[1, 3, 3, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>} : (tensor<1x17x17x64xf32>, tensor<f32>) -> tensor<1x8x8x64xf32>
+  }) {window_dimensions = array<i64: 1, 3, 3, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>} : (tensor<1x17x17x64xf32>, tensor<f32>) -> tensor<1x8x8x64xf32>
   func.return %1 : tensor<1x8x8x64xf32>
 }
 
@@ -502,8 +502,8 @@ func.func @reduce_window_sum_max_nhwc(%arg0: tensor<1x17x17x64xf32>,
     %1 = stablehlo.add %arg2, %arg4 : tensor<f32>
     %2 = stablehlo.maximum %arg3, %arg5 : tensor<f32>
     "stablehlo.return"(%1, %2) : (tensor<f32>, tensor<f32>) -> ()
-  }) {window_dimensions = dense<[1, 3, 3, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>} : (tensor<1x17x17x64xf32>, tensor<1x17x17x64xf32>, tensor<f32>, tensor<f32>) -> (tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>)
+  }) {window_dimensions = array<i64: 1, 3, 3, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>} : (tensor<1x17x17x64xf32>, tensor<1x17x17x64xf32>, tensor<f32>, tensor<f32>) -> (tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>)
   func.return %0#0, %0#1 : tensor<1x8x8x64xf32>, tensor<1x8x8x64xf32>
 }
 
@@ -537,8 +537,8 @@ func.func @reduce_window_unsigned(%arg0: tensor<1x1xui32>) -> tensor<1x1xui32> {
   ^bb0(%arg1: tensor<ui32>, %arg2: tensor<ui32>):
     stablehlo.return %arg1 : tensor<ui32>
   }) {
-    window_dimensions = dense<[1, 1]> : tensor<2xi64>,
-    window_strides = dense<[1, 1]> : tensor<2xi64>
+    window_dimensions = array<i64: 1, 1>,
+    window_strides = array<i64: 1, 1>
   } : (tensor<1x1xui32>, tensor<ui32>) -> tensor<1x1xui32>
   return %1 : tensor<1x1xui32>
 }
@@ -554,8 +554,8 @@ func.func @dynamic_reduce_window_sum_nhwc(%arg0: tensor<?x?x?x?xf32>,
   ^bb0(%arg2: tensor<f32>, %arg3 : tensor<f32>):
     %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {window_dimensions = dense<[1, 3, 3, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>} : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<?x?x?x?xf32>
+  }) {window_dimensions = array<i64: 1, 3, 3, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>} : (tensor<?x?x?x?xf32>, tensor<f32>) -> tensor<?x?x?x?xf32>
   func.return %0 : tensor<?x?x?x?xf32>
 }
 // CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
@@ -593,8 +593,8 @@ func.func @reduce_window_min_ndhwc(%arg0: tensor<1x17x17x17x64xf32>,
   ^bb0(%arg2: tensor<f32>, %arg3 : tensor<f32>):
     %1 = stablehlo.minimum %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {window_dimensions = dense<[1, 3, 3, 3, 1]> : tensor<5xi64>,
-      window_strides = dense<[1, 2, 2, 2, 1]> : tensor<5xi64>} : (tensor<1x17x17x17x64xf32>, tensor<f32>) -> tensor<1x8x8x8x64xf32>
+  }) {window_dimensions = array<i64: 1, 3, 3, 3, 1>,
+      window_strides = array<i64: 1, 2, 2, 2, 1>} : (tensor<1x17x17x17x64xf32>, tensor<f32>) -> tensor<1x8x8x8x64xf32>
   func.return %0 : tensor<1x8x8x8x64xf32>
 }
 // CHECK:         %[[WINDOW:.+]] = tensor.empty() : tensor<3x3x3xf32>
@@ -618,8 +618,8 @@ func.func @reduce_window_max_ndhwc(%arg0: tensor<1x17x17x17x64xf32>,
   ^bb0(%arg2: tensor<f32>, %arg3 : tensor<f32>):
     %1 = stablehlo.maximum %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {window_dimensions = dense<[1, 3, 3, 3, 1]> : tensor<5xi64>,
-      window_strides = dense<[1, 2, 2, 2, 1]> : tensor<5xi64>} : (tensor<1x17x17x17x64xf32>, tensor<f32>) -> tensor<1x8x8x8x64xf32>
+  }) {window_dimensions = array<i64: 1, 3, 3, 3, 1>,
+      window_strides = array<i64: 1, 2, 2, 2, 1>} : (tensor<1x17x17x17x64xf32>, tensor<f32>) -> tensor<1x8x8x8x64xf32>
   func.return %0 : tensor<1x8x8x8x64xf32>
 }
 // CHECK:         %[[WINDOW:.+]] = tensor.empty() : tensor<3x3x3xf32>
@@ -643,8 +643,8 @@ func.func @reduce_window_sum_ndhwc(%arg0: tensor<1x17x17x17x64xf32>,
   ^bb0(%arg2: tensor<f32>, %arg3 : tensor<f32>):
     %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {window_dimensions = dense<[1, 3, 3, 3, 1]> : tensor<5xi64>,
-      window_strides = dense<[1, 2, 2, 2, 1]> : tensor<5xi64>} : (tensor<1x17x17x17x64xf32>, tensor<f32>) -> tensor<1x8x8x8x64xf32>
+  }) {window_dimensions = array<i64: 1, 3, 3, 3, 1>,
+      window_strides = array<i64: 1, 2, 2, 2, 1>} : (tensor<1x17x17x17x64xf32>, tensor<f32>) -> tensor<1x8x8x8x64xf32>
   func.return %0 : tensor<1x8x8x8x64xf32>
 }
 // CHECK:         %[[WINDOW:.+]] = tensor.empty() : tensor<3x3x3xf32>
@@ -668,9 +668,9 @@ func.func @reduce_window_sum_ndhwc_dilated_base(
   ^bb0(%arg2: tensor<f32>, %arg3 : tensor<f32>):
     %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {base_dilations = dense<[1, 1, 1, 2, 1]> : tensor<5xi64>,
-      window_dimensions = dense<[1, 3, 3, 3, 1]> : tensor<5xi64>,
-      window_strides = dense<[1, 2, 2, 2, 1]> : tensor<5xi64>} : (tensor<1x17x17x17x64xf32>, tensor<f32>) -> tensor<1x8x8x16x64xf32>
+  }) {base_dilations = array<i64: 1, 1, 1, 2, 1>,
+      window_dimensions = array<i64: 1, 3, 3, 3, 1>,
+      window_strides = array<i64: 1, 2, 2, 2, 1>} : (tensor<1x17x17x17x64xf32>, tensor<f32>) -> tensor<1x8x8x16x64xf32>
   func.return %0 : tensor<1x8x8x16x64xf32>
 }
 
@@ -690,7 +690,11 @@ func.func @reduce_window_generic(%arg0: tensor<4x6xf32>, %arg1: tensor<f32>) -> 
   ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
     %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {base_dilations = dense<1> : tensor<2xi64>, padding = dense<[[0, 3], [1, 2]]> : tensor<2x2xi64>, window_dilations = dense<[1, 2]> : tensor<2xi64>, window_dimensions = dense<[1, 2]> : tensor<2xi64>, window_strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x6xf32>, tensor<f32>) -> tensor<4x7xf32>
+  }) {base_dilations = array<i64: 1, 1>,
+      padding = dense<[[0, 3], [1, 2]]> : tensor<2x2xi64>,
+      window_dilations = array<i64: 1, 2>,
+      window_dimensions = array<i64: 1, 2>,
+      window_strides = array<i64: 2, 1>} : (tensor<4x6xf32>, tensor<f32>) -> tensor<4x7xf32>
   func.return %0 : tensor<4x7xf32>
 }
 // CHECK: %[[INIT:.+]] = tensor.empty() : tensor<4x7xf32>
@@ -727,7 +731,11 @@ func.func @reduce_window_generic_captured_constant(%arg0: tensor<4x6xf32>, %arg1
     %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
     %2 = stablehlo.multiply %1, %c2 : tensor<f32>
     "stablehlo.return"(%2) : (tensor<f32>) -> ()
-  }) {base_dilations = dense<1> : tensor<2xi64>, padding = dense<[[0, 3], [1, 2]]> : tensor<2x2xi64>, window_dilations = dense<[1, 2]> : tensor<2xi64>, window_dimensions = dense<[1, 2]> : tensor<2xi64>, window_strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<4x6xf32>, tensor<f32>) -> tensor<4x7xf32>
+  }) {base_dilations = array<i64: 1, 1>,
+      padding = dense<[[0, 3], [1, 2]]> : tensor<2x2xi64>,
+      window_dilations = array<i64: 1, 2>,
+      window_dimensions = array<i64: 1, 2>,
+      window_strides = array<i64: 2, 1>} : (tensor<4x6xf32>, tensor<f32>) -> tensor<4x7xf32>
   func.return %0 : tensor<4x7xf32>
 }
 
@@ -747,7 +755,10 @@ func.func @reduce_window_generic_padding(%arg0: tensor<3x6xf32>, %arg1: tensor<f
   ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
     %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {padding = dense<[[0, 3], [1, 2]]> : tensor<2x2xi64>, window_dilations = dense<[1, 2]> : tensor<2xi64>, window_dimensions = dense<[1, 2]> : tensor<2xi64>, window_strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<3x6xf32>, tensor<f32>) -> tensor<3x7xf32>
+  }) {padding = dense<[[0, 3], [1, 2]]> : tensor<2x2xi64>,
+      window_dilations = array<i64: 1, 2>,
+      window_dimensions = array<i64: 1, 2>,
+      window_strides = array<i64: 2, 1>} : (tensor<3x6xf32>, tensor<f32>) -> tensor<3x7xf32>
   func.return %0 : tensor<3x7xf32>
 }
 // CHECK: %[[PADVAL:.+]] = tensor.extract %[[ARG1]][] : tensor<f32>
@@ -764,7 +775,10 @@ func.func @reduce_window_generic_base_dilation(%arg0: tensor<3x6xf32>, %arg1: te
   ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
     %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {base_dilations = dense<[2, 1]> : tensor<2xi64>, window_dilations = dense<[1, 2]> : tensor<2xi64>, window_dimensions = dense<[1, 2]> : tensor<2xi64>, window_strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<3x6xf32>, tensor<f32>) -> tensor<3x4xf32>
+  }) {base_dilations = array<i64: 2, 1>,
+      window_dilations = array<i64: 1, 2>,
+      window_dimensions = array<i64: 1, 2>,
+      window_strides = array<i64: 2, 1>} : (tensor<3x6xf32>, tensor<f32>) -> tensor<3x4xf32>
   func.return %0 : tensor<3x4xf32>
 }
 // CHECK: %[[PADVAL:.+]] = tensor.extract %[[ARG1]][] : tensor<f32>
@@ -782,7 +796,11 @@ func.func @reduce_window_generic_padding_base_dilation(%arg0: tensor<3x6xf32>, %
   ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
     %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {base_dilations = dense<[2, 1]> : tensor<2xi64>, padding = dense<[[0, 3], [1, 2]]> : tensor<2x2xi64>, window_dilations = dense<[1, 2]> : tensor<2xi64>, window_dimensions = dense<[1, 2]> : tensor<2xi64>, window_strides = dense<[2, 1]> : tensor<2xi64>} : (tensor<3x6xf32>, tensor<f32>) -> tensor<4x7xf32>
+  }) {base_dilations = array<i64: 2, 1>,
+      padding = dense<[[0, 3], [1, 2]]> : tensor<2x2xi64>,
+      window_dilations = array<i64: 1, 2>,
+      window_dimensions = array<i64: 1, 2>,
+      window_strides = array<i64: 2, 1>} : (tensor<3x6xf32>, tensor<f32>) -> tensor<4x7xf32>
   func.return %0 : tensor<4x7xf32>
 }
 // CHECK: %[[PADVAL:.+]] = tensor.extract %[[ARG1]][] : tensor<f32>
@@ -799,7 +817,11 @@ func.func @reduce_window_generic_scalar(%arg0: tensor<f32>, %arg1: tensor<f32>) 
   ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
     %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {base_dilations = dense<> : tensor<0xi64>, padding = dense<> : tensor<0x2xi64>, window_dilations = dense<> : tensor<0xi64>, window_dimensions = dense<> : tensor<0xi64>, window_strides = dense<> : tensor<0xi64>} : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  }) {base_dilations = array<i64>,
+      padding = dense<> : tensor<0x2xi64>,
+      window_dilations = array<i64>,
+      window_dimensions = array<i64>,
+      window_strides = array<i64>} : (tensor<f32>, tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 // CHECK: linalg.generic {indexing_maps = [#[[MAP]], #[[MAP]], #[[MAP]]]

--- a/stablehlo/conversions/tosa/tests/binary.mlir
+++ b/stablehlo/conversions/tosa/tests/binary.mlir
@@ -109,7 +109,7 @@ func.func @gather(%arg0 : tensor<3x4x5xi32>, %arg1 : tensor<3x2xi32>) -> tensor<
       start_index_map = [0, 1]
     >,
     indices_are_sorted = false,
-    slice_sizes = dense<[1, 2, 5]> : tensor<3xi64>
+    slice_sizes = array<i64: 1, 2, 5>
   } : (tensor<3x4x5xi32>, tensor<3x2xi32>) -> tensor<3x2x5xi32>
   return %0 : tensor<3x2x5xi32>
 }
@@ -127,7 +127,7 @@ func.func @gather_unranked(%arg0 : tensor<*xi32>, %arg1 : tensor<3x2xi32>) -> te
       start_index_map = [0, 1]
     >,
     indices_are_sorted = false,
-    slice_sizes = dense<[1, 2, 5]> : tensor<3xi64>
+    slice_sizes = array<i64: 1, 2, 5>
   } : (tensor<*xi32>, tensor<3x2xi32>) -> tensor<*xi32>
   return %0 : tensor<*xi32>
 }
@@ -182,7 +182,7 @@ func.func @reduce_max(%arg0: tensor<1x10xf32>, %arg1: tensor<f32>) -> tensor<1xf
   ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
     %1 = stablehlo.maximum %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {dimensions = dense<1> : tensor<1xi64>} : (tensor<1x10xf32>, tensor<f32>) -> tensor<1xf32>
+  }) {dimensions = array<i64: 1>} : (tensor<1x10xf32>, tensor<f32>) -> tensor<1xf32>
   return %0 : tensor<1xf32>
 }
 
@@ -194,7 +194,7 @@ func.func @reduce_sum(%arg0: tensor<5x4xf32>, %arg1: tensor<f32>) -> tensor<4xf3
   ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
     %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {dimensions = dense<0> : tensor<1xi64>} : (tensor<5x4xf32>, tensor<f32>) -> tensor<4xf32>
+  }) {dimensions = array<i64: 0>} : (tensor<5x4xf32>, tensor<f32>) -> tensor<4xf32>
   return %0 : tensor<4xf32>
 }
 

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -193,7 +193,7 @@ func.func @gather_c13(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x
       start_index_map = [0, 1]
     >,
     indices_are_sorted = false,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>
+    slice_sizes = array<i64: 1, 1, 8>
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
   // CHECK: types0 = tensor<1x5x8xi32>
   %1 = "hlo_test_infer.get_return_types"(%res) : (tensor<1x5x8xi32>) -> tensor<1x5x8xindex>
@@ -212,7 +212,7 @@ func.func @gather_bounds(%operand : tensor<?x?x?xi32, #stablehlo.bounds<2, 4, 8>
       start_index_map = [0, 1]
     >,
     indices_are_sorted = false,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>
+    slice_sizes = array<i64: 1, 1, 8>
   } : (tensor<?x?x?xi32, #stablehlo.bounds<2, 4, 8>>, tensor<?x?x?xi32, #stablehlo.bounds<16, 32, 64>>)
   -> tensor<?x?x8xi32>
 
@@ -467,7 +467,7 @@ func.func @map(%arg0: tensor<4x5xf32>, %arg1: tensor<4x5xf32>) -> tensor<4x5xind
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
     %1 = stablehlo.constant dense<2.0> : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {dimensions = dense<[0, 1]> : tensor<2xi64>} : (tensor<4x5xf32>, tensor<4x5xf32>) -> tensor<4x5xf32>
+  }) {dimensions = array<i64: 0, 1>} : (tensor<4x5xf32>, tensor<4x5xf32>) -> tensor<4x5xf32>
   // CHECK: types0 = tensor<4x5xf32>
   %2 = "hlo_test_infer.get_return_types"(%0) : (tensor<4x5xf32>) -> tensor<4x5xindex>
   func.return %2 : tensor<4x5xindex>
@@ -619,8 +619,8 @@ func.func @select_and_scatter_c11_c12(
     %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
     "stablehlo.return"(%2) : (tensor<f32>) -> ()
   }) {
-    window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-    window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>
+    window_dimensions = array<i64: 1, 2, 2, 1>,
+    window_strides = array<i64: 1, 2, 2, 1>
   } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
         tensor<10x24x24x64xf32>
   // CHECK: types0 = tensor<10x24x24x64xf32>
@@ -647,8 +647,8 @@ func.func @select_and_scatter_c11_c12(
     %2 = stablehlo.add %arg3, %arg4 : tensor<f64>
     "stablehlo.return"(%2) : (tensor<f64>) -> ()
   }) {
-    window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-    window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>
+    window_dimensions = array<i64: 1, 2, 2, 1>,
+    window_strides = array<i64: 1, 2, 2, 1>
   } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
         tensor<10x24x24x64xf64>
   %2 = "hlo_test_infer.get_return_types"(%1) : (tensor<10x24x24x64xf64>) -> tensor<10x24x24x64xindex>
@@ -879,7 +879,7 @@ func.func @reduce(%arg0: tensor<7x5xf32>, %arg1 : tensor<5xf32>)
   ^bb0(%arg2: tensor<5xf32>, %arg3: tensor<5xf32> ):
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<5xf32>, tensor<5xf32>) -> tensor<5xf32>
     "stablehlo.return"(%1) : (tensor<5xf32>) -> ()
-  }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<7x5xf32>, tensor<5xf32>) -> tensor<5xf32>
+  }) {dimensions = array<i64: 0>} : (tensor<7x5xf32>, tensor<5xf32>) -> tensor<5xf32>
   // CHECK: types0 = tensor<5xf32>
   %2 = "hlo_test_infer.get_return_types"(%0)
       : (tensor<5xf32>) -> tensor<5xindex>
@@ -899,7 +899,7 @@ func.func @reduce(%arg0: tensor<4x?xf32>, %arg1 : tensor<4xf32>)-> (tensor<1xind
   ^bb0(%arg2: tensor<4xf32>, %arg3: tensor<4xf32> ):
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
     "stablehlo.return"(%1) : (tensor<4xf32>) -> ()
-  }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<4x?xf32>, tensor<4xf32>) -> tensor<?xf32>
+  }) {dimensions = array<i64: 0>} : (tensor<4x?xf32>, tensor<4xf32>) -> tensor<?xf32>
   %1 = "hlo_test_infer.reify_return_type_shapes"(%result): (tensor<?xf32>) -> tensor<1xindex>
   func.return %1: tensor<1xindex>
 }
@@ -913,7 +913,7 @@ func.func @reduce_unranked(%arg0: tensor<*xf32>, %arg1 : tensor<f32>)
   ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32> ):
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<*xf32>, tensor<f32>) -> tensor<*xf32>
+  }) {dimensions = array<i64: 0>} : (tensor<*xf32>, tensor<f32>) -> tensor<*xf32>
   // CHECK: types0 = tensor<*xf32>
   %2 = "hlo_test_infer.get_return_types"(%0)
       : (tensor<*xf32>) -> tensor<*xindex>
@@ -929,7 +929,7 @@ func.func @reduce_c7(%arg0: tensor<7x5xf32>, %arg1 : tensor<5xf32>) -> tensor<6x
   ^bb0(%arg2: tensor<5xf32>, %arg3: tensor<5xf32> ):
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<5xf32>, tensor<5xf32>) -> tensor<5xf32>
     "stablehlo.return"(%1) : (tensor<5xf32>) -> ()
-  }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<7x5xf32>, tensor<5xf32>) -> tensor<6xf32>
+  }) {dimensions = array<i64: 0>} : (tensor<7x5xf32>, tensor<5xf32>) -> tensor<6xf32>
   func.return %0: tensor<6xf32>
 }
 
@@ -945,7 +945,7 @@ func.func @reduce_c8(%arg0: tensor<4x4xf32>, %arg1 : tensor<f32>)
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<f64>, tensor<f64>) -> tensor<f64>
     "stablehlo.return"(%1) : (tensor<f64>) -> ()
 
-  }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<4x4xf32>, tensor<f32>) -> tensor<4xf32>
+  }) {dimensions = array<i64: 0>} : (tensor<4x4xf32>, tensor<f32>) -> tensor<4xf32>
 
   func.return %0: tensor<4xf32>
 }
@@ -963,7 +963,7 @@ func.func @reduce_c3_c7(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32>,
     %2 = "stablehlo.add"(%arg5, %arg7) : (tensor<i32>, tensor<i32>) -> tensor<i32>
     "stablehlo.return"(%1, %2) : (tensor<f32>, tensor<i32>) -> ()
 
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<f32>, tensor<i32>) -> (tensor<?xf32>, tensor<?xi32>, tensor<?xi32>)
+  }) {dimensions = array<i64: 1>} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<f32>, tensor<i32>) -> (tensor<?xf32>, tensor<?xi32>, tensor<?xi32>)
 
   func.return %0#0: tensor<?xf32>
 }
@@ -981,7 +981,7 @@ func.func @reduce_c7_c8(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32>,
     %2 = "stablehlo.add"(%arg5, %arg7) : (tensor<i32>, tensor<i32>) -> tensor<i32>
     "stablehlo.return"(%1, %2) : (tensor<f32>, tensor<i32>) -> ()
 
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<f32>, tensor<i32>) -> (tensor<?xf32>, tensor<?x?xf32>)
+  }) {dimensions = array<i64: 1>} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<f32>, tensor<i32>) -> (tensor<?xf32>, tensor<?x?xf32>)
 
   func.return %0#0: tensor<?xf32>
 }
@@ -998,7 +998,7 @@ func.func @reduce_c8(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
 
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xi32>
+  }) {dimensions = array<i64: 1>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xi32>
 
   func.return %0: tensor<?xi32>
 }
@@ -1030,8 +1030,9 @@ func.func @reduce_window(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>,
               "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1>
+         }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
 
@@ -1055,8 +1056,8 @@ func.func @reduce_window_c1(%arg0: tensor<4x2xf32>,
               "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64>
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1>
          }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               tensor<2x2xf32>
@@ -1078,8 +1079,8 @@ func.func @reduce_window_c14_c15(%arg0: tensor<4x2xf32>,
               "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64>
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1>
          }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x3xi32>)
@@ -1101,8 +1102,8 @@ func.func @reduce_window_c16(%arg0: tensor<4x2xf32>,
               "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64>
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1>
          }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xi32>, tensor<2x2xi32>)
@@ -1121,8 +1122,8 @@ func.func @reduce_window_c16(%arg0: tensor<4x2xf32>, %init0: tensor<f32>) ->
               "stablehlo.return"(%1) : (tensor<f64>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64>
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1>
          }
          : (tensor<4x2xf32>, tensor<f32>) -> (tensor<2x2xf32>)
   func.return %0 : tensor<2x2xf32>
@@ -1561,7 +1562,7 @@ func.func @gather(%operand : tensor<3x4x2xi32>, %start_indices : tensor<?x3x2xi6
       collapsed_slice_dims = [0],
       start_index_map = [1, 0],
       index_vector_dim = 2>,
-      slice_sizes = dense<[1, 2, 2]> : tensor<3xi64>,
+      slice_sizes = array<i64: 1, 2, 2>,
       indices_are_sorted = false
   } : (tensor<3x4x2xi32>, tensor<?x3x2xi64>) -> tensor<?x3x2x2xi32>
   %1 = "hlo_test_infer.reify_return_type_shapes"(%result) : (tensor<?x3x2x2xi32>) -> tensor<4xindex>
@@ -1631,7 +1632,7 @@ func.func @reduce_with_bounds(%arg0: tensor<?x?x5xf32, #stablehlo.bounds<3, 7, ?
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<5xf32>, tensor<5xf32>) -> tensor<5xf32>
     "stablehlo.return"(%1) : (tensor<5xf32>) -> ()
 
-  }) {dimensions = dense<[0]> : tensor<1xi64>}
+  }) {dimensions = array<i64: 0>}
       : (tensor<?x?x5xf32, #stablehlo.bounds<3, 7, ?>>, tensor<5xf32>)
           -> tensor<?x5xf32, #stablehlo.bounds<7, ?>>
 
@@ -1653,7 +1654,7 @@ func.func @reduce_with_scalar_result(%arg0: tensor<?xf32, #stablehlo.bounds<3>>,
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
 
-  }) {dimensions = dense<[0]> : tensor<1xi64>}
+  }) {dimensions = array<i64: 0>}
       : (tensor<?xf32, #stablehlo.bounds<3>>, tensor<f32>)
           -> tensor<*xf32>
 
@@ -1820,8 +1821,8 @@ func.func @select_and_scatter_bound(
     %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
     "stablehlo.return"(%2) : (tensor<f32>) -> ()
   }) {
-    window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-    window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>
+    window_dimensions = array<i64: 1, 2, 2, 1>,
+    window_strides = array<i64: 1, 2, 2, 1>
   } : (tensor<?x24x24x64xf32, #stablehlo.bounds<10, ?, ?, ?>>,
        tensor<?x12x12x64xf32, #stablehlo.bounds<10, ?, ?, ?>>,
        tensor<f32>) -> tensor<*xf32>
@@ -1841,8 +1842,8 @@ func.func @reduce_window_bound(%arg0: tensor<4x?x?x?xf32, #stablehlo.bounds<?, ?
     "stablehlo.return"(%2) : (tensor<f32>) -> ()
   }) {
     padding = dense<[[0, 0], [0, 0], [2, 2], [0, 0]]> : tensor<4x2xi64>,
-    window_dimensions = dense<[1, 1, 5, 1]> : tensor<4xi64>,
-    window_strides = dense<[1, 1, 3, 1]> : tensor<4xi64>
+    window_dimensions = array<i64: 1, 1, 5, 1>,
+    window_strides = array<i64: 1, 1, 3, 1>
   } : (tensor<4x?x?x?xf32, #stablehlo.bounds<?, ?, 4, 2>>,
        tensor<f32>) -> (tensor<*xf32>)
   // CHECK: types0 = tensor<4x?x?x?xf32, #stablehlo.bounds<?, ?, 2, 2>>

--- a/stablehlo/tests/interpret/gather.mlir
+++ b/stablehlo/tests/interpret/gather.mlir
@@ -12,7 +12,7 @@ func.func @gather_op_test() {
       collapsed_slice_dims = [0],
       start_index_map = [1, 0],
       index_vector_dim = 2>,
-    slice_sizes = dense<[1, 2, 2]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 2, 2>,
     indices_are_sorted = false
   } : (tensor<3x4x2xi64>, tensor<2x3x2xi64>) -> tensor<2x3x2x2xi64>
   check.expect_eq_const %result, dense<[[[[1, 2], [3, 4]],

--- a/stablehlo/tests/interpret/map.mlir
+++ b/stablehlo/tests/interpret/map.mlir
@@ -8,7 +8,7 @@ func.func @map_op_test_si64() {
       %0 = stablehlo.multiply %arg0, %arg1 : tensor<i64>
       stablehlo.return %0 : tensor<i64>
   }) {
-    dimensions = dense<[0, 1]> : tensor<2xi64>
+    dimensions = array<i64: 0, 1>
   } : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<2x2xi64>
   check.expect_eq_const %result, dense<[[0, 5], [12, 21]]> : tensor<2x2xi64>
   func.return

--- a/stablehlo/tests/interpret/reduce.mlir
+++ b/stablehlo/tests/interpret/reduce.mlir
@@ -8,7 +8,7 @@ func.func @reduce() {
       %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
       stablehlo.return %0 : tensor<i64>
   }) {
-    dimensions = dense<1> : tensor<1xi64>
+    dimensions = array<i64: 1>
   } : (tensor<1x6xi64>, tensor<i64>) -> tensor<1xi64>
   check.expect_eq_const %result, dense<[15]> : tensor<1xi64>
   func.return

--- a/stablehlo/tests/interpret/reduce_window.mlir
+++ b/stablehlo/tests/interpret/reduce_window.mlir
@@ -8,11 +8,11 @@ func.func @reduce_window() {
       %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
       stablehlo.return %0 : tensor<i64>
   }) {
-    base_dilations = dense<[2, 1]> : tensor<2xi64>,
+    base_dilations = array<i64: 2, 1>,
     padding = dense<[[2, 1], [0, 0]]> : tensor<2x2xi64>,
-    window_dilations = dense<[3, 1]> : tensor<2xi64>,
-    window_dimensions = dense<[2, 1]> : tensor<2xi64>,
-    window_strides = dense<[4, 1]> : tensor<2xi64>
+    window_dilations = array<i64: 3, 1>,
+    window_dimensions = array<i64: 2, 1>,
+    window_strides = array<i64: 4, 1>
   } : (tensor<3x2xi64>, tensor<i64>) -> tensor<2x2xi64>
   check.expect_eq_const %result, dense<[[0, 0], [3, 4]]> : tensor<2x2xi64>
   func.return
@@ -28,11 +28,11 @@ func.func @reduce_window_issue_1662() {
       %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
       stablehlo.return %0 : tensor<i64>
   }) {
-    base_dilations = dense<[2, 1]> : tensor<2xi64>,
+    base_dilations = array<i64: 2, 1>,
     padding = dense<[[2, 1], [0, 0]]> : tensor<2x2xi64>,
-    window_dilations = dense<[3, 1]> : tensor<2xi64>,
-    window_dimensions = dense<[3, 1]> : tensor<2xi64>,
-    window_strides = dense<[4, 1]> : tensor<2xi64>
+    window_dilations = array<i64: 3, 1>,
+    window_dimensions = array<i64: 3, 1>,
+    window_strides = array<i64: 4, 1>
   } : (tensor<3x2xi64>, tensor<i64>) -> tensor<1x2xi64>
   check.expect_eq_const %result, dense<[[5, 6]]> : tensor<1x2xi64>
   func.return

--- a/stablehlo/tests/interpret/select_and_scatter.mlir
+++ b/stablehlo/tests/interpret/select_and_scatter.mlir
@@ -17,8 +17,8 @@ func.func @select_and_scatter_op_test() {
       %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
       stablehlo.return %0 : tensor<i64>
   }) {
-    window_dimensions = dense<[3, 1]> : tensor<2xi64>,
-    window_strides = dense<[2, 1]> : tensor<2xi64>,
+    window_dimensions = array<i64: 3, 1>,
+    window_strides = array<i64: 2, 1>,
     padding = dense<[[0, 1], [0, 0]]> : tensor<2x2xi64>
   } : (tensor<4x2xi64>, tensor<2x2xi64>, tensor<i64>) -> tensor<4x2xi64>
   check.expect_eq_const %result, dense<[[0, 0],

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1851,7 +1851,7 @@ func.func @map(%arg0: tensor<4x5xf32>, %arg1: tensor<4x5xf32>) -> tensor<4x5xf32
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
     %1 = stablehlo.constant dense<2.0> : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {dimensions = dense<[0, 1]> : tensor<2xi64>} : (tensor<4x5xf32>, tensor<4x5xf32>) -> tensor<4x5xf32>
+  }) {dimensions = array<i64: 0, 1>} : (tensor<4x5xf32>, tensor<4x5xf32>) -> tensor<4x5xf32>
   func.return %0 : tensor<4x5xf32>
 }
 
@@ -1864,7 +1864,7 @@ func.func @map_c3(%arg0: tensor<4x5xf32>, %arg1: tensor<4x5xf32>) -> tensor<4x5x
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
     %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {dimensions = dense<[1, 0]> : tensor<2xi64>} : (tensor<4x5xf32>, tensor<4x5xf32>) -> tensor<4x5xf32>
+  }) {dimensions = array<i64: 1, 0>} : (tensor<4x5xf32>, tensor<4x5xf32>) -> tensor<4x5xf32>
   func.return %0 : tensor<4x5xf32>
 }
 
@@ -1877,7 +1877,7 @@ func.func @map_c3(%arg0: tensor<4x5xf32>, %arg1: tensor<4x5xf32>) -> tensor<4x5x
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
     %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {dimensions = dense<[0, 1, 2]> : tensor<3xi64>} : (tensor<4x5xf32>, tensor<4x5xf32>) -> tensor<4x5xf32>
+  }) {dimensions = array<i64: 0, 1, 2>} : (tensor<4x5xf32>, tensor<4x5xf32>) -> tensor<4x5xf32>
   func.return %0 : tensor<4x5xf32>
 }
 
@@ -1890,7 +1890,7 @@ func.func @map_c4(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
     ^bb0(%arg: tensor<f32>):
     %1 = stablehlo.add %arg, %arg : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {dimensions = dense<0> : tensor<1xi64>} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+  }) {dimensions = array<i64: 0>} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }
 
@@ -1903,7 +1903,7 @@ func.func @map_c4(%arg0: tensor<4x5xf32>, %arg1: tensor<4x5xf32>) -> tensor<4x5x
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<5xf32>):
     %1 = stablehlo.constant dense<2.0> : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {dimensions = dense<[0, 1]> : tensor<2xi64>} : (tensor<4x5xf32>, tensor<4x5xf32>) -> tensor<4x5xf32>
+  }) {dimensions = array<i64: 0, 1>} : (tensor<4x5xf32>, tensor<4x5xf32>) -> tensor<4x5xf32>
   func.return %0 : tensor<4x5xf32>
 }
 
@@ -1916,7 +1916,7 @@ func.func @map_c4(%arg0: tensor<4x5xf32>, %arg1: tensor<4x5xf32>) -> tensor<4x5x
     ^bb0(%arg2: tensor<i32>, %arg3: tensor<i32>):
     %1 = stablehlo.constant dense<2.0> : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {dimensions = dense<[0, 1]> : tensor<2xi64>} : (tensor<4x5xf32>, tensor<4x5xf32>) -> tensor<4x5xf32>
+  }) {dimensions = array<i64: 0, 1>} : (tensor<4x5xf32>, tensor<4x5xf32>) -> tensor<4x5xf32>
   func.return %0 : tensor<4x5xf32>
 }
 
@@ -1929,7 +1929,7 @@ func.func @map_c4(%arg0: tensor<4x5xf32>, %arg1: tensor<4x5xf32>) -> tensor<4x5x
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
     %1 = stablehlo.constant dense<2.0> : tensor<f32>
     "stablehlo.return"() : () -> ()
-  }) {dimensions = dense<[0, 1]> : tensor<2xi64>} : (tensor<4x5xf32>, tensor<4x5xf32>) -> tensor<4x5xf32>
+  }) {dimensions = array<i64: 0, 1>} : (tensor<4x5xf32>, tensor<4x5xf32>) -> tensor<4x5xf32>
   func.return %0 : tensor<4x5xf32>
 }
 
@@ -1942,7 +1942,7 @@ func.func @map_c4(%arg0: tensor<4x5xf32>, %arg1: tensor<4x5xf32>) -> tensor<4x5x
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
     %1 = stablehlo.constant dense<2.0> : tensor<5xf32>
     "stablehlo.return"(%1) : (tensor<5xf32>) -> ()
-  }) {dimensions = dense<[0, 1]> : tensor<2xi64>} : (tensor<4x5xf32>, tensor<4x5xf32>) -> tensor<4x5xf32>
+  }) {dimensions = array<i64: 0, 1>} : (tensor<4x5xf32>, tensor<4x5xf32>) -> tensor<4x5xf32>
   func.return %0 : tensor<4x5xf32>
 }
 
@@ -1953,7 +1953,7 @@ func.func @map_heterogeneous_inputs(%arg0: tensor<2xf32>, %arg1: tensor<2xi32>) 
   %0 = "stablehlo.map"(%arg0, %arg1) ({
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<i32>):
     "stablehlo.return"(%arg2) : (tensor<f32>) -> ()
-  }) {dimensions = dense<0> : tensor<1xi64>} : (tensor<2xf32>, tensor<2xi32>) -> tensor<2xf32>
+  }) {dimensions = array<i64: 0>} : (tensor<2xf32>, tensor<2xi32>) -> tensor<2xf32>
   func.return %0 : tensor<2xf32>
 }
 
@@ -1977,7 +1977,7 @@ func.func @map_scalar_operands(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
     %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {dimensions = dense<> : tensor<0xi64>} : (tensor<f32>, tensor<f32>) -> tensor<f32>
+  }) {dimensions = array<i64>} : (tensor<f32>, tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
 
@@ -1989,7 +1989,7 @@ func.func @map_unranked(%arg0: tensor<*xf32>, %arg1: tensor<*xf32>) -> tensor<*x
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
     %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {dimensions = dense<0> : tensor<1xi64>} : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
+  }) {dimensions = array<i64: 0>} : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
   func.return %0 : tensor<*xf32>
 }
 
@@ -3562,7 +3562,7 @@ func.func @gather(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x2xi3
       start_index_map = [0, 1],
       index_vector_dim = 2
     >,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     indices_are_sorted = false
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
   func.return %res : tensor<1x5x8xi32>
@@ -3579,7 +3579,7 @@ func.func @gather(%operand : tensor<*xi32>, %start_indices : tensor<1x5x2xi32>) 
       start_index_map = [0, 1],
       index_vector_dim = 2
     >,
-    slice_sizes = dense<[1, 1, 8, 1, 7, 1, 6, 1]> : tensor<8xi64>,
+    slice_sizes = array<i64: 1, 1, 8, 1, 7, 1, 6, 1>,
     indices_are_sorted = false
   } : (tensor<*xi32>, tensor<1x5x2xi32>) -> tensor<8x?x7x1x6x1x?xi32>
   func.return %res : tensor<8x?x7x1x6x1x?xi32>
@@ -3596,7 +3596,7 @@ func.func @gather(%operand : tensor<2x4x9xi32>, %start_indices : tensor<*xi32>) 
       start_index_map = [0, 1],
       index_vector_dim = 2
     >,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     indices_are_sorted = false
   } : (tensor<2x4x9xi32>, tensor<*xi32>) -> tensor<1x5x8xi32>
   func.return %res : tensor<1x5x8xi32>
@@ -3612,7 +3612,7 @@ func.func @gather(%operand : tensor<*xi32>, %start_indices : tensor<*xi32>) -> t
       start_index_map = [0, 1],
       index_vector_dim = 2
     >,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     indices_are_sorted = false
   } : (tensor<*xi32>, tensor<*xi32>) -> tensor<*xi32>
   func.return %res : tensor<*xi32>
@@ -3630,7 +3630,7 @@ func.func @gather_c1(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x2
       start_index_map = [0, 1],
       index_vector_dim = 2
     >,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     indices_are_sorted = false
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
   func.return %res : tensor<1x5x8xi32>
@@ -3648,7 +3648,7 @@ func.func @gather_c2(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x2
       start_index_map = [0, 1],
       index_vector_dim = -1
     >,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     indices_are_sorted = false
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
   func.return %res : tensor<1x5x8xi32>
@@ -3666,7 +3666,7 @@ func.func @gather_c2(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x2
       start_index_map = [0, 1],
       index_vector_dim = 4
     >,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     indices_are_sorted = false
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
   func.return %res : tensor<1x5x8xi32>
@@ -3684,7 +3684,7 @@ func.func @gather_c3(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x2
       start_index_map = [0],
       index_vector_dim = 2
     >,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     indices_are_sorted = false
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
   func.return %res : tensor<1x5x8xi32>
@@ -3702,7 +3702,7 @@ func.func @gather_c3(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x2
       start_index_map = [0, 1],
       index_vector_dim = 3
     >,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     indices_are_sorted = false
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
   func.return %res : tensor<1x5x8xi32>
@@ -3720,7 +3720,7 @@ func.func @gather_c4(%operand : tensor<16x11xi32>, %start_indices : tensor<5x2xi
       start_index_map = [0, 1],
       index_vector_dim = 1
     >,
-    slice_sizes = dense<[8, 6]> : tensor<2xi64>,
+    slice_sizes = array<i64: 8, 6>,
     indices_are_sorted = false
   } : (tensor<16x11xi32>, tensor<5x2xi32>) -> tensor<5x8x6xi32>
   func.return %res : tensor<5x8x6xi32>
@@ -3738,7 +3738,7 @@ func.func @gather_c4(%operand : tensor<16x11xi32>, %start_indices : tensor<5x2xi
       start_index_map = [0, 1],
       index_vector_dim = 1
     >,
-    slice_sizes = dense<[8, 6]> : tensor<2xi64>,
+    slice_sizes = array<i64: 8, 6>,
     indices_are_sorted = false
   } : (tensor<16x11xi32>, tensor<5x2xi32>) -> tensor<5x8x6xi32>
   func.return %res : tensor<5x8x6xi32>
@@ -3756,7 +3756,7 @@ func.func @gather_c5(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x2
       start_index_map = [0, 1],
       index_vector_dim = 2
     >,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     indices_are_sorted = false
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
   func.return %res : tensor<1x5x8xi32>
@@ -3774,7 +3774,7 @@ func.func @gather_c5(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x2
       start_index_map = [0, 1],
       index_vector_dim = 2
     >,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     indices_are_sorted = false
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
   func.return %res : tensor<1x5x8xi32>
@@ -3792,7 +3792,7 @@ func.func @gather_c6(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x2
       start_index_map = [0, 1],
       index_vector_dim = 2
     >,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     indices_are_sorted = false
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
   func.return %res : tensor<1x5x8xi32>
@@ -3810,7 +3810,7 @@ func.func @gather_c6(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x2
       start_index_map = [0, 1],
       index_vector_dim = 2
     >,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     indices_are_sorted = false
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
   func.return %res : tensor<1x5x8xi32>
@@ -3828,7 +3828,7 @@ func.func @gather_c7(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x2
       start_index_map = [0, 1],
       index_vector_dim = 2
     >,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     indices_are_sorted = false
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
   func.return %res : tensor<1x5x8xi32>
@@ -3846,7 +3846,7 @@ func.func @gather_c7(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x2
       start_index_map = [0, 1],
       index_vector_dim = 2
     >,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     indices_are_sorted = false
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
   func.return %res : tensor<1x5x8xi32>
@@ -3864,7 +3864,7 @@ func.func @gather_c8(%operand : tensor<*xi32>, %start_indices : tensor<*xi32>) -
       start_index_map = [0, 1],
       index_vector_dim = 2
     >,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     indices_are_sorted = false
   } : (tensor<*xi32>, tensor<*xi32>) -> tensor<*xi32>
   func.return %res : tensor<*xi32>
@@ -3882,7 +3882,7 @@ func.func @gather_c9(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x2
       start_index_map = [0, 0],
       index_vector_dim = 2
     >,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     indices_are_sorted = false
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
   func.return %res : tensor<1x5x8xi32>
@@ -3900,7 +3900,7 @@ func.func @gather_c10(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x
       start_index_map = [-2, -1],
       index_vector_dim = 2
     >,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     indices_are_sorted = false
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
   func.return %res : tensor<1x5x8xi32>
@@ -3918,7 +3918,7 @@ func.func @gather_c10(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x
       start_index_map = [0, 3],
       index_vector_dim = 2
     >,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     indices_are_sorted = false
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
   func.return %res : tensor<1x5x8xi32>
@@ -3936,7 +3936,7 @@ func.func @gather_c11(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x
       start_index_map = [0, 1],
       index_vector_dim = 2
     >,
-    slice_sizes = dense<[1, 8]> : tensor<2xi64>,
+    slice_sizes = array<i64: 1, 8>,
     indices_are_sorted = false
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
   func.return %res : tensor<1x5x8xi32>
@@ -3954,7 +3954,7 @@ func.func @gather_c11(%operand : tensor<*xi32>, %start_indices : tensor<*xi32>) 
       start_index_map = [0, 1],
       index_vector_dim = 2
     >,
-    slice_sizes = dense<[1, 1, 8, 1, 2, 3]> : tensor<6xi64>,
+    slice_sizes = array<i64: 1, 1, 8, 1, 2, 3>,
     indices_are_sorted = false
   } : (tensor<*xi32>, tensor<*xi32>) -> tensor<*xi32>
   func.return %res : tensor<*xi32>
@@ -3972,7 +3972,7 @@ func.func @gather_c12(%operand : tensor<?x?x2xi32>, %start_indices : tensor<*xi3
       start_index_map = [0, 1],
       index_vector_dim = 2
     >,
-    slice_sizes = dense<[1, 1, -1]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, -1>,
     indices_are_sorted = false
   } : (tensor<?x?x2xi32>, tensor<*xi32>) -> tensor<*xi32>
   func.return %res : tensor<*xi32>
@@ -3990,7 +3990,7 @@ func.func @gather_c12(%operand : tensor<?x?x2xi32>, %start_indices : tensor<*xi3
       start_index_map = [0, 1],
       index_vector_dim = 2
     >,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>,
+    slice_sizes = array<i64: 1, 1, 8>,
     indices_are_sorted = false
   } : (tensor<?x?x2xi32>, tensor<*xi32>) -> tensor<*xi32>
   func.return %res : tensor<*xi32>
@@ -4009,7 +4009,7 @@ func.func @gather_c14(%operand : tensor<2x4x9xi32>, %start_indices : tensor<1x5x
       start_index_map = [0, 1]
     >,
     indices_are_sorted = false,
-    slice_sizes = dense<[1, 1, 8]> : tensor<3xi64>
+    slice_sizes = array<i64: 1, 1, 8>
   } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<3xi32>
   func.return %res : tensor<3xi32>
 }
@@ -4027,7 +4027,7 @@ func.func @gather_c14(%operand : tensor<*xi32>, %start_indices : tensor<?x?x?xi3
       start_index_map = [0, 1]
     >,
     indices_are_sorted = false,
-    slice_sizes = dense<[1, 1, 8, 1, 7, 1, 6, 1]> : tensor<8xi64>
+    slice_sizes = array<i64: 1, 1, 8, 1, 7, 1, 6, 1>
   } : (tensor<*xi32>, tensor<?x?x?xi32>) -> tensor<3xi32>
   func.return %res : tensor<3xi32>
 }
@@ -5792,7 +5792,7 @@ func.func @dynamic_iota_output_shape_mismatching_size() -> tensor<4xf32> {
 
 // CHECK-LABEL: func @broadcast_in_dim_elements
 func.func @broadcast_in_dim_elements(%arg0: tensor<1x2xi32>) -> tensor<1x2x2xi32> {
-  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = dense<[1, 2]> : tensor<2xi64>} : (tensor<1x2xi32>) -> tensor<1x2x2xi32>
+  %0 = "stablehlo.broadcast_in_dim"(%arg0) {broadcast_dimensions = array<i64: 1, 2>} : (tensor<1x2xi32>) -> tensor<1x2x2xi32>
   func.return %0 : tensor<1x2x2xi32>
 }
 
@@ -5812,7 +5812,7 @@ func.func @broadcast_in_dim_dense_array(%arg0: tensor<1x2xi32>) -> tensor<1x2x2x
 // CHECK: reverse = [true, false]
 func.func @convolution_elements(%arg0: tensor<1x8x8x207xf32>, %arg1: tensor<3x3x207x16xf32>) -> tensor<1x6x6x16xf32> {
   %0 = "stablehlo.convolution"(%arg0, %arg1) {
-    window_reversal = dense<[true, false]> : tensor<2xi1>,
+    window_reversal = array<i1: true, false>,
     dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f]>,
     feature_group_count = 1 : i64,
     batch_group_count = 1 : i64

--- a/stablehlo/tests/ops_stablehlo_roundtrip.mlir
+++ b/stablehlo/tests/ops_stablehlo_roundtrip.mlir
@@ -210,10 +210,10 @@ func.func @test_convolution(%arg0 : tensor<100x26x26x32xf32>, %arg1 : tensor<3x3
       output_spatial_dimensions = [1, 2]
     >,
     feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
+    lhs_dilation = array<i64: 1, 1>,
     padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
+    rhs_dilation = array<i64: 1, 1>,
+    window_strides = array<i64: 1, 1>
   } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) -> tensor<100x28x28x1xf32>
   func.return %result : tensor<100x28x28x1xf32>
 }
@@ -234,10 +234,10 @@ func.func @test_convolution2(%arg0 : tensor<100x26x26x32xi8>, %arg1 : tensor<3x3
       output_spatial_dimensions = [1, 2]
     >,
     feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
+    lhs_dilation = array<i64: 1, 1>,
     padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
+    rhs_dilation = array<i64: 1, 1>,
+    window_strides = array<i64: 1, 1>
   } : (tensor<100x26x26x32xi8>, tensor<3x3x1x32xi8>) -> tensor<100x28x28x1xi32>
   func.return %result : tensor<100x28x28x1xi32>
 }
@@ -258,11 +258,11 @@ func.func @test_convolution3(%arg0 : tensor<100x26x26x32xi8>, %arg1 : tensor<3x3
       output_spatial_dimensions = [1, 2]
     >,
     feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
+    lhs_dilation = array<i64: 1, 1>,
     padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>,
-    window_reversal = dense<true> : tensor<2xi1>
+    rhs_dilation = array<i64: 1, 1>,
+    window_strides = array<i64: 1, 1>,
+    window_reversal = array<i1: true, true>
   } : (tensor<100x26x26x32xi8>, tensor<3x3x1x32xi8>) -> tensor<100x28x28x1xi32>
   func.return %result : tensor<100x28x28x1xi32>
 }
@@ -370,7 +370,7 @@ func.func @test_gather(%arg0: tensor<200x100x300xf32>, %arg1: tensor<10x2xi32>) 
       start_index_map = [0,1],
     >,
     indices_are_sorted = true,
-    slice_sizes = dense<[1, 1, 300]> : tensor<3xi64>
+    slice_sizes = array<i64: 1, 1, 300>
   } : (tensor<200x100x300xf32>, tensor<10x2xi32>) -> tensor<10x300xf32>
   func.return %0 : tensor<10x300xf32>
 }
@@ -415,7 +415,7 @@ func.func @test_map(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32>
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
     %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {dimensions = dense<0> : tensor<1xi64>} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+  }) {dimensions = array<i64: 0>} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }
 
@@ -423,7 +423,7 @@ func.func @test_map2(%arg0: tensor<4xf32>, %arg1: tensor<4xi32>) -> tensor<4xf32
   %0 = "stablehlo.map"(%arg0, %arg1) ({
     ^bb0(%arg2: tensor<f32>, %arg3: tensor<i32>):
     "stablehlo.return"(%arg2) : (tensor<f32>) -> ()
-  }) {dimensions = dense<0> : tensor<1xi64>} : (tensor<4xf32>, tensor<4xi32>) -> tensor<4xf32>
+  }) {dimensions = array<i64: 0>} : (tensor<4xf32>, tensor<4xi32>) -> tensor<4xf32>
   func.return %0 : tensor<4xf32>
 }
 
@@ -493,7 +493,7 @@ func.func @test_reduce(%arg0 : tensor<1x10xf32>, %arg1 : tensor<1x10xi32>, %arg2
       %fmax = "stablehlo.maximum"(%fa, %fb) {} : (tensor<f32>, tensor<f32>) -> tensor<f32>
       %imax = "stablehlo.maximum"(%ia, %ib) {} : (tensor<i32>, tensor<i32>) -> tensor<i32>
       "stablehlo.return"(%fmax, %imax) : (tensor<f32>, tensor<i32>) -> ()
-    }) {dimensions = dense<1> : tensor<1xi64>} : (tensor<1x10xf32>, tensor<1x10xi32>, tensor<f32>, tensor<i32>) -> (tensor<1xf32>, tensor<1xi32>)
+  }) {dimensions = array<i64: 1>} : (tensor<1x10xf32>, tensor<1x10xi32>, tensor<f32>, tensor<i32>) -> (tensor<1xf32>, tensor<1xi32>)
   func.return %result0, %result1 : tensor<1xf32>, tensor<1xi32>
 }
 
@@ -545,11 +545,11 @@ func.func @test_reduce_window(%arg0: tensor<2x17x31x7xi32>) -> tensor<2x5x8x7xi3
     %2 = stablehlo.maximum %arg1, %arg2 : tensor<i32>
     "stablehlo.return"(%2) : (tensor<i32>) -> ()
   }) {
-    window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-    window_strides = dense<[1, 4, 4, 1]> : tensor<4xi64>,
+    window_dimensions = array<i64: 1, 2, 2, 1>,
+    window_strides = array<i64: 1, 4, 4, 1>,
     padding = dense<[[0, 0], [2, 0], [0, 2], [0, 0]]> : tensor<4x2xi64>,
-    base_dilations = dense<[1, 1, 1, 1]> : tensor<4xi64>,
-    window_dilations = dense<[1, 2, 2, 1]> : tensor<4xi64>
+    base_dilations = array<i64: 1, 1, 1, 1>,
+    window_dilations = array<i64: 1, 2, 2, 1>
   } : (tensor<2x17x31x7xi32>, tensor<i32>) -> tensor<2x5x8x7xi32>
   func.return %1 : tensor<2x5x8x7xi32>
 }
@@ -562,8 +562,8 @@ func.func @test_reduce_window2(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>, %
               "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64> } : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) -> (tensor<2x2xf32>, tensor<2x2xi32>)
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1> } : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) -> (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
 }
 
@@ -643,8 +643,8 @@ func.func @test_select_and_scatter(%arg0: tensor<10x24x24x64xf32>, %arg1: tensor
     %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
     "stablehlo.return"(%2) : (tensor<f32>) -> ()
   }) {
-    window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-    window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>
+    window_dimensions = array<i64: 1, 2, 2, 1>,
+    window_strides = array<i64: 1, 2, 2, 1>
   } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) -> tensor<10x24x24x64xf32>
   func.return %1 : tensor<10x24x24x64xf32>
 }

--- a/stablehlo/tests/print_reduce.mlir
+++ b/stablehlo/tests/print_reduce.mlir
@@ -20,7 +20,7 @@ func.func @reduce_one_op_all_locs_same(%arg0: tensor<?x?xf32>, %arg1 : tensor<f3
   ^bb0(%arg2: tensor<f32> loc("foo"), %arg3: tensor<f32> loc("foo")):
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<f32>, tensor<f32>) -> tensor<f32> loc("foo")
     "stablehlo.return"(%1) : (tensor<f32>) -> () loc("foo")
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32> loc("foo")
+  }) {dimensions = array<i64: 1>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32> loc("foo")
 
   func.return %0: tensor<?xf32>
 }
@@ -36,7 +36,7 @@ func.func @reduce_one_op_all_locs_not_same_1(%arg0: tensor<?x?xf32>, %arg1 : ten
   ^bb0(%arg2: tensor<f32> loc("foo"), %arg3: tensor<f32> loc("foo")):
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<f32>, tensor<f32>) -> tensor<f32> loc("foo")
     "stablehlo.return"(%1) : (tensor<f32>) -> () loc("foo")
-  }) {dimensions = dense<[1]> : tensor<1xi64>, foo = "bar"} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32> loc("not_foo")
+  }) {dimensions = array<i64: 1>, foo = "bar"} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32> loc("not_foo")
 
   func.return %0: tensor<?xf32>
 }
@@ -52,7 +52,7 @@ func.func @reduce_one_op_all_locs_not_same_2(%arg0: tensor<?x?xf32>, %arg1 : ten
   ^bb0(%arg2: tensor<f32> loc("foo"), %arg3: tensor<f32> loc("not_foo")):
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<f32>, tensor<f32>) -> tensor<f32> loc("foo")
     "stablehlo.return"(%1) : (tensor<f32>) -> () loc("foo")
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32> loc("foo")
+  }) {dimensions = array<i64: 1>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32> loc("foo")
 
   func.return %0: tensor<?xf32>
 }
@@ -70,7 +70,7 @@ func.func @reduce_one_op_more_than_two_block_args(%arg0: tensor<?x?xf32>, %arg1:
   ^bb0(%arg4: tensor<f32> loc("foo"), %arg5: tensor<f32> loc("foo"), %arg6: tensor<f32> loc("foo"), %arg7: tensor<f32> loc("foo")):
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<f32>, tensor<f32>) -> tensor<f32> loc("foo")
     "stablehlo.return"(%1, %1) : (tensor<f32>, tensor<f32>) -> () loc("foo")
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<?x?xf32>, tensor<f32>, tensor<f32>) -> (tensor<?xf32>, tensor<?xf32>)  loc("foo")
+  }) {dimensions = array<i64: 1>} : (tensor<?x?xf32>, tensor<?x?xf32>, tensor<f32>, tensor<f32>) -> (tensor<?xf32>, tensor<?xf32>)  loc("foo")
 
   func.return %0#0: tensor<?xf32>
 }
@@ -86,7 +86,7 @@ func.func @reduce_non_commutative_inner_op(%arg0: tensor<?x?xf32>, %arg1: tensor
   ^bb0(%arg2: tensor<f32> loc("foo"), %arg3: tensor<f32> loc("foo")):
     %1 = "stablehlo.divide"(%arg2, %arg3) : (tensor<f32>, tensor<f32>) -> tensor<f32> loc("foo")
     "stablehlo.return"(%1) : (tensor<f32>) -> () loc("foo")
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32> loc("foo")
+    }) {dimensions = array<i64: 1>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32> loc("foo")
 
   func.return %0: tensor<?xf32>
 }
@@ -102,7 +102,7 @@ func.func @reduce_non_binary_inner_op(%arg0: tensor<?x?xf32>, %arg1: tensor<f32>
   ^bb0(%arg2: tensor<f32> loc("foo"), %arg3: tensor<f32> loc("foo")):
     %1 = "stablehlo.reshape"(%arg2) : (tensor<f32>) -> tensor<f32> loc("foo")
     "stablehlo.return"(%1) : (tensor<f32>) -> () loc("foo")
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32> loc("foo")
+    }) {dimensions = array<i64: 1>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32> loc("foo")
 
   func.return %0: tensor<?xf32>
 }
@@ -120,7 +120,7 @@ func.func @reduce_more_than_one_inner_op(%arg0: tensor<1x8xf32>, %arg1: tensor<1
     %1 = stablehlo.add %arg4, %arg6 : tensor<f32> loc("foo")
     %2 = stablehlo.add %arg5, %arg7 : tensor<i32> loc("foo")
     "stablehlo.return"(%1, %2) : (tensor<f32>, tensor<i32>) -> () loc("foo")
-  }) {dimensions = dense<0> : tensor<1xi64>}
+  }) {dimensions = array<i64: 0>}
     : (tensor<1x8xf32>, tensor<1x8xi32>, tensor<f32>, tensor<i32>) -> (tensor<8xf32>, tensor<8xi32>) loc("foo")
 
   func.return %0#0, %0#1 : tensor<8xf32>, tensor<8xi32>
@@ -136,7 +136,7 @@ func.func @reduce_complex_type(%arg0: tensor<1x2xcomplex<f32>>, %arg1 : tensor<c
   ^bb0(%arg2: tensor<complex<f32>> loc("foo"), %arg3: tensor<complex<f32>> loc("foo")):
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<complex<f32>>, tensor<complex<f32>>) -> tensor<complex<f32>> loc("foo")
     "stablehlo.return"(%1) : (tensor<complex<f32>>) -> () loc("foo")
-  }) {dimensions = dense<1> : tensor<1xi64>} : (tensor<1x2xcomplex<f32>>, tensor<complex<f32>>) -> tensor<1xcomplex<f32>> loc("foo")
+  }) {dimensions = array<i64: 1>} : (tensor<1x2xcomplex<f32>>, tensor<complex<f32>>) -> tensor<1xcomplex<f32>> loc("foo")
 
   func.return %0: tensor<1xcomplex<f32>>
 }
@@ -158,7 +158,7 @@ func.func @reduce_innerop_type_not_trivially_derived(%arg0: tensor<4x4xf32>, %ar
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
     "stablehlo.return"(%1) : (tensor<4xf32>) -> ()
 
-  }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<4x4xf32>, tensor<4xf32>) -> tensor<4xf32>
+  }) {dimensions = array<i64: 0>} : (tensor<4x4xf32>, tensor<4xf32>) -> tensor<4xf32>
 
   func.return %0: tensor<4xf32>
 }

--- a/stablehlo/tests/stablehlo_canonicalize_dynamism.mlir
+++ b/stablehlo/tests/stablehlo_canonicalize_dynamism.mlir
@@ -214,9 +214,9 @@ func.func @dynamic_conv_success_static_result_type(%arg0: tensor<100x26x26x32xf3
   %0 = stablehlo.constant dense<2> : tensor<2x2xi32>
   %1 = "stablehlo.dynamic_conv"(%arg0, %arg1, %0) {
     dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, o, i]->[b, 0, 1, f]>,
-    window_strides = dense<1> : tensor<2xi64>,
-    lhs_dilation = dense<1> : tensor<2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = array<i64: 1, 1>,
+    lhs_dilation = array<i64: 1, 1>,
+    rhs_dilation = array<i64: 1, 1>,
     feature_group_count = 1 : i64,
     batch_group_count = 1 : i64
   } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>, tensor<2x2xi32>) -> tensor<100x28x28x1xf32>
@@ -242,9 +242,9 @@ func.func @dynamic_conv_success_dynamic_result_type(%arg0: tensor<100x26x26x32xf
   %0 = stablehlo.constant dense<2> : tensor<2x2xi32>
   %1 = "stablehlo.dynamic_conv"(%arg0, %arg1, %0) {
     dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, o, i]->[b, 0, 1, f]>,
-    window_strides = dense<1> : tensor<2xi64>,
-    lhs_dilation = dense<1> : tensor<2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = array<i64: 1, 1>,
+    lhs_dilation = array<i64: 1, 1>,
+    rhs_dilation = array<i64: 1, 1>,
     feature_group_count = 1 : i64,
     batch_group_count = 1 : i64
   } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>, tensor<2x2xi32>) -> tensor<?x28x28x1xf32>
@@ -258,9 +258,9 @@ func.func @dynamic_conv_inapplicable_dynamic_padding(%arg0: tensor<100x26x26x32x
   // CHECK: stablehlo.dynamic_conv
   %0 = "stablehlo.dynamic_conv"(%arg0, %arg1, %arg2) {
     dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, o, i]->[b, 0, 1, f]>,
-    window_strides = dense<1> : tensor<2xi64>,
-    lhs_dilation = dense<1> : tensor<2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
+    window_strides = array<i64: 1, 1>,
+    lhs_dilation = array<i64: 1, 1>,
+    rhs_dilation = array<i64: 1, 1>,
     feature_group_count = 1 : i64,
     batch_group_count = 1 : i64
   } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>, tensor<2x2xi32>) -> tensor<100x28x28x1xf32>

--- a/stablehlo/tests/stablehlo_refine_shapes.mlir
+++ b/stablehlo/tests/stablehlo_refine_shapes.mlir
@@ -569,9 +569,9 @@ func.func @refine_dynamic_conv(%arg0 : tensor<100x26x26x32xf32>, %arg1 : tensor<
   %0 = stablehlo.constant dense<[[2, 2], [2, 2]]> : tensor<2x2xi32>
   %1 = "stablehlo.dynamic_conv"(%arg0, %arg1, %0) {
     dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, o, i]->[b, 0, 1, f]>,
-    window_strides = dense<[1, 1]> : tensor<2xi64>,
-    lhs_dilation = dense<[1, 1]> : tensor<2xi64>,
-    rhs_dilation = dense<[1, 1]> : tensor<2xi64>,
+    window_strides = array<i64: 1, 1>,
+    lhs_dilation = array<i64: 1, 1>,
+    rhs_dilation = array<i64: 1, 1>,
     feature_group_count = 1 : i64,
     batch_group_count = 1 : i64
   } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>, tensor<2x2xi32>) -> tensor<*xf32>

--- a/stablehlo/tests/verify_conv.mlir
+++ b/stablehlo/tests/verify_conv.mlir
@@ -19,10 +19,10 @@ func.func @main(%arg0 : tensor<100x26x26x32xf32>, %arg1 : tensor<3x3x1x32xf32>) 
       output_spatial_dimensions = [1, 2]
     >,
     feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
+    lhs_dilation = array<i64: 1, 1>,
     padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
+    rhs_dilation = array<i64: 1, 1>,
+    window_strides = array<i64: 1, 1>
   } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
     tensor<100x28x28x1xf32>
   func.return %result : tensor<100x28x28x1xf32>
@@ -49,10 +49,10 @@ func.func @convolution_upcast(%arg0 : tensor<100x26x26x32xi8>,
       output_spatial_dimensions = [1, 2]
     >,
     feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
+    lhs_dilation = array<i64: 1, 1>,
     padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
+    rhs_dilation = array<i64: 1, 1>,
+    window_strides = array<i64: 1, 1>
   } : (tensor<100x26x26x32xi8>, tensor<3x3x1x32xi8>) -> tensor<100x28x28x1xi32>
   func.return %result : tensor<100x28x28x1xi32>
 }
@@ -209,10 +209,10 @@ func.func @invalid_conv_dimensions(%arg0 : tensor<100x26x26x32xf32>,
       output_spatial_dimensions = [1, 2]
     >,
     feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
+    lhs_dilation = array<i64: 1, 1>,
     padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
+    rhs_dilation = array<i64: 1, 1>,
+    window_strides = array<i64: 1, 1>
   } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
     tensor<100x28x28x1xf32>
   func.return %result : tensor<100x28x28x1xf32>
@@ -237,10 +237,10 @@ func.func @invalid_conv_dimensions(%arg0 : tensor<100x26x26x32xf32>,
       output_spatial_dimensions = [1, 2]
     >,
     feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
+    lhs_dilation = array<i64: 1, 1>,
     padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
+    rhs_dilation = array<i64: 1, 1>,
+    window_strides = array<i64: 1, 1>
   } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
     tensor<100x28x28x1xf32>
   func.return %result : tensor<100x28x28x1xf32>
@@ -265,10 +265,10 @@ func.func @invalid_conv_dimensions(%arg0 : tensor<100x26x26x32xf32>,
       output_spatial_dimensions = [0, 3]
     >,
     feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
+    lhs_dilation = array<i64: 1, 1>,
     padding = dense<2> : tensor<2x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
+    rhs_dilation = array<i64: 1, 1>,
+    window_strides = array<i64: 1, 1>
   } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
     tensor<100x28x28x1xf32>
   func.return %result : tensor<100x28x28x1xf32>
@@ -541,10 +541,10 @@ func.func @invalid_conv_dimensions(%arg0 : tensor<100x26x26x32xf32>, %arg1 : ten
       output_spatial_dimensions = [1, 2]
     >,
     feature_group_count = 1 : i64,
-    lhs_dilation = dense<1> : tensor<2xi64>,
+    lhs_dilation = array<i64: 1, 1>,
     padding = dense<2> : tensor<3x2xi64>,
-    rhs_dilation = dense<1> : tensor<2xi64>,
-    window_strides = dense<1> : tensor<2xi64>
+    rhs_dilation = array<i64: 1, 1>,
+    window_strides = array<i64: 1, 1>
   } : (tensor<100x26x26x32xf32>, tensor<3x3x1x32xf32>) ->
     tensor<100x28x28x1xf32>
   func.return %result : tensor<100x28x28x1xf32>
@@ -820,7 +820,7 @@ func.func @conv2d_generic(%arg0: tensor<1x8x8x32x207xf32>, %arg1: tensor<3x3x32x
       output_batch_dimension = 1,
       output_feature_dimension = 4,
       output_spatial_dimensions = [2, 3]
-    >, feature_group_count = 1 : i64, lhs_dilation = dense<1> : tensor<2xi64>, padding = dense<1> : tensor<2x2xi64>, precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>], rhs_dilation = dense<1> : tensor<2xi64>, window_strides = dense<1> : tensor<2xi64>} :
+      >, feature_group_count = 1 : i64, lhs_dilation = array<i64: 1, 1>, padding = dense<1> : tensor<2x2xi64>, precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>], rhs_dilation = array<i64: 1, 1>, window_strides = array<i64: 1, 1>} :
        (tensor<1x8x8x32x207xf32>, tensor<3x3x32x207x16xf32>) -> tensor<32x1x8x8x16xf32>
   func.return %0 : tensor<32x1x8x8x16xf32>
 }

--- a/stablehlo/tests/verify_reduce.mlir
+++ b/stablehlo/tests/verify_reduce.mlir
@@ -11,7 +11,7 @@ func.func @reduce(%arg0: tensor<4x4xf32>, %arg1 : tensor<4xf32>)
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
     "stablehlo.return"(%1) : (tensor<4xf32>) -> ()
 
-  }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<4x4xf32>, tensor<4xf32>) -> tensor<4xf32>
+  }) {dimensions = array<i64: 0>} : (tensor<4x4xf32>, tensor<4xf32>) -> tensor<4xf32>
 
   func.return %0: tensor<4xf32>
 }
@@ -26,7 +26,7 @@ func.func @reduce_complex_type(%arg0: tensor<1x2xcomplex<f32>>, %arg1 : tensor<c
   ^bb0(%arg2: tensor<complex<f32>> loc("foo"), %arg3: tensor<complex<f32>> loc("foo")):
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<complex<f32>>, tensor<complex<f32>>) -> tensor<complex<f32>> loc("foo")
     "stablehlo.return"(%1) : (tensor<complex<f32>>) -> () loc("foo")
-  }) {dimensions = dense<1> : tensor<1xi64>} : (tensor<1x2xcomplex<f32>>, tensor<complex<f32>>) -> tensor<1xcomplex<f32>> loc("foo")
+  }) {dimensions = array<i64: 1>} : (tensor<1x2xcomplex<f32>>, tensor<complex<f32>>) -> tensor<1xcomplex<f32>> loc("foo")
 
   func.return %0: tensor<1xcomplex<f32>>
 }
@@ -54,7 +54,7 @@ func.func @reduce_unranked(%arg0: tensor<4x4xf32>, %arg1: tensor<4x4xf32>,
     %2 = "stablehlo.add"(%arg5, %arg7) : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
     "stablehlo.return"(%1, %2) : (tensor<*xf32>, tensor<*xf32>) -> ()
 
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<4x4xf32>, tensor<4x4xf32>, tensor<*xf32>, tensor<*xf32>) -> (tensor<*xf32>, tensor<*xf32>)
+  }) {dimensions = array<i64: 1>} : (tensor<4x4xf32>, tensor<4x4xf32>, tensor<*xf32>, tensor<*xf32>) -> (tensor<*xf32>, tensor<*xf32>)
 
   func.return %0#0, %0#1 : tensor<*xf32>, tensor<*xf32>
 }
@@ -72,7 +72,7 @@ func.func @reduce_verify_dynamic_operand(%arg0: tensor<8x?xf32>, %arg1 : tensor<
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
     "stablehlo.return"(%1) : (tensor<4xf32>) -> ()
 
-  }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<8x?xf32>, tensor<4xf32>) -> tensor<?xf32>
+  }) {dimensions = array<i64: 0>} : (tensor<8x?xf32>, tensor<4xf32>) -> tensor<?xf32>
 
   func.return %0: tensor<?xf32>
 }
@@ -89,7 +89,7 @@ func.func @reduce_mix_rank_and_unranked(%arg0: tensor<4x4xf32>, %arg1: tensor<*x
     %2 = "stablehlo.add"(%arg5, %arg7) : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
     "stablehlo.return"(%1, %2) : (tensor<4xf32>, tensor<*xf32>) -> ()
 
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<4x4xf32>, tensor<*xf32>, tensor<4xf32>, tensor<*xf32>) -> (tensor<4xf32>, tensor<*xf32>)
+  }) {dimensions = array<i64: 1>} : (tensor<4x4xf32>, tensor<*xf32>, tensor<4xf32>, tensor<*xf32>) -> (tensor<4xf32>, tensor<*xf32>)
 
   func.return %0#0, %0#1 : tensor<4xf32>, tensor<*xf32>
 }
@@ -105,7 +105,7 @@ func.func @reduce_with_promotable_types(%arg0: tensor<4x4xf32>, %arg1 : tensor<f
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<f64>, tensor<f64>) -> tensor<f64>
     "stablehlo.return"(%1) : (tensor<f64>) -> ()
 
-  }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<4x4xf32>, tensor<f32>) -> tensor<4xf64>
+  }) {dimensions = array<i64: 0>} : (tensor<4x4xf32>, tensor<f32>) -> tensor<4xf64>
 
   func.return %0: tensor<4xf64>
 }
@@ -136,7 +136,7 @@ func.func @reduce_c1(%arg0: tensor<2x3xf32>, %arg1: tensor<3x2xf32>,
     %2 = "stablehlo.add"(%arg5, %arg7) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%1, %2) : (tensor<f32>, tensor<f32>) -> ()
 
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<2x3xf32>, tensor<3x2xf32>, tensor<f32>, tensor<f32>) -> (tensor<2xf32>, tensor<2xf32>)
+  }) {dimensions = array<i64: 1>} : (tensor<2x3xf32>, tensor<3x2xf32>, tensor<f32>, tensor<f32>) -> (tensor<2xf32>, tensor<2xf32>)
 
   func.return %0#0, %0#1 : tensor<2xf32>, tensor<2xf32>
 }
@@ -154,7 +154,7 @@ func.func @reduce_c1(%arg0: tensor<?x?xf32>, %arg1: tensor<?xf32>,
     %2 = "stablehlo.add"(%arg5, %arg7) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%1, %2) : (tensor<f32>, tensor<f32>) -> ()
 
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<?xf32>, tensor<f32>, tensor<f32>) -> (tensor<?xf32>, tensor<?xf32>)
+  }) {dimensions = array<i64: 1>} : (tensor<?x?xf32>, tensor<?xf32>, tensor<f32>, tensor<f32>) -> (tensor<?xf32>, tensor<?xf32>)
 
   func.return %0#0, %0#1 : tensor<?xf32>, tensor<?xf32>
 }
@@ -172,7 +172,7 @@ func.func @reduce_c2(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32>,
     %2 = "stablehlo.add"(%arg5, %arg7) : (tensor<i32>, tensor<i32>) -> tensor<i32>
     "stablehlo.return"(%2, %1) : (tensor<i32>, tensor<f32>) -> ()
 
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<f32>, tensor<i32>) -> (tensor<?xf32>, tensor<?xi32>)
+  }) {dimensions = array<i64: 1>} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<f32>, tensor<i32>) -> (tensor<?xf32>, tensor<?xi32>)
 
   func.return %0#0, %0#1 : tensor<?xf32>, tensor<?xi32>
 }
@@ -190,7 +190,7 @@ func.func @reduce_c2(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32>,
     %2 = "stablehlo.maximum"(%arg4, %arg6) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%1, %2) : (tensor<f32>, tensor<f32>) -> ()
 
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<f32>, tensor<f32>) -> (tensor<?xf32>, tensor<?xi32>)
+  }) {dimensions = array<i64: 1>} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<f32>, tensor<f32>) -> (tensor<?xf32>, tensor<?xi32>)
 
   func.return %0#0, %0#1 : tensor<?xf32>, tensor<?xi32>
 }
@@ -206,7 +206,7 @@ func.func @reduce_c4(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
   ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32> ):
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {dimensions = dense<[-1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32>
+  }) {dimensions = array<i64: -1>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32>
 
   func.return %0: tensor<?xf32>
 }
@@ -222,7 +222,7 @@ func.func @reduce_c4(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
   ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32> ):
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
-  }) {dimensions = dense<[2]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32>
+  }) {dimensions = array<i64: 2>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32>
 
   func.return %0: tensor<?xf32>
 }
@@ -237,7 +237,7 @@ func.func @reduce_c4(%arg0: tensor<*xf32>, %arg1 : tensor<*xf32>)
   ^bb0(%arg2: tensor<*xf32>, %arg3: tensor<*xf32> ):
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
     "stablehlo.return"(%1) : (tensor<*xf32>) -> ()
-  }) {dimensions = dense<[-1]> : tensor<1xi64>} : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
+  }) {dimensions = array<i64: -1>} : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
   func.return %0: tensor<*xf32>
 }
 
@@ -253,7 +253,7 @@ func.func @reduce_c5(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
 
-  }) {dimensions = dense<[1,1]> : tensor<2xi64>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32>
+  }) {dimensions = array<i64: 1, 1>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<?xf32>
 
   func.return %0: tensor<?xf32>
 }
@@ -273,7 +273,7 @@ func.func @reduce_c6(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>,
     %2 = "stablehlo.add"(%arg5, %arg7) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%arg5, %arg7) : (tensor<f32>, tensor<f32>) -> ()
 
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<?x?xf32>, tensor<f32>) -> (tensor<?xf32>, tensor<?xf32>)
+  }) {dimensions = array<i64: 1>} : (tensor<?x?xf32>, tensor<?x?xf32>, tensor<f32>) -> (tensor<?xf32>, tensor<?xf32>)
 
   func.return %0#0, %0#1 : tensor<?xf32>, tensor<?xf32>
 }
@@ -290,7 +290,7 @@ func.func @reduce_c6(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"() : () -> ()
 
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<f32>
+  }) {dimensions = array<i64: 1>} : (tensor<?x?xf32>, tensor<f32>) -> tensor<f32>
 
     func.return %0: tensor<f32>
 }
@@ -307,7 +307,7 @@ func.func @reduce_c6(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>,
     %1 = "stablehlo.add"(%arg4, %arg6) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%1) : (tensor<f32>) -> ()
 
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<?x?xf32>, tensor<f32>, tensor<f32>) -> (tensor<?xf32>, tensor<?xf32>)
+  }) {dimensions = array<i64: 1>} : (tensor<?x?xf32>, tensor<?x?xf32>, tensor<f32>, tensor<f32>) -> (tensor<?xf32>, tensor<?xf32>)
 
   func.return %0#0, %0#1 : tensor<?xf32>, tensor<?xf32>
 }
@@ -326,7 +326,7 @@ func.func @reduce_c6(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32>,
     %3 = "stablehlo.tuple"(%1, %2) : (tensor<f32>, tensor<i32>) -> tuple<tensor<f32>, tensor<i32>>
     "stablehlo.return"(%3, %1) : (tuple<tensor<f32>, tensor<i32>>, tensor<f32>) -> ()
 
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<f32>, tensor<i32>) -> (tensor<?xf32>, tensor<?xi32>)
+  }) {dimensions = array<i64: 1>} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<f32>, tensor<i32>) -> (tensor<?xf32>, tensor<?xi32>)
 
   func.return %0#0, %0#1 : tensor<?xf32>, tensor<?xi32>
 }
@@ -344,7 +344,7 @@ func.func @reduce_c6(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32>,
     %2 = "stablehlo.add"(%arg5, %arg7) : (tensor<i32>, tensor<i32>) -> tensor<i32>
     "stablehlo.return"(%1, %2) : (tensor<i32>, tensor<i32>) -> ()
 
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<f32>, tensor<i32>) -> (tensor<?xf32>, tensor<?xi32>)
+  }) {dimensions = array<i64: 1>} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<f32>, tensor<i32>) -> (tensor<?xf32>, tensor<?xi32>)
 
   func.return %0#0, %0#1 : tensor<?xf32>, tensor<?xi32>
 }
@@ -362,7 +362,7 @@ func.func @reduce_c6(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32>,
     %2 = "stablehlo.add"(%arg5, %arg7) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%1, %2) : (tensor<f32>, tensor<f32>) -> ()
 
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<f32>, tensor<i32>) -> (tensor<?xf32>, tensor<?xi32>)
+  }) {dimensions = array<i64: 1>} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<f32>, tensor<i32>) -> (tensor<?xf32>, tensor<?xi32>)
 
   func.return %0#0, %0#1 : tensor<?xf32>, tensor<?xi32>
 }
@@ -380,7 +380,7 @@ func.func @reduce_c6(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32>,
     %2 = "stablehlo.maximum"(%arg4, %arg6) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     "stablehlo.return"(%1, %2) : (tensor<f32>, tensor<f32>) -> ()
 
-  }) {dimensions = dense<[1]> : tensor<1xi64>} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<f32>, tensor<f32>) -> (tensor<?xf32>, tensor<?xf32>)
+  }) {dimensions = array<i64: 1>} : (tensor<?x?xf32>, tensor<?x?xi32>, tensor<f32>, tensor<f32>) -> (tensor<?xf32>, tensor<?xf32>)
 
   func.return %0#0, %0#1 : tensor<?xf32>, tensor<?xf32>
 }
@@ -397,7 +397,7 @@ func.func @reduce_c6(%arg0: tensor<?xf32>, %arg1 : tensor<?xf32>)
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
     "stablehlo.return"(%1) : (tensor<?xf32>) -> ()
 
-  }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<?xf32>, tensor<?xf32>) -> tensor<f32>
+  }) {dimensions = array<i64: 0>} : (tensor<?xf32>, tensor<?xf32>) -> tensor<f32>
 
   func.return %0: tensor<f32>
 }
@@ -414,7 +414,7 @@ func.func @reduce_c6(%arg0: tensor<8x5xf32>, %arg1 : tensor<4xf32>)
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
     "stablehlo.return"(%1) : (tensor<4xf32>) -> ()
 
-  }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<8x5xf32>, tensor<4xf32>) -> tensor<5xf32>
+  }) {dimensions = array<i64: 0>} : (tensor<8x5xf32>, tensor<4xf32>) -> tensor<5xf32>
 
   func.return %0: tensor<5xf32>
 }
@@ -432,7 +432,7 @@ func.func @reduce_c6(%arg0: tensor<4x4xi32>, %arg1 : tensor<i32>)
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<i8>, tensor<i8>) -> tensor<i8>
     "stablehlo.return"(%1) : (tensor<i8>) -> ()
 
-  }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<4x4xi32>, tensor<i32>) -> tensor<4xi8>
+  }) {dimensions = array<i64: 0>} : (tensor<4x4xi32>, tensor<i32>) -> tensor<4xi8>
 
   func.return %0: tensor<4xi8>
 }
@@ -449,7 +449,7 @@ func.func @reduce_c6(%arg0: tensor<4x4xi32>, %arg1 : tensor<i8>)
     %1 = "stablehlo.add"(%arg2, %arg3) : (tensor<i8>, tensor<i8>) -> tensor<i8>
     "stablehlo.return"(%1) : (tensor<i8>) -> ()
 
-  }) {dimensions = dense<[0]> : tensor<1xi64>} : (tensor<4x4xi32>, tensor<i8>) -> tensor<4xi8>
+  }) {dimensions = array<i64: 0>} : (tensor<4x4xi32>, tensor<i8>) -> tensor<4xi8>
 
   func.return %0: tensor<4xi8>
 }

--- a/stablehlo/tests/verify_reduce_window.mlir
+++ b/stablehlo/tests/verify_reduce_window.mlir
@@ -12,8 +12,8 @@ func.func @reduce_window(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>,
               "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1>}
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
@@ -31,8 +31,8 @@ func.func @reduce_window_with_non_scalar_block_arg1(%arg0: tensor<4x2xf32>,
             })
          {
            padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[4, 2]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64>
+           window_dimensions = array<i64: 4, 2>,
+           window_strides = array<i64: 3, 1>
          }
          : (tensor<4x2xf32>, tensor<4xf32>) -> (tensor<2x1xf32>)
   func.return %0 : tensor<2x1xf32>
@@ -50,8 +50,8 @@ func.func @reduce_window_with_non_scalar_block_arg2(%arg0: tensor<4x2xf32>,
             })
          {
            padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[4, 2]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64>
+           window_dimensions = array<i64: 4, 2>,
+           window_strides = array<i64: 3, 1>
          }
          : (tensor<4x2xf32>, tensor<2xf32>) -> (tensor<2x1xf32>)
   func.return %0 : tensor<2x1xf32>
@@ -71,10 +71,10 @@ func.func @reduce_window_with_unranked_dynamic_dims(%arg0: tensor<*xf32>,
               "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64>,
-           base_dilations = dense<[1, 1]> : tensor<2xi64>,
-           window_dilations = dense<[1, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1>,
+           base_dilations = array<i64: 1, 1>,
+           window_dilations = array<i64: 1, 1> }
          : (tensor<*xf32>, tensor<4x?xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<?x?xf32>, tensor<*xi32>)
   func.return %0#0, %0#1 : tensor<?x?xf32>, tensor<*xi32>
@@ -94,8 +94,8 @@ func.func @reduce_window_with_promotable_types(%arg0: tensor<4x2xf32>,
               "stablehlo.return"(%2,%3) : (tensor<f64>, tensor<f32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1>}
          : (tensor<4x2xf32>, tensor<4x2xf32>, tensor<f32>, tensor<f32>) ->
               (tensor<2x2xf64>, tensor<2x2xf32>)
   func.return %0#0, %0#1 : tensor<2x2xf64>, tensor<2x2xf32>
@@ -113,8 +113,8 @@ func.func @reduce_window_with_promotable_quantized_types(%arg0: tensor<4x2x!quan
               "stablehlo.return"(%1) : (tensor<!quant.uniform<i32:f32, 2.000000e+00:15>>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64>
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1>
          }
          : (tensor<4x2x!quant.uniform<i8:f32, 2.000000e+00:15>>, tensor<!quant.uniform<i8:f32, 2.000000e+00:15>>) -> (tensor<2x2x!quant.uniform<i32:f32, 2.000000e+00:15>>)
   func.return %0 : tensor<2x2x!quant.uniform<i32:f32, 2.000000e+00:15>>
@@ -131,8 +131,8 @@ func.func @reduce_window_c1(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>,
       "stablehlo.return"() : () -> ()
     }) {
       padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-      window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-      window_strides = dense<[3, 1]> : tensor<2xi64>
+      window_dimensions = array<i64: 5, 1>,
+      window_strides = array<i64: 3, 1>
     } : () -> ()
   func.return
 }
@@ -151,8 +151,8 @@ func.func @reduce_window_c2(%arg0: tensor<4x2xf32>,
               "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1> }
          : (tensor<4x2xf32>, tensor<4x3xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
@@ -172,8 +172,8 @@ func.func @reduce_window_c3(%arg0: tensor<4x2xf32>,
               "stablehlo.return"(%2,%2) : (tensor<f32>, tensor<f32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<f32>) ->
               (tensor<2x2xf32>, tensor<2x2xf32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xf32>
@@ -193,8 +193,8 @@ func.func @reduce_window_c4(%arg0: tensor<4x2xf32>,
               "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5]> : tensor<1xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5>,
+           window_strides = array<i64: 3, 1> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
@@ -214,8 +214,8 @@ func.func @reduce_window_c5(%arg0: tensor<4x2xf32>,
               "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 0]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 0>,
+           window_strides = array<i64: 3, 1> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
@@ -235,8 +235,8 @@ func.func @reduce_window_c6(%arg0: tensor<4x2xf32>,
               "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[1]> : tensor<1xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 1> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
@@ -256,8 +256,8 @@ func.func @reduce_window_c7(%arg0: tensor<4x2xf32>,
               "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[0, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 0, 1> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
@@ -277,10 +277,10 @@ func.func @reduce_window_c8(%arg0: tensor<4x2xf32>,
               "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64>,
-           base_dilations = dense<[1]> : tensor<1xi64>,
-           window_dilations = dense<[1, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1>,
+           base_dilations = array<i64: 1>,
+           window_dilations = array<i64: 1, 1> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
@@ -300,10 +300,10 @@ func.func @reduce_window_c9(%arg0: tensor<4x2xf32>,
               "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64>,
-           base_dilations = dense<[1, 0]> : tensor<2xi64>,
-           window_dilations = dense<[1, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1>,
+           base_dilations = array<i64: 1, 0>,
+           window_dilations = array<i64: 1, 1> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
@@ -323,10 +323,10 @@ func.func @reduce_window_c10(%arg0: tensor<4x2xf32>,
               "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64>,
-           base_dilations = dense<[1, 1]> : tensor<2xi64>,
-           window_dilations = dense<[1]> : tensor<1xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1>,
+           base_dilations = array<i64: 1, 1>,
+           window_dilations = array<i64: 1> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
@@ -346,10 +346,10 @@ func.func @reduce_window_c11(%arg0: tensor<4x2xf32>,
               "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64>,
-           base_dilations = dense<[1, 1]> : tensor<2xi64>,
-           window_dilations = dense<[0, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1>,
+           base_dilations = array<i64: 1, 1>,
+           window_dilations = array<i64: 0, 1> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
@@ -369,8 +369,8 @@ func.func @reduce_window_c12(%arg0: tensor<4x2xf32>,
               "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[2, 2]]> : tensor<1x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
@@ -390,8 +390,8 @@ func.func @reduce_window_c12(%arg0: tensor<4x2xf32>,
               "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[2], [2], [0], [0]]> : tensor<4x1xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
@@ -409,8 +409,8 @@ func.func @reduce_window_c13(%arg0: tensor<4x2xf32>,
               "stablehlo.return"(%2) : (tensor<f32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
@@ -430,8 +430,8 @@ func.func @reduce_window_c13(%arg0: tensor<4x2xf32>,
               "stablehlo.return"() : () -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
@@ -452,8 +452,8 @@ func.func @reduce_window_c13(%arg0: tensor<4x2xf32>,
                   -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
@@ -476,8 +476,8 @@ func.func @reduce_window_c13(%arg0: tensor<4x2xf32>,
                   (tuple<tensor<f32>, tensor<i32>>, tensor<f32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
@@ -497,8 +497,8 @@ func.func @reduce_window_c13(%arg0: tensor<4x2xf32>,
               "stablehlo.return"(%3,%2) : (tensor<i32>, tensor<f32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
@@ -518,8 +518,8 @@ func.func @reduce_window_c13(%arg0: tensor<4x2xf32>,
               "stablehlo.return"(%2,%3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
@@ -539,8 +539,8 @@ func.func @reduce_window_c13(%arg0: tensor<4x2xf32>,
               "stablehlo.return"(%2,%2) : (tensor<f32>, tensor<f32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
@@ -557,7 +557,7 @@ func.func @reduce_window_c13(%arg0: tensor<f32>, %init0: tensor<1xf32>)
               "stablehlo.return"(%2) : (tensor<1xf32>) -> ()
             })
          {
-           window_dimensions = dense<> : tensor<0xi64>
+           window_dimensions = array<i64>
          }
          : (tensor<f32>, tensor<1xf32>) -> (tensor<f32>)
   func.return %0 : tensor<f32>
@@ -575,8 +575,8 @@ func.func @reduce_window_c13(%arg0: tensor<4x2xf32>, %init0: tensor<4x2xf32>)
             })
          {
            padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64>
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1>
          }
          : (tensor<4x2xf32>, tensor<4x2xf32>) -> (tensor<2x2xf32>)
   func.return %0 : tensor<2x2xf32>
@@ -594,8 +594,8 @@ func.func @reduce_window_c13(%arg0: tensor<4x2xi32>, %init0: tensor<i32>) ->
               "stablehlo.return"(%1) : (tensor<i8>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64>
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1>
          }
          : (tensor<4x2xi32>, tensor<i32>) -> (tensor<2x2xi8>)
   func.return %0 : tensor<2x2xi8>
@@ -613,8 +613,8 @@ func.func @reduce_window_c13(%arg0: tensor<4x2xi32>, %init0: tensor<i8>) ->
               "stablehlo.return"(%1) : (tensor<i8>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64>
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1>
          }
          : (tensor<4x2xi32>, tensor<i8>) -> (tensor<2x2xi8>)
   func.return %0 : tensor<2x2xi8>
@@ -632,8 +632,8 @@ func.func @reduce_window_c13(%arg0: tensor<4x2x!quant.uniform<i8:f32, 2.000000e+
               "stablehlo.return"(%1) : (tensor<!quant.uniform<i32:f64, 2.000000e+00:15>>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64>
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1>
          }
          : (tensor<4x2x!quant.uniform<i8:f32, 2.000000e+00:15>>, tensor<!quant.uniform<i8:f32, 2.000000e+00:15>>) -> (tensor<2x2x!quant.uniform<i32:f64, 2.000000e+00:15>>)
   func.return %0 : tensor<2x2x!quant.uniform<i32:f64, 2.000000e+00:15>>
@@ -651,8 +651,8 @@ func.func @reduce_window_c13(%arg0: tensor<4x2x!quant.uniform<i8:f64, 2.000000e+
               "stablehlo.return"(%1) : (tensor<!quant.uniform<i32:f32, 2.000000e+00:15>>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64>
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1>
          }
          : (tensor<4x2x!quant.uniform<i8:f64, 2.000000e+00:15>>, tensor<!quant.uniform<i8:f32, 2.000000e+00:15>>) -> (tensor<2x2x!quant.uniform<i32:f32, 2.000000e+00:15>>)
   func.return %0 : tensor<2x2x!quant.uniform<i32:f32, 2.000000e+00:15>>
@@ -672,8 +672,8 @@ func.func @reduce_window_i2(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>,
               "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[2, 2], [0, 0]]> : tensor<2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<1xf32>, tensor<1xi32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>
@@ -781,8 +781,8 @@ func.func @reduce_window_i7_c12(%arg0: tensor<4x2xf32>, %arg1: tensor<4x2xi32>,
               "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<i32>) -> ()
             })
          { padding = dense<[[[2, 2], [0, 0]]]> : tensor<1x2x2xi64>,
-           window_dimensions = dense<[5, 1]> : tensor<2xi64>,
-           window_strides = dense<[3, 1]> : tensor<2xi64> }
+           window_dimensions = array<i64: 5, 1>,
+           window_strides = array<i64: 3, 1> }
          : (tensor<4x2xf32>, tensor<4x2xi32>, tensor<f32>, tensor<i32>) ->
               (tensor<2x2xf32>, tensor<2x2xi32>)
   func.return %0#0, %0#1 : tensor<2x2xf32>, tensor<2x2xi32>

--- a/stablehlo/tests/verify_select_and_scatter.mlir
+++ b/stablehlo/tests/verify_select_and_scatter.mlir
@@ -17,8 +17,8 @@ func.func @select_and_scatter(
       %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
       "stablehlo.return"(%2) : (tensor<f32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
     func.return %1 : tensor<10x24x24x64xf32>
@@ -42,8 +42,8 @@ func.func @select_and_scatter_with_promotable_types(
       %2 = stablehlo.add %arg3, %arg4 : tensor<f64>
       "stablehlo.return"(%2) : (tensor<f64>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>,
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>,
       padding = dense<0> : tensor<4x2xi64>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf64>
@@ -71,8 +71,8 @@ func.func @select_and_scatter_with_promotable_quantized_types(
     %2 = stablehlo.add %arg3, %arg4 : tensor<!quant.uniform<i32:f32, 2.000000e+00:15>>
     "stablehlo.return"(%2) : (tensor<!quant.uniform<i32:f32, 2.000000e+00:15>>) -> ()
   }) {
-    window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-    window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>
+    window_dimensions = array<i64: 1, 2, 2, 1>,
+    window_strides = array<i64: 1, 2, 2, 1>
   } : (tensor<10x24x24x64x!quant.uniform<i8:f32, 2.000000e+00:15>>,
       tensor<10x12x12x64x!quant.uniform<i8:f32, 2.000000e+00:15>>,
       tensor<!quant.uniform<i8:f32, 2.000000e+00:15>>) ->
@@ -104,8 +104,8 @@ func.func @select_and_scatter_with_unranked_dims(
     "stablehlo.return"(%4) : (tensor<*xbf16>) -> ()
   }) {
     padding = dense<0> : tensor<4x2xi64>,
-    window_dimensions = dense<[2, 3, 1, 1]> : tensor<4xi64>,
-    window_strides = dense<[2, 2, 1, 1]> : tensor<4xi64>}
+    window_dimensions = array<i64: 2, 3, 1, 1>,
+    window_strides = array<i64: 2, 2, 1, 1>}
   : (tensor<4x5x1x1xbf16>, tensor<2x2x1x1xbf16>, tensor<bf16>) ->
       tensor<?x?x?x?xbf16>
   func.return %3 : tensor<?x?x?x?xbf16>
@@ -129,8 +129,8 @@ func.func @select_and_scatter_c1(
       %2 = stablehlo.add %arg3, %arg4 : tensor<i32>
       "stablehlo.return"(%2) : (tensor<i32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>,
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>,
       padding = dense<0> : tensor<4x2xi64>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xi32>, tensor<i32>) ->
           tensor<10x24x24x64xf32>
@@ -155,8 +155,8 @@ func.func @select_and_scatter_c2(
       %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
       "stablehlo.return"(%2) : (tensor<f32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>,
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>,
       padding = dense<0> : tensor<4x2xi64>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x32xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
@@ -181,8 +181,8 @@ func.func @select_and_scatter_c3_c11(
       %2 = stablehlo.add %arg3, %arg3 : tensor<f32>
       "stablehlo.return"(%2) : (tensor<f32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>,
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>,
       padding = dense<0> : tensor<4x2xi64>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
@@ -207,7 +207,7 @@ func.func @select_and_scatter_c4(
       %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
       "stablehlo.return"(%2) : (tensor<f32>) -> ()
     }) {
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>
+      window_strides = array<i64: 1, 2, 2, 1>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
     func.return %1 : tensor<10x24x24x64xf32>
@@ -231,8 +231,8 @@ func.func @select_and_scatter_c5(
       %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
       "stablehlo.return"(%2) : (tensor<f32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 0]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>,
+      window_dimensions = array<i64: 1, 2, 2, 0>,
+      window_strides = array<i64: 1, 2, 2, 1>,
       padding = dense<0> : tensor<4x2xi64>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
@@ -257,8 +257,8 @@ func.func @select_and_scatter_c6(
       %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
       "stablehlo.return"(%2) : (tensor<f32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2]> : tensor<3xi64>
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
     func.return %1 : tensor<10x24x24x64xf32>
@@ -283,8 +283,8 @@ func.func @select_and_scatter_c7(
       %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
       "stablehlo.return"(%2) : (tensor<f32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[0, 2, 2, 1]> : tensor<4xi64>,
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 0, 2, 2, 1>,
       padding = dense<0> : tensor<4x2xi64>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
@@ -310,8 +310,8 @@ func.func @select_and_scatter_c8(
       %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
       "stablehlo.return"(%2) : (tensor<f32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>,
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>,
       padding = dense<0> : tensor<3x2xi64>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
@@ -336,8 +336,8 @@ func.func @select_and_scatter_c8(
       %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
       "stablehlo.return"(%2) : (tensor<f32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>,
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>,
       padding = dense<0> : tensor<4x3xi64>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
@@ -363,8 +363,8 @@ func.func @select_and_scatter_c9(
       %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
       "stablehlo.return"(%2) : (tensor<f32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
     func.return %1 : tensor<10x24x24x64xf32>
@@ -388,8 +388,8 @@ func.func @select_and_scatter_c9(
       %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
       "stablehlo.return"(%2) : (tensor<f32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
     func.return %1 : tensor<10x24x24x64xf32>
@@ -414,8 +414,8 @@ func.func @select_and_scatter_c9(
       %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
       "stablehlo.return"(%2) : (tensor<f32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
     func.return %1 : tensor<10x24x24x64xf32>
@@ -439,8 +439,8 @@ func.func @select_and_scatter_c9(
       %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
       "stablehlo.return"(%2) : (tensor<f32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
     func.return %1 : tensor<10x24x24x64xf32>
@@ -466,8 +466,8 @@ func.func @select_and_scatter_c9(
       %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
       "stablehlo.return"(%2) : (tensor<f32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
 
@@ -493,8 +493,8 @@ func.func @select_and_scatter_c9(
       %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
       "stablehlo.return"(%2) : (tensor<f32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
     func.return %1 : tensor<10x24x24x64xf32>
@@ -518,8 +518,8 @@ func.func @select_and_scatter_c10(
       %2 = stablehlo.add %arg3, %arg3 : tensor<f32>
       "stablehlo.return"(%2) : (tensor<f32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>,
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>,
       padding = dense<0> : tensor<4x2xi64>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
@@ -544,8 +544,8 @@ func.func @select_and_scatter_c10(
       %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
       "stablehlo.return"() : () -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>,
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>,
       padding = dense<0> : tensor<4x2xi64>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
@@ -570,8 +570,8 @@ func.func @select_and_scatter_c10(
       %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
       "stablehlo.return"(%2, %2) : (tensor<f32>, tensor<f32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>,
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>,
       padding = dense<0> : tensor<4x2xi64>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
@@ -597,8 +597,8 @@ func.func @select_and_scatter_c10(
       %3 = "stablehlo.tuple"(%2) : (tensor<f32>) -> tuple<tensor<f32>>
       "stablehlo.return"(%3) : (tuple<tensor<f32>>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>,
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>,
       padding = dense<0> : tensor<4x2xi64>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
@@ -623,8 +623,8 @@ func.func @select_and_scatter_c10(
       %2 = "llvm.add" (%arg3, %arg4) : (f32, f32) -> f32
       "stablehlo.return"(%2) : (f32) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>,
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>,
       padding = dense<0> : tensor<4x2xi64>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
@@ -649,8 +649,8 @@ func.func @select_and_scatter_c10(
       %2 = stablehlo.constant dense<0> : tensor<i32>
       "stablehlo.return"(%2) : (tensor<i32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>,
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>,
       padding = dense<0> : tensor<4x2xi64>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
@@ -675,8 +675,8 @@ func.func @select_and_scatter_c10(
       %2 = stablehlo.add %arg3, %arg4 : tensor<i32>
       "stablehlo.return"(%2) : (tensor<i32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>,
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>,
       padding = dense<0> : tensor<4x2xi64>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<f32>) ->
           tensor<10x24x24x64xf32>
@@ -701,8 +701,8 @@ func.func @select_and_scatter_c10(
       %2 = stablehlo.add %arg3, %arg4 : tensor<i32>
       "stablehlo.return"(%2) : (tensor<i32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>,
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>,
       padding = dense<0> : tensor<4x2xi64>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<i32>) ->
           tensor<10x24x24x64xf32>
@@ -727,8 +727,8 @@ func.func @select_and_scatter_c10(
       %2 = stablehlo.add %arg3, %arg4 : tensor<1xf32>
       "stablehlo.return"(%2) : (tensor<1xf32>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>,
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>,
       padding = dense<0> : tensor<4x2xi64>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<1xf32>) ->
           tensor<10x24x24x64xf32>
@@ -755,8 +755,8 @@ func.func @select_and_scatter_c10(
     %2 = stablehlo.add %arg3, %arg4 : tensor<i8>
     "stablehlo.return"(%2) : (tensor<i8>) -> ()
   }) {
-    window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-    window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>
+    window_dimensions = array<i64: 1, 2, 2, 1>,
+    window_strides = array<i64: 1, 2, 2, 1>
   } : (tensor<10x24x24x64xi32>, tensor<10x12x12x64xi32>, tensor<i32>) ->
         tensor<10x24x24x64xi8>
   func.return %1 : tensor<10x24x24x64xi8>
@@ -780,8 +780,8 @@ func.func @select_and_scatter_c10(
       %2 = stablehlo.add %arg3, %arg4 : tensor<i8>
       "stablehlo.return"(%2) : (tensor<i8>) -> ()
     }) {
-      window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-      window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>,
+      window_dimensions = array<i64: 1, 2, 2, 1>,
+      window_strides = array<i64: 1, 2, 2, 1>,
       padding = dense<0> : tensor<4x2xi64>
     } : (tensor<10x24x24x64xf32>, tensor<10x12x12x64xf32>, tensor<i8>) ->
           tensor<10x24x24x64xf32>
@@ -809,8 +809,8 @@ func.func @select_and_scatter_c10(
     %2 = stablehlo.add %arg3, %arg4 : tensor<!quant.uniform<i32:f64, 2.000000e+00:15>>
     "stablehlo.return"(%2) : (tensor<!quant.uniform<i32:f64, 2.000000e+00:15>>) -> ()
   }) {
-    window_dimensions = dense<[1, 2, 2, 1]> : tensor<4xi64>,
-    window_strides = dense<[1, 2, 2, 1]> : tensor<4xi64>
+    window_dimensions = array<i64: 1, 2, 2, 1>,
+    window_strides = array<i64: 1, 2, 2, 1>
   } : (tensor<10x24x24x64x!quant.uniform<i8:f32, 2.000000e+00:15>>,
       tensor<10x12x12x64x!quant.uniform<i8:f32, 2.000000e+00:15>>,
       tensor<!quant.uniform<i8:f32, 2.000000e+00:15>>) ->


### PR DESCRIPTION
This change flips all the literals that can be written using `array` instead of `dense` without requiring C++ changes. The purpose of this change is to reduce the diff in a future change, where I will actually change the op fields to use `DenseI64ArrayAttr` instead of `I64DenseArrayOrElements1DAttr`. That will require making changes to parsing and serialization, among others. 