### PR TITLE
Add CollectiveBroadcastOp to the status tracker

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -61,6 +61,7 @@ one of the following tracking labels.
 | ceil                     | yes           | yes          | yes            | yes             | yes         |
 | cholesky                 | yes           | yes          | yes            | yes             | revisit     |
 | clamp                    | yes           | revisit      | yes            | yes             | yes         |
+| collective_broadcast     | yes           | revisit      | yes            | no              | no          |
 | collective_permute       | yes           | revisit      | yes            | no              | yes         |
 | compare                  | yes           | yes          | yes            | yes             | yes         |
 | complex                  | yes           | yes          | yes            | yes             | yes         |


### PR DESCRIPTION
* Spec: yes, merged through RFC
* Verification: revisit, currently all of the collective ops are marked revisited. Will need to look into the verifications of this category further.
* Type Inference: yes, inferred trivially
* Pretty Printing: no
* Interpreter: no