### PR TITLE
Enhance rendezvous docs and fix race condition

### DIFF
--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -870,7 +870,7 @@ Tensor evalAllGatherOp(const Tensor &operand, int64_t allGatherDim,
         process->getId().replicaId, process->getId().partitionId));
 
   auto rendezvousResult =
-      *process->rendezvous(*processGroup, channelId, operand);
+      process->rendezvous(*processGroup, channelId, operand);
   SmallVector<Tensor> groupOperands(llvm::map_range(
       *processGroup,
       [&](const ProcessId &id) { return rendezvousResult.lookup(id); }));
@@ -901,8 +901,8 @@ Tensor evalAllReduceOp(const Tensor &operand,
         "Failed to find process group with process_id: (%d, %d)",
         process->getId().replicaId, process->getId().partitionId));
 
-  auto groupOperands = process->rendezvous(*processGroup, channelId, operand)
-                           ->getSortedTensors();
+  auto groupOperands =
+      process->rendezvous(*processGroup, channelId, operand).getSortedTensors();
 
   Tensor result(resultType);
   for (auto resultIt = result.index_begin(); resultIt != result.index_end();
@@ -942,8 +942,8 @@ Tensor evalAllToAllOp(const Tensor &operand, Axis splitDimension,
         "Failed to find process group with process_id: (%d, %d)",
         process->getId().replicaId, process->getId().partitionId));
 
-  auto groupOperands = process->rendezvous(*processGroup, channelId, operand)
-                           ->getSortedTensors();
+  auto groupOperands =
+      process->rendezvous(*processGroup, channelId, operand).getSortedTensors();
 
   SmallVector<Tensor> scatteredParts;
   for (const auto &groupOperand : groupOperands) {
@@ -1093,7 +1093,7 @@ Tensor evalCollectivePermuteOp(
     if (from != process->getId() && to != process->getId()) continue;
 
     auto rendezvousResult =
-        *process->rendezvous(processGroup, channelId, operand);
+        process->rendezvous(processGroup, channelId, operand);
     if (to != process->getId()) continue;
     result = rendezvousResult.lookup(from);
   }

--- a/stablehlo/reference/Process.cpp
+++ b/stablehlo/reference/Process.cpp
@@ -50,8 +50,9 @@ SmallVector<Tensor> Process::recv(ChannelId channelId) {
   return grid_->recv(channelId, getId());
 }
 
-std::shared_ptr<RendezvousResult const> Process::rendezvous(
-    ProcessGroup processGroup, ChannelId channelId, const Tensor &operand) {
+RendezvousResult Process::rendezvous(ProcessGroup processGroup,
+                                     ChannelId channelId,
+                                     const Tensor &operand) {
   return grid_->rendezvous(processGroup, channelId, getId(), operand);
 }
 

--- a/stablehlo/reference/Process.cpp
+++ b/stablehlo/reference/Process.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 The StableHLO Authors.
+/* Copyright 2023-2024 The StableHLO Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/stablehlo/reference/Process.h
+++ b/stablehlo/reference/Process.h
@@ -1,4 +1,4 @@
-/* Copyright 2023 The StableHLO Authors.
+/* Copyright 2023-2024 The StableHLO Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/stablehlo/reference/Process.h
+++ b/stablehlo/reference/Process.h
@@ -60,9 +60,8 @@ class Process {
   SmallVector<Tensor> recv(ChannelId channelId);
 
   /// See `ProcessGrid::rendezvous`.
-  std::shared_ptr<RendezvousResult const> rendezvous(ProcessGroup processGroup,
-                                                     ChannelId channelId,
-                                                     const Tensor &operand);
+  RendezvousResult rendezvous(ProcessGroup processGroup, ChannelId channelId,
+                              const Tensor &operand);
 
   /// See `ProcessGrid::send`.
   void send(ArrayRef<Tensor> inputs, ChannelId channelId);

--- a/stablehlo/reference/ProcessGrid.cpp
+++ b/stablehlo/reference/ProcessGrid.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2023 The StableHLO Authors.
+/* Copyright 2023-2024 The StableHLO Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/stablehlo/reference/ProcessGrid.h
+++ b/stablehlo/reference/ProcessGrid.h
@@ -67,7 +67,6 @@ namespace detail {
 /// Once all processes have added their data, the data in `values` is moved to
 /// `result` that multiple processes can concurrently read from.
 struct RendezvousState {
- public:
   /// Synchronization primitive used to manage concurrent access to this
   /// object.
   std::mutex mutex;
@@ -75,8 +74,8 @@ struct RendezvousState {
   /// Internal storage used to store data contributed by the processes.
   std::map<ProcessId, Tensor> values;
 
-  /// Internal state management counter the number of processes that
-  // contributed.
+  /// Internal state management counter which counts the number of processes
+  /// that contributed already.
   size_t useCount;
 
   /// Stores the result of `rendezvous`.

--- a/stablehlo/reference/ProcessGrid.h
+++ b/stablehlo/reference/ProcessGrid.h
@@ -1,4 +1,4 @@
-/* Copyright 2023 The StableHLO Authors.
+/* Copyright 2023-2024 The StableHLO Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ class RendezvousResult {
 
 namespace detail {
 
-/// Internal storate used in `rendezvous` to manage concurrent access to the
+/// Internal storage used in `rendezvous` to manage concurrent access to the
 /// shared resource. Processes contribute their data to `values` concurrently.
 /// Once all processes have added their data, the data in `values` is moved to
 /// `result` that multiple processes can concurrently read from.

--- a/stablehlo/reference/ProcessGrid.h
+++ b/stablehlo/reference/ProcessGrid.h
@@ -66,7 +66,7 @@ namespace detail {
 /// shared resource. Processes contribute their data to `values` concurrently.
 /// Once all processes have added their data, the data in `values` is moved to
 /// `result` that multiple processes can concurrently read from.
-class RendezvousState {
+struct RendezvousState {
  public:
   /// Synchronization primitive used to manage concurrent access to this
   /// object.
@@ -75,7 +75,11 @@ class RendezvousState {
   /// Internal storage used to store data contributed by the processes.
   std::map<ProcessId, Tensor> values;
 
-  /// Shared pointer to the result of `rendezvous`.
+  /// Internal state management counter the number of processes that
+  // contributed.
+  size_t useCount;
+
+  /// Stores the result of `rendezvous`.
   RendezvousResult result;
 };
 

--- a/stablehlo/reference/ProcessGrid.h
+++ b/stablehlo/reference/ProcessGrid.h
@@ -33,7 +33,32 @@ namespace mlir {
 namespace stablehlo {
 
 struct ProcessId;
-class RendezvousResult;
+
+/// Represents a result of a `ProcessGrid::rendezvous` where multiple processes
+/// synchronize at a barrier and contribute a Tensor each.
+/// This class is pretty much a map from ProcessId to Tensor, with the
+/// map-like API.
+class RendezvousResult {
+ public:
+  RendezvousResult() = default;
+  RendezvousResult(std::map<ProcessId, Tensor> const &result);
+
+  /// Iterates through the (ProcessId, Tensor) map entires and returns a vector
+  /// of Tensors sorted by ProcessId--(replicaId, partitionId) pair--in
+  /// lexicographical order.
+  SmallVector<Tensor> getSortedTensors() const;
+
+  /// Inserts `tensor` into the map using the key `processId`.
+  void insert(ProcessId processId, Tensor tensor);
+
+  /// Iterates through the map and returns the value associated with the key
+  /// `processId`. If key is not found, return an empty `Tensor`.
+  Tensor lookup(ProcessId processId) const;
+
+ private:
+  /// Internal map representation of the result of `ProcessGrid::rendezvous`.
+  std::map<ProcessId, Tensor> result_;
+};
 
 namespace detail {
 
@@ -41,7 +66,8 @@ namespace detail {
 /// shared resource. Processes contribute their data to `values` concurrently.
 /// Once all processes have added their data, the data in `values` is moved to
 /// `result` that multiple processes can concurrently read from.
-struct RendezvousState {
+class RendezvousState {
+ public:
   /// Synchronization primitive used to manage concurrent access to this
   /// object.
   std::mutex mutex;
@@ -49,14 +75,8 @@ struct RendezvousState {
   /// Internal storage used to store data contributed by the processes.
   std::map<ProcessId, Tensor> values;
 
-  /// Flag to check whether all processes have contributed.
-  bool sharingDone;
-
-  /// Count of how many processes have contributed so far.
-  size_t contributionCount;
-
   /// Shared pointer to the result of `rendezvous`.
-  std::shared_ptr<RendezvousResult> result;
+  RendezvousResult result;
 };
 
 struct SendRecvState {
@@ -170,31 +190,6 @@ class ProcessGroups : public SmallVector<ProcessGroup> {
   std::optional<ProcessGroup> findGroup(ProcessId processId);
 };
 
-/// Represents a result of a `ProcessGrid::rendezvous` where multiple processes
-/// synchronize at a barrier and contribute a Tensor each.
-/// This class is pretty much a map from ProcessId to Tensor, with the
-/// map-like API.
-class RendezvousResult {
- public:
-  RendezvousResult(std::map<ProcessId, Tensor> const &result);
-
-  /// Iterates through the (ProcessId, Tensor) map entires and returns a vector
-  /// of Tensors sorted by ProcessId--(replicaId, partitionId) pair--in
-  /// lexicographical order.
-  SmallVector<Tensor> getSortedTensors() const;
-
-  /// Inserts `tensor` into the map using the key `processId`.
-  void insert(ProcessId processId, Tensor tensor);
-
-  /// Iterates through the map and returns the value associated with the key
-  /// `processId`. If key is not found, return an empty `Tensor`.
-  Tensor lookup(ProcessId processId) const;
-
- private:
-  /// Internal map representation of the result of `ProcessGrid::rendezvous`.
-  std::map<ProcessId, Tensor> result_;
-};
-
 /// StableHLO process grid.
 class ProcessGrid {
  public:
@@ -251,10 +246,8 @@ class ProcessGrid {
   /// tensors are accumulated in `RendezvousResult` whose shared pointer is
   /// returned to all callers once the barrier has been reached by all StableHLO
   /// processes.
-  std::shared_ptr<RendezvousResult const> rendezvous(ProcessGroup processGroup,
-                                                     ChannelId channelId,
-                                                     ProcessId processId,
-                                                     const Tensor &operand);
+  RendezvousResult rendezvous(ProcessGroup processGroup, ChannelId channelId,
+                              ProcessId processId, const Tensor &operand);
 
   /// Sends `inputs` to a channel with `channelId`.
   /// The channel with `channelId` is emptied before the receiving process can

--- a/stablehlo/reference/ProcessGrid.h
+++ b/stablehlo/reference/ProcessGrid.h
@@ -49,6 +49,12 @@ struct RendezvousState {
   /// Internal storage used to store data contributed by the processes.
   std::map<ProcessId, Tensor> values;
 
+  /// Flag to check whether all processes have contributed.
+  bool sharingDone;
+
+  /// Count of how many processes have contributed so far.
+  int64_t contributionCount;
+
   /// Shared pointer to the result of `rendezvous`.
   std::shared_ptr<RendezvousResult> result;
 };

--- a/stablehlo/reference/ProcessGrid.h
+++ b/stablehlo/reference/ProcessGrid.h
@@ -53,7 +53,7 @@ struct RendezvousState {
   bool sharingDone;
 
   /// Count of how many processes have contributed so far.
-  int64_t contributionCount;
+  size_t contributionCount;
 
   /// Shared pointer to the result of `rendezvous`.
   std::shared_ptr<RendezvousResult> result;


### PR DESCRIPTION
The PR removes the use of `shared_ptr`s as it complicates the logic of `rendezvous`. Instead of relying on the use count of `shared_ptr`, I've added a variable to track the state separately instead. Now, there is no need to worry about the scope of the `shared_ptr`s and cleaning up resource before exiting.

Thanks @mlevesquedion for sharing code snippets offline to help simplify this!