### PR TITLE
Use reference interpreter to eval ops in refine shapes pass

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -927,6 +927,8 @@ cc_library(
         ":base",
         ":chlo_ops",
         ":interpreter_ops",
+        ":reference_ops",
+        ":reference_tensor",
         ":stablehlo_ops",
         ":stablehlo_ops_inc_gen",
         ":stablehlo_pass_inc_gen",

--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -145,7 +145,7 @@ bool isCompatibleForHloTypeInference(Value shape1, Type tp2) {
 
 LogicalResult matchInts(Value value, SmallVector<int64_t>& result) {
   DenseIntElementsAttr attr;
-  if (!matchPattern(value, m_Constant(&attr))) return failure();
+  if (failed(matchInts(value, attr))) return failure();
   for (auto element : attr.getValues<APInt>()) {
     result.push_back(element.getSExtValue());
   }
@@ -154,7 +154,7 @@ LogicalResult matchInts(Value value, SmallVector<int64_t>& result) {
 
 LogicalResult matchInts(Value value, SmallVector<APSInt>& result) {
   DenseIntElementsAttr attr;
-  if (!matchPattern(value, m_Constant(&attr))) return failure();
+  if (failed(matchInts(value, attr))) return failure();
 
   // Signless types are treated as signed, per StableHLO convention.
   // Unless the type is i1 (which models boolean type from the StableHLO spec),
@@ -171,7 +171,12 @@ LogicalResult matchInts(Value value, SmallVector<APSInt>& result) {
 
 LogicalResult matchInts(Value value) {
   DenseIntElementsAttr attr;
-  return success(/*isSuccess=*/matchPattern(value, m_Constant(&attr)));
+  return matchInts(value, attr);
+}
+
+LogicalResult matchInts(Value value, DenseIntElementsAttr& result) {
+  if (!matchPattern(value, m_Constant(&result))) return failure();
+  return success();
 }
 
 LogicalResult deriveShapeFromOperand(

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -132,6 +132,9 @@ LogicalResult matchInts(Value value, SmallVector<APSInt> &result);
 // that the given argument is indeed a constant tensor with integer values.
 LogicalResult matchInts(Value value);
 
+// Matches a constant tensor with integer values into a dense int elements attr.
+LogicalResult matchInts(Value value, DenseIntElementsAttr &result);
+
 // Shape derivation function that computes the shape of the result based on an
 // operand. For a 2-dimensional input tensor, this produces IR of the form
 //

--- a/stablehlo/tests/stablehlo_refine_shapes.mlir
+++ b/stablehlo/tests/stablehlo_refine_shapes.mlir
@@ -401,7 +401,7 @@ func.func @eval_sign() -> tensor<3xi64> {
   // CHECK-NOT: stablehlo.sign
   // CHECK: [[RESULT:%.*]] = stablehlo.constant dense<[-1, 0, 1]> : tensor<3xi64>
   // CHECK: return [[RESULT]]
-  %0 = stablehlo.constant dense<[-1, 0, 1]> : tensor<3xi64>
+  %0 = stablehlo.constant dense<[-5, 0, 2]> : tensor<3xi64>
   %1 = stablehlo.sign %0 : (tensor<3xi64>) -> tensor<3xi64>
   func.return %1 : tensor<3xi64>
 }


### PR DESCRIPTION
This change removes some duplication between the interpreter and the refine shapes pass. I didn't go all the way (there is still some duplication, e.g. the slice op is reimplemented in the refine shapes pass), because I'm not sure if the purpose of the interpreter is _only_ to be used as a reference, or if we want to use it for passes too.

The implementation in the interpreter is of course more generic than what is needed here, and we likely lose some efficiency due to the type conversions. However, I think reducing duplication is more important.