### PR TITLE
Avoid explicitly constructing compatible attributes in a few places

### DIFF
--- a/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
@@ -831,11 +831,8 @@ struct TransposeOpToTransposeConverter final
     Value emptyTensor =
         getEmptyTensorFor(rewriter, loc, resultTy, op, adaptor.getOperands());
 
-    auto permutation =
-        rewriter.getDenseI64ArrayAttr(llvm::to_vector(op.getPermutation()));
-
     rewriter.replaceOpWithNewOp<linalg::TransposeOp>(
-        op, adaptor.getOperand(), emptyTensor, permutation,
+        op, adaptor.getOperand(), emptyTensor, op.getPermutationAttr(),
         linalg::getPrunedAttributeList(op));
     return success();
   }

--- a/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
+++ b/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
@@ -111,8 +111,7 @@ struct CanonicalizeDynamicBroadcastInDimOpPattern
     if (!op.getType().hasStaticShape())
       return rewriter.notifyMatchFailure(op, "expected static result type");
     rewriter.replaceOpWithNewOp<BroadcastInDimOp>(
-        op, op.getType(), op.getOperand(),
-        rewriter.getDenseI64ArrayAttr(op.getBroadcastDimensions()));
+        op, op.getType(), op.getOperand(), op.getBroadcastDimensionsAttr());
     return success();
   }
 };


### PR DESCRIPTION
Attrs will be implicitly copied. Avoid explicitly constructing the attrs as this introduces a dependency on the type of the attrs, meaning the code will need to be changed if the attrs' type changes.