### PR TITLE
Notify before returning to avoid race condition

### DIFF
--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -16,7 +16,6 @@ limitations under the License.
 #include "stablehlo/reference/Ops.h"
 
 #include <algorithm>
-#include <string>
 
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/APInt.h"
@@ -864,19 +863,11 @@ Tensor evalAllGatherOp(const Tensor &operand, int64_t allGatherDim,
     processGroups = process->flattenedIds(replicaGroups);
 
   auto processGroup = processGroups.findGroup(process->getId());
-  // llvm::errs() << "processGroup count: " +
-  //                     std::to_string(processGroup->size()) + "\n";
   if (!processGroup)
     llvm::report_fatal_error(invalidArgument(
         "Failed to find process group with process_id: (%d, %d)",
         process->getId().replicaId, process->getId().partitionId));
 
-  // auto groupOperands = process->rendezvous(*processGroup, channelId, operand)
-  //                          ->getSortedTensors();
-
-  // std::string processId = std::to_string(process->getId().replicaId) + ", " +
-  //                         std::to_string(process->getId().partitionId);
-  // llvm::errs() << "current process:" + processId + "\n";
   auto rendezvousResult =
       *process->rendezvous(*processGroup, channelId, operand);
   SmallVector<Tensor> groupOperands(llvm::map_range(

--- a/stablehlo/reference/ProcessGrid.cpp
+++ b/stablehlo/reference/ProcessGrid.cpp
@@ -223,9 +223,6 @@ SmallVector<Tensor> ProcessGrid::recv(ChannelId channelId,
 std::shared_ptr<RendezvousResult const> ProcessGrid::rendezvous(
     ProcessGroup processGroup, ChannelId channelId, ProcessId processId,
     const Tensor &operand) {
-  std::string id = "(" + std::to_string(processId.replicaId) + "," +
-                   std::to_string(processId.partitionId) + "): ";
-  // std::string id = "rendezvous: " + id + "\n";
   std::pair<ProcessGroup, ChannelId> channelKey(processGroup, channelId);
   // Process wait/notify logic below doesn't work for single process.
   if (processGroup.size() == 1)
@@ -238,16 +235,12 @@ std::shared_ptr<RendezvousResult const> ProcessGrid::rendezvous(
   state.values[processId] = operand;
 
   if (state.values.size() == processGroup.size()) {
-    llvm::errs() << id + "(B) values.size() = " +
-                        std::to_string(state.values.size()) + "\n\n";
     // If values are full, that means all other processes are currently waiting.
     // The last process to contribute moves the values into the result
     // then waits for each process to return a copy of the result before
     // cleaning up the state variable for future computations in this process
     // grid.
     state.result = std::make_shared<RendezvousResult>(state.values);
-    llvm::errs() << id + "use_count: "
-                 << std::to_string(state.result.use_count()) << "\n\n";
     state.values.clear();
     channelConditions_[channelKey].notify_one();
 
@@ -261,8 +254,6 @@ std::shared_ptr<RendezvousResult const> ProcessGrid::rendezvous(
       llvm::report_fatal_error(
           "rendezvous timed out: not all processes have contributed yet");
 
-    llvm::errs() << "\n" + id + "finished reading\n\n";
-
     if (state.result.use_count() > static_cast<int64_t>(processGroup.size()))
       llvm::report_fatal_error(
           "Each process should have only one shared access to the result.");
@@ -270,15 +261,9 @@ std::shared_ptr<RendezvousResult const> ProcessGrid::rendezvous(
     // The last process to contribute takes the result from the state to allow
     // the process that contributed last to exit the function.
     auto result = std::move(state.result);
-    llvm::errs() << id + "use_count: "
-                 << std::to_string(state.result.use_count()) << "\n";
     channelConditions_[channelKey].notify_one();
-    llvm::errs() << id + "im exiting\n\n";
     return result;
   }
-
-  llvm::errs() << id + "(A) values.size() = " +
-                      std::to_string(state.values.size()) + "\n";
 
   // Wait for all processes to contribute values.
   if (!channelConditions_[channelKey].wait_for(
@@ -287,14 +272,8 @@ std::shared_ptr<RendezvousResult const> ProcessGrid::rendezvous(
     llvm::report_fatal_error(
         "rendezvous timed out: not all process has received the results yet");
 
-  llvm::errs() << id + "finished waiting for all process to contribute\n";
-  llvm::errs() << id + "state.result is null? " +
-                      std::to_string(state.result == nullptr) + "\n";
-
   // Copy result from the state before notifying.
   auto result = state.result;
-  llvm::errs() << id + "use_count: " << std::to_string(state.result.use_count())
-               << "\n";
   channelConditions_[channelKey].notify_one();
 
   // Wait for the remaining processes to have retrieved the result. In other
@@ -304,9 +283,7 @@ std::shared_ptr<RendezvousResult const> ProcessGrid::rendezvous(
           [&] { return state.result == nullptr; }))
     llvm::report_fatal_error(
         "rendezvous timed out: not all process has received the results yet");
-  llvm::errs() << id + "use_count: " << std::to_string(state.result.use_count())
-               << "\n";
-  llvm::errs() << id + "last process exited, im exiting\n";
+
   channelConditions_[channelKey].notify_one();
   return result;
 }

--- a/stablehlo/reference/ProcessGrid.h
+++ b/stablehlo/reference/ProcessGrid.h
@@ -242,7 +242,7 @@ class ProcessGrid {
   /// deadlock the interpreter.
   ///
   /// At the barrier, each StableHLO process contributes a tensor, and these
-  /// tensors are accumulated in `RendezvousResult` whose shard pointer is
+  /// tensors are accumulated in `RendezvousResult` whose shared pointer is
   /// returned to all callers once the barrier has been reached by all StableHLO
   /// processes.
   std::shared_ptr<RendezvousResult const> rendezvous(ProcessGroup processGroup,

--- a/stablehlo/tests/interpret/all_gather.mlir
+++ b/stablehlo/tests/interpret/all_gather.mlir
@@ -1,51 +1,51 @@
 // RUN: stablehlo-translate --interpret -split-input-file %s
 
-module @cross_replica {
-  func.func public @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
-    %result = "stablehlo.all_gather"(%arg0) {
-      all_gather_dim = 1 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
-    } : (tensor<2x2xi64>) -> tensor<2x4xi64>
-    return %result : tensor<2x4xi64>
-  }
-  func.func public @main() {
-    %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
-    %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
-    %results:2 = "interpreter.run_parallel"(%0, %1) {
-      programs=[[@all_gather], [@all_gather]]
-    } : (tensor<2x2xi64>, tensor<2x2xi64>) -> (tensor<2x4xi64>, tensor<2x4xi64>)
-    check.expect_eq_const %results#0, dense<[[1, 2, 5, 6],
-                                             [3, 4, 7, 8]]> : tensor<2x4xi64>
-    check.expect_eq_const %results#1, dense<[[1, 2, 5, 6],
-                                             [3, 4, 7, 8]]> : tensor<2x4xi64>
-    func.return
-  }
-}
+// module @cross_replica {
+//   func.func public @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
+//     %result = "stablehlo.all_gather"(%arg0) {
+//       all_gather_dim = 1 : i64,
+//       replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
+//     } : (tensor<2x2xi64>) -> tensor<2x4xi64>
+//     return %result : tensor<2x4xi64>
+//   }
+//   func.func public @main() {
+//     %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
+//     %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
+//     %results:2 = "interpreter.run_parallel"(%0, %1) {
+//       programs=[[@all_gather], [@all_gather]]
+//     } : (tensor<2x2xi64>, tensor<2x2xi64>) -> (tensor<2x4xi64>, tensor<2x4xi64>)
+//     check.expect_eq_const %results#0, dense<[[1, 2, 5, 6],
+//                                              [3, 4, 7, 8]]> : tensor<2x4xi64>
+//     check.expect_eq_const %results#1, dense<[[1, 2, 5, 6],
+//                                              [3, 4, 7, 8]]> : tensor<2x4xi64>
+//     func.return
+//   }
+// }
 
-// -----
+// // -----
 
-module @cross_replica_and_partition {
-  func.func public @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
-    %result = "stablehlo.all_gather"(%arg0) {
-      all_gather_dim = 1 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
-      channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>
-    } : (tensor<2x2xi64>) -> tensor<2x4xi64>
-    return %result : tensor<2x4xi64>
-  }
-  func.func public @main() {
-    %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
-    %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
-    %results:2 = "interpreter.run_parallel"(%0, %1) {
-      programs=[[@all_gather], [@all_gather]]
-    } : (tensor<2x2xi64>, tensor<2x2xi64>) -> (tensor<2x4xi64>, tensor<2x4xi64>)
-    check.expect_eq_const %results#0, dense<[[1, 2, 5, 6],
-                                             [3, 4, 7, 8]]> : tensor<2x4xi64>
-    check.expect_eq_const %results#1, dense<[[1, 2, 5, 6],
-                                             [3, 4, 7, 8]]> : tensor<2x4xi64>
-    func.return
-  }
-}
+// module @cross_replica_and_partition {
+//   func.func public @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
+//     %result = "stablehlo.all_gather"(%arg0) {
+//       all_gather_dim = 1 : i64,
+//       replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+//       channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>
+//     } : (tensor<2x2xi64>) -> tensor<2x4xi64>
+//     return %result : tensor<2x4xi64>
+//   }
+//   func.func public @main() {
+//     %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
+//     %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
+//     %results:2 = "interpreter.run_parallel"(%0, %1) {
+//       programs=[[@all_gather], [@all_gather]]
+//     } : (tensor<2x2xi64>, tensor<2x2xi64>) -> (tensor<2x4xi64>, tensor<2x4xi64>)
+//     check.expect_eq_const %results#0, dense<[[1, 2, 5, 6],
+//                                              [3, 4, 7, 8]]> : tensor<2x4xi64>
+//     check.expect_eq_const %results#1, dense<[[1, 2, 5, 6],
+//                                              [3, 4, 7, 8]]> : tensor<2x4xi64>
+//     func.return
+//   }
+// }
 
 // -----
 
@@ -62,16 +62,24 @@ module @cross_replica_and_partition_issue_1933 {
     %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
     %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
     %results:4 = "interpreter.run_parallel"(%1, %1, %0, %1) {
-      programs=[[@all_gather, @all_gather], [@all_gather,@all_gather]]
+      programs=[[@all_gather, @all_gather], [@all_gather, @all_gather]]
     } : (tensor<2x2xi64>, tensor<2x2xi64>, tensor<2x2xi64>, tensor<2x2xi64>) -> (tensor<2x8xi64>, tensor<2x8xi64>, tensor<2x8xi64>, tensor<2x8xi64>)
-    check.expect_eq_const %results#0, dense<[[5, 6, 1, 2, 5, 6, 5, 6],
-                                             [7, 8, 3, 4, 7, 8, 7, 8]]> : tensor<2x8xi64>
-    check.expect_eq_const %results#1, dense<[[5, 6, 1, 2, 5, 6, 5, 6],
-                                             [7, 8, 3, 4, 7, 8, 7, 8]]> : tensor<2x8xi64>
-    check.expect_eq_const %results#2, dense<[[5, 6, 1, 2, 5, 6, 5, 6],
-                                             [7, 8, 3, 4, 7, 8, 7, 8]]> : tensor<2x8xi64>
-    check.expect_eq_const %results#3, dense<[[5, 6, 1, 2, 5, 6, 5, 6],
-                                             [7, 8, 3, 4, 7, 8, 7, 8]]> : tensor<2x8xi64>
+    check.expect_eq_const %results#0, dense<[[5, 6, 5, 6, 1, 2, 5, 6],
+                                             [7, 8, 7, 8, 3, 4, 7, 8]]> : tensor<2x8xi64>
+    check.expect_eq_const %results#1, dense<[[5, 6, 5, 6, 1, 2, 5, 6],
+                                             [7, 8, 7, 8, 3, 4, 7, 8]]> : tensor<2x8xi64>
+    check.expect_eq_const %results#2, dense<[[5, 6, 5, 6, 1, 2, 5, 6],
+                                             [7, 8, 7, 8, 3, 4, 7, 8]]> : tensor<2x8xi64>
+    check.expect_eq_const %results#3, dense<[[5, 6, 5, 6, 1, 2, 5, 6],
+                                             [7, 8, 7, 8, 3, 4, 7, 8]]> : tensor<2x8xi64>
+    // check.expect_eq_const %results#0, dense<[[5, 6, 1, 2, 5, 6, 5, 6],
+    //                                          [7, 8, 3, 4, 7, 8, 7, 8]]> : tensor<2x8xi64>
+    // check.expect_eq_const %results#1, dense<[[5, 6, 1, 2, 5, 6, 5, 6],
+    //                                          [7, 8, 3, 4, 7, 8, 7, 8]]> : tensor<2x8xi64>
+    // check.expect_eq_const %results#2, dense<[[5, 6, 1, 2, 5, 6, 5, 6],
+    //                                          [7, 8, 3, 4, 7, 8, 7, 8]]> : tensor<2x8xi64>
+    // check.expect_eq_const %results#3, dense<[[5, 6, 1, 2, 5, 6, 5, 6],
+    //                                          [7, 8, 3, 4, 7, 8, 7, 8]]> : tensor<2x8xi64>
 
     func.return
   }
@@ -79,26 +87,26 @@ module @cross_replica_and_partition_issue_1933 {
 
 // -----
 
-module @flattened_ids {
-  func.func public @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
-    %result = "stablehlo.all_gather"(%arg0) {
-      all_gather_dim = 1 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
-      channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
-      use_global_device_ids
-    } : (tensor<2x2xi64>) -> tensor<2x4xi64>
-    return %result : tensor<2x4xi64>
-  }
-  func.func public @main() {
-    %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
-    %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
-    %results:2 = "interpreter.run_parallel"(%0, %1) {
-      programs=[[@all_gather], [@all_gather]]
-    } : (tensor<2x2xi64>, tensor<2x2xi64>) -> (tensor<2x4xi64>, tensor<2x4xi64>)
-    check.expect_eq_const %results#0, dense<[[1, 2, 5, 6],
-                                             [3, 4, 7, 8]]> : tensor<2x4xi64>
-    check.expect_eq_const %results#1, dense<[[1, 2, 5, 6],
-                                             [3, 4, 7, 8]]> : tensor<2x4xi64>
-    func.return
-  }
-}
+// module @flattened_ids {
+//   func.func public @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
+//     %result = "stablehlo.all_gather"(%arg0) {
+//       all_gather_dim = 1 : i64,
+//       replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+//       channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+//       use_global_device_ids
+//     } : (tensor<2x2xi64>) -> tensor<2x4xi64>
+//     return %result : tensor<2x4xi64>
+//   }
+//   func.func public @main() {
+//     %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
+//     %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
+//     %results:2 = "interpreter.run_parallel"(%0, %1) {
+//       programs=[[@all_gather], [@all_gather]]
+//     } : (tensor<2x2xi64>, tensor<2x2xi64>) -> (tensor<2x4xi64>, tensor<2x4xi64>)
+//     check.expect_eq_const %results#0, dense<[[1, 2, 5, 6],
+//                                              [3, 4, 7, 8]]> : tensor<2x4xi64>
+//     check.expect_eq_const %results#1, dense<[[1, 2, 5, 6],
+//                                              [3, 4, 7, 8]]> : tensor<2x4xi64>
+//     func.return
+//   }
+// }

--- a/stablehlo/tests/interpret/all_gather.mlir
+++ b/stablehlo/tests/interpret/all_gather.mlir
@@ -1,51 +1,51 @@
 // RUN: stablehlo-translate --interpret -split-input-file %s
 
-// module @cross_replica {
-//   func.func public @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
-//     %result = "stablehlo.all_gather"(%arg0) {
-//       all_gather_dim = 1 : i64,
-//       replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
-//     } : (tensor<2x2xi64>) -> tensor<2x4xi64>
-//     return %result : tensor<2x4xi64>
-//   }
-//   func.func public @main() {
-//     %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
-//     %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
-//     %results:2 = "interpreter.run_parallel"(%0, %1) {
-//       programs=[[@all_gather], [@all_gather]]
-//     } : (tensor<2x2xi64>, tensor<2x2xi64>) -> (tensor<2x4xi64>, tensor<2x4xi64>)
-//     check.expect_eq_const %results#0, dense<[[1, 2, 5, 6],
-//                                              [3, 4, 7, 8]]> : tensor<2x4xi64>
-//     check.expect_eq_const %results#1, dense<[[1, 2, 5, 6],
-//                                              [3, 4, 7, 8]]> : tensor<2x4xi64>
-//     func.return
-//   }
-// }
+module @cross_replica {
+  func.func public @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
+    %result = "stablehlo.all_gather"(%arg0) {
+      all_gather_dim = 1 : i64,
+      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
+    } : (tensor<2x2xi64>) -> tensor<2x4xi64>
+    return %result : tensor<2x4xi64>
+  }
+  func.func public @main() {
+    %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
+    %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
+    %results:2 = "interpreter.run_parallel"(%0, %1) {
+      programs=[[@all_gather], [@all_gather]]
+    } : (tensor<2x2xi64>, tensor<2x2xi64>) -> (tensor<2x4xi64>, tensor<2x4xi64>)
+    check.expect_eq_const %results#0, dense<[[1, 2, 5, 6],
+                                             [3, 4, 7, 8]]> : tensor<2x4xi64>
+    check.expect_eq_const %results#1, dense<[[1, 2, 5, 6],
+                                             [3, 4, 7, 8]]> : tensor<2x4xi64>
+    func.return
+  }
+}
 
-// // -----
+// -----
 
-// module @cross_replica_and_partition {
-//   func.func public @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
-//     %result = "stablehlo.all_gather"(%arg0) {
-//       all_gather_dim = 1 : i64,
-//       replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
-//       channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>
-//     } : (tensor<2x2xi64>) -> tensor<2x4xi64>
-//     return %result : tensor<2x4xi64>
-//   }
-//   func.func public @main() {
-//     %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
-//     %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
-//     %results:2 = "interpreter.run_parallel"(%0, %1) {
-//       programs=[[@all_gather], [@all_gather]]
-//     } : (tensor<2x2xi64>, tensor<2x2xi64>) -> (tensor<2x4xi64>, tensor<2x4xi64>)
-//     check.expect_eq_const %results#0, dense<[[1, 2, 5, 6],
-//                                              [3, 4, 7, 8]]> : tensor<2x4xi64>
-//     check.expect_eq_const %results#1, dense<[[1, 2, 5, 6],
-//                                              [3, 4, 7, 8]]> : tensor<2x4xi64>
-//     func.return
-//   }
-// }
+module @cross_replica_and_partition {
+  func.func public @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
+    %result = "stablehlo.all_gather"(%arg0) {
+      all_gather_dim = 1 : i64,
+      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+      channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>
+    } : (tensor<2x2xi64>) -> tensor<2x4xi64>
+    return %result : tensor<2x4xi64>
+  }
+  func.func public @main() {
+    %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
+    %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
+    %results:2 = "interpreter.run_parallel"(%0, %1) {
+      programs=[[@all_gather], [@all_gather]]
+    } : (tensor<2x2xi64>, tensor<2x2xi64>) -> (tensor<2x4xi64>, tensor<2x4xi64>)
+    check.expect_eq_const %results#0, dense<[[1, 2, 5, 6],
+                                             [3, 4, 7, 8]]> : tensor<2x4xi64>
+    check.expect_eq_const %results#1, dense<[[1, 2, 5, 6],
+                                             [3, 4, 7, 8]]> : tensor<2x4xi64>
+    func.return
+  }
+}
 
 // -----
 
@@ -63,23 +63,16 @@ module @cross_replica_and_partition_issue_1933 {
     %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
     %results:4 = "interpreter.run_parallel"(%1, %1, %0, %1) {
       programs=[[@all_gather, @all_gather], [@all_gather, @all_gather]]
-    } : (tensor<2x2xi64>, tensor<2x2xi64>, tensor<2x2xi64>, tensor<2x2xi64>) -> (tensor<2x8xi64>, tensor<2x8xi64>, tensor<2x8xi64>, tensor<2x8xi64>)
-    check.expect_eq_const %results#0, dense<[[5, 6, 5, 6, 1, 2, 5, 6],
-                                             [7, 8, 7, 8, 3, 4, 7, 8]]> : tensor<2x8xi64>
-    check.expect_eq_const %results#1, dense<[[5, 6, 5, 6, 1, 2, 5, 6],
-                                             [7, 8, 7, 8, 3, 4, 7, 8]]> : tensor<2x8xi64>
-    check.expect_eq_const %results#2, dense<[[5, 6, 5, 6, 1, 2, 5, 6],
-                                             [7, 8, 7, 8, 3, 4, 7, 8]]> : tensor<2x8xi64>
-    check.expect_eq_const %results#3, dense<[[5, 6, 5, 6, 1, 2, 5, 6],
-                                             [7, 8, 7, 8, 3, 4, 7, 8]]> : tensor<2x8xi64>
-    // check.expect_eq_const %results#0, dense<[[5, 6, 1, 2, 5, 6, 5, 6],
-    //                                          [7, 8, 3, 4, 7, 8, 7, 8]]> : tensor<2x8xi64>
-    // check.expect_eq_const %results#1, dense<[[5, 6, 1, 2, 5, 6, 5, 6],
-    //                                          [7, 8, 3, 4, 7, 8, 7, 8]]> : tensor<2x8xi64>
-    // check.expect_eq_const %results#2, dense<[[5, 6, 1, 2, 5, 6, 5, 6],
-    //                                          [7, 8, 3, 4, 7, 8, 7, 8]]> : tensor<2x8xi64>
-    // check.expect_eq_const %results#3, dense<[[5, 6, 1, 2, 5, 6, 5, 6],
-    //                                          [7, 8, 3, 4, 7, 8, 7, 8]]> : tensor<2x8xi64>
+    } : (tensor<2x2xi64>, tensor<2x2xi64>, tensor<2x2xi64>, tensor<2x2xi64>) ->
+        (tensor<2x8xi64>, tensor<2x8xi64>, tensor<2x8xi64>, tensor<2x8xi64>)
+    check.expect_eq_const %results#0, dense<[[5, 6, 1, 2, 5, 6, 5, 6],
+                                             [7, 8, 3, 4, 7, 8, 7, 8]]> : tensor<2x8xi64>
+    check.expect_eq_const %results#1, dense<[[5, 6, 1, 2, 5, 6, 5, 6],
+                                             [7, 8, 3, 4, 7, 8, 7, 8]]> : tensor<2x8xi64>
+    check.expect_eq_const %results#2, dense<[[5, 6, 1, 2, 5, 6, 5, 6],
+                                             [7, 8, 3, 4, 7, 8, 7, 8]]> : tensor<2x8xi64>
+    check.expect_eq_const %results#3, dense<[[5, 6, 1, 2, 5, 6, 5, 6],
+                                             [7, 8, 3, 4, 7, 8, 7, 8]]> : tensor<2x8xi64>
 
     func.return
   }
@@ -87,26 +80,26 @@ module @cross_replica_and_partition_issue_1933 {
 
 // -----
 
-// module @flattened_ids {
-//   func.func public @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
-//     %result = "stablehlo.all_gather"(%arg0) {
-//       all_gather_dim = 1 : i64,
-//       replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
-//       channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
-//       use_global_device_ids
-//     } : (tensor<2x2xi64>) -> tensor<2x4xi64>
-//     return %result : tensor<2x4xi64>
-//   }
-//   func.func public @main() {
-//     %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
-//     %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
-//     %results:2 = "interpreter.run_parallel"(%0, %1) {
-//       programs=[[@all_gather], [@all_gather]]
-//     } : (tensor<2x2xi64>, tensor<2x2xi64>) -> (tensor<2x4xi64>, tensor<2x4xi64>)
-//     check.expect_eq_const %results#0, dense<[[1, 2, 5, 6],
-//                                              [3, 4, 7, 8]]> : tensor<2x4xi64>
-//     check.expect_eq_const %results#1, dense<[[1, 2, 5, 6],
-//                                              [3, 4, 7, 8]]> : tensor<2x4xi64>
-//     func.return
-//   }
-// }
+module @flattened_ids {
+  func.func public @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
+    %result = "stablehlo.all_gather"(%arg0) {
+      all_gather_dim = 1 : i64,
+      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+      channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>,
+      use_global_device_ids
+    } : (tensor<2x2xi64>) -> tensor<2x4xi64>
+    return %result : tensor<2x4xi64>
+  }
+  func.func public @main() {
+    %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
+    %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
+    %results:2 = "interpreter.run_parallel"(%0, %1) {
+      programs=[[@all_gather], [@all_gather]]
+    } : (tensor<2x2xi64>, tensor<2x2xi64>) -> (tensor<2x4xi64>, tensor<2x4xi64>)
+    check.expect_eq_const %results#0, dense<[[1, 2, 5, 6],
+                                             [3, 4, 7, 8]]> : tensor<2x4xi64>
+    check.expect_eq_const %results#1, dense<[[1, 2, 5, 6],
+                                             [3, 4, 7, 8]]> : tensor<2x4xi64>
+    func.return
+  }
+}


### PR DESCRIPTION
There's a data race when the last process returns via `std::move`. If the other processes are notified before the move happens, they will hang since `state.result` is still not null. To prevent this, we move it to another variable first so that `state.result` is empty before calling notify to other waiting processes.

Similarly, once the last process that contributed exits and notifies another process, it should notify other waiting processes before exiting. Otherwise, they will hang until the timeout, check the condition is true, and then proceed forward, which is not ideal.

Also includes minor formatting & typo fixes.


Here's an example output from debugging:
```
(0,0): (A) values.size() = 1
(0,1): (A) values.size() = 2
(1,0): (A) values.size() = 3
(1,1): (B) values.size() = 4

(1,1): use_count: 1

(0,0): finished waiting for all process to contribute
(0,0): state.result is null? 0
(0,0): use_count: 2
(0,1): finished waiting for all process to contribute
(0,1): state.result is null? 0
(0,1): use_count: 3
(1,0): finished waiting for all process to contribute
(1,0): state.result is null? 0
(1,0): use_count: 4

(1,1): finished reading

(1,1): use_count: 0
(1,1): im exiting

(0,0): use_count: 0
(0,0): last process exited, im exiting
(0,1): use_count: 0
(0,1): last process exited, im exiting
(1,0): use_count: 0
(1,0): last process exited, im exiting
```