### PR TITLE
Replace non-breaking spaces with regular spaces

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -5796,7 +5796,7 @@ More formally, `result = dequantize(operand)`.
 
 #### Semantics
 
-Performs element-wise conversion of floating-point tensor or quantized tensor
+Performs element-wise conversion of floating-point tensor or quantized tensor
 `operand` to a quantized tensor `result` according to the quantization
 parameters defined by the `result` type.
 
@@ -5812,7 +5812,7 @@ More formally,
 
 | Label | Name      | Type                                       | Constraints |
 |-------|-----------|--------------------------------------------|-------------|
-| (I1)  | `operand` | tensor of floating-point or quantized type | (C1), (C2)  |
+| (I1)  | `operand` | tensor of floating-point or quantized type | (C1), (C2)  |
 
 #### Outputs
 

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -3098,7 +3098,7 @@ def StableHLO_UniformQuantizeOp : StableHLO_UnaryElementwiseOp<"uniform_quantize
       HLO_QuantizedIntTensor> { /*uniform_quantize_c1*/
   let summary = "UniformQuantize operation";
   let description = [{
-    Performs element-wise conversion of floating-point tensor or quantized
+    Performs element-wise conversion of floating-point tensor or quantized
     tensor `operand` to a quantized tensor `result` according to the
     quantization parameters defined by the `result` type.
 


### PR DESCRIPTION
Even though there is (for the most part) no difference in how these characters are rendered, in some cases this can cause subtle issues that are hard to debug.

I used `ripgrep` to find the non-breaking spaces: `rg '\xA0'`.