### PR TITLE
Per-axis specification for `dot-general` and `add`

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -627,22 +627,28 @@ Performs element-wise addition of two tensors `lhs` and `rhs` and produces a
 
 #### Inputs
 
-| Label | Name  | Type                       | Constraints |
-|-------|-------|----------------------------|-------------|
-| (I1)  | `lhs` | tensor or quantized tensor | (C1-C2)     |
-| (I2)  | `rhs` | tensor or quantized tensor | (C1-C2)     |
+| Label | Name  | Type                       | Constraints   |
+|-------|-------|----------------------------|---------------|
+| (I1)  | `lhs` | tensor or quantized tensor | (C1-C4)       |
+| (I2)  | `rhs` | tensor or quantized tensor | (C1-C3), (C5) |
 
 #### Outputs
 
 | Name     | Type                       | Constraints |
 |----------|----------------------------|-------------|
-| `result` | tensor or quantized tensor | (C1-C2)     |
+| `result` | tensor or quantized tensor | (C1-C5)     |
 
 #### Constraints
 
 * (C1) `baseline_type(lhs) = baseline_type(rhs) = baseline_type(result)`.
-* (C2) If the operation uses quantized tensors, then
-  `is_quantized(lhs) and is_quantized(rhs) and is_quantized(result)`.
+* If the operation uses quantized tensors:
+  * (C2) `is_quantized(lhs) and is_quantized(rhs) and is_quantized(result)`.
+  * (C3) `(is_per_axis_quantized(lhs) or is_per_axis_quantized(rhs)) =
+    is_per_axis_quantized(result)`.
+  * (C4) If `is_per_axis_quantized(lhs)`, then `quantization_dimension(lhs) =
+    quantization_dimension(result)`.
+  * (C5) If `is_per_axis_quantized(rhs)`, then `quantization_dimension(rhs) =
+    quantization_dimension(result)`.
 
 #### Examples
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -629,25 +629,28 @@ Performs element-wise addition of two tensors `lhs` and `rhs` and produces a
 
 | Label | Name  | Type                       | Constraints   |
 |-------|-------|----------------------------|---------------|
-| (I1)  | `lhs` | tensor or quantized tensor | (C1-C4)       |
-| (I2)  | `rhs` | tensor or quantized tensor | (C1-C3), (C5) |
+| (I1)  | `lhs` | tensor or quantized tensor | (C1-C6)       |
+| (I2)  | `rhs` | tensor or quantized tensor | (C1-C5), (C7) |
 
 #### Outputs
 
 | Name     | Type                       | Constraints |
 |----------|----------------------------|-------------|
-| `result` | tensor or quantized tensor | (C1-C5)     |
+| `result` | tensor or quantized tensor | (C1-C7)     |
 
 #### Constraints
 
-* (C1) `baseline_type(lhs) = baseline_type(rhs) = baseline_type(result)`.
+* If the operation uses non-quantized tensors:
+  * (C1) `type(lhs) = type(rhs) = type(result)`.
 * If the operation uses quantized tensors:
   * (C2) `is_quantized(lhs) and is_quantized(rhs) and is_quantized(result)`.
-  * (C3) `(is_per_axis_quantized(lhs) or is_per_axis_quantized(rhs)) =
+  * (C3) `storage_type(lhs) = storage_type(rhs) = storage_type(result)`.
+  * (C4) `expressed_type(lhs) = expressed_type(rhs) = expressed_type(result)`.
+  * (C5) `(is_per_axis_quantized(lhs) or is_per_axis_quantized(rhs)) =
     is_per_axis_quantized(result)`.
-  * (C4) If `is_per_axis_quantized(lhs)`, then `quantization_dimension(lhs) =
+  * (C6) If `is_per_axis_quantized(lhs)`, then `quantization_dimension(lhs) =
     quantization_dimension(result)`.
-  * (C5) If `is_per_axis_quantized(rhs)`, then `quantization_dimension(rhs) =
+  * (C7) If `is_per_axis_quantized(rhs)`, then `quantization_dimension(rhs) =
     quantization_dimension(result)`.
 
 #### Examples

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -627,20 +627,22 @@ Performs element-wise addition of two tensors `lhs` and `rhs` and produces a
 
 #### Inputs
 
-| Label | Name  | Type                                  | Constraints |
-|-------|-------|---------------------------------------|-------------|
-| (I1)  | `lhs` | tensor or per-tensor quantized tensor | (C1)        |
-| (I2)  | `rhs` | tensor or per-tensor quantized tensor | (C1)        |
+| Label | Name  | Type                       | Constraints |
+|-------|-------|----------------------------|-------------|
+| (I1)  | `lhs` | tensor or quantized tensor | (C1-C2)     |
+| (I2)  | `rhs` | tensor or quantized tensor | (C1-C2)     |
 
 #### Outputs
 
-| Name     | Type                                  | Constraints |
-|----------|---------------------------------------|-------------|
-| `result` | tensor or per-tensor quantized tensor | (C1)        |
+| Name     | Type                       | Constraints |
+|----------|----------------------------|-------------|
+| `result` | tensor or quantized tensor | (C1-C2)     |
 
 #### Constraints
 
 * (C1) `baseline_type(lhs) = baseline_type(rhs) = baseline_type(result)`.
+* (C2) If the operation uses quantized tensors, then
+  `is_quantized(lhs) and is_quantized(rhs) and is_quantized(result)`.
 
 #### Examples
 
@@ -2477,21 +2479,21 @@ planning to address this in
 
 #### Inputs
 
-| Label | Name                         | Type                                                         | Constraints                   |
-|-------|------------------------------|--------------------------------------------------------------|-------------------------------|
-| (I1)  | `lhs`                        | tensor or per-tensor quantized tensor                        | (C5-C6), (C9-C10), (C12-C16)  |
-| (I2)  | `rhs`                        | tensor or per-tensor quantized tensor                        | (C7-C10), (C12)               |
-| (I3)  | `lhs_batching_dimensions`    | 1-dimensional tensor constant of type `si64`                 | (C1), (C3), (C5), (C9), (C12) |
-| (I4)  | `rhs_batching_dimensions`    | 1-dimensional tensor constant of type `si64`                 | (C1), (C4), (C7), (C9)        |
-| (I5)  | `lhs_contracting_dimensions` | 1-dimensional tensor constant of type `si64`                 | (C2), (C3), (C6), (C10)       |
-| (I6)  | `rhs_contracting_dimensions` | 1-dimensional tensor constant of type `si64`                 | (C2), (C4), (C8), (C10)       |
-| (I7)  | `precision_config`           | variadic number of enums of `DEFAULT`, `HIGH`, and `HIGHEST` | (C11)                         |
+| Label | Name                         | Type                                                         | Constraints                    |
+|-------|------------------------------|--------------------------------------------------------------|--------------------------------|
+| (I1)  | `lhs`                        | tensor or per-tensor quantized tensor                        | (C5-C6), (C9-C10), (C12-C16)   |
+| (I2)  | `rhs`                        | tensor or quantized tensor                                   | (C7-C10), (C12), (C18-C19)     |
+| (I3)  | `lhs_batching_dimensions`    | 1-dimensional tensor constant of type `si64`                 | (C1), (C3), (C5), (C9), (C12)  |
+| (I4)  | `rhs_batching_dimensions`    | 1-dimensional tensor constant of type `si64`                 | (C1), (C4), (C7), (C9)         |
+| (I5)  | `lhs_contracting_dimensions` | 1-dimensional tensor constant of type `si64`                 | (C2), (C3), (C6), (C10)        |
+| (I6)  | `rhs_contracting_dimensions` | 1-dimensional tensor constant of type `si64`                 | (C2), (C4), (C8), (C10), (C19) |
+| (I7)  | `precision_config`           | variadic number of enums of `DEFAULT`, `HIGH`, and `HIGHEST` | (C11)                          |
 
 #### Outputs
 
-| Name     | Type                                  | Constraints         |
-|----------|---------------------------------------|---------------------|
-| `result` | tensor or per-tensor quantized tensor | (C12), (C14), (C16) |
+| Name     | Type                       | Constraints                |
+|----------|----------------------------|----------------------------|
+| `result` | tensor or quantized tensor | (C12), (C14), (C16), (C18) |
 
 #### Constraints
 
@@ -2518,6 +2520,10 @@ planning to address this in
   * (C15) `storage_type(lhs) = storage_type(rhs)`.
   * (C16) `expressed_type(lhs) = expressed_type(rhs) = expressed_type(result)`.
   * (C17) `zero_points(rhs) = 0`.
+  * (C18) If `is_per_tensor_quantized(rhs)`, then
+    `is_per_tensor_quantized(result)`.
+  * (C19) If `is_per_axis_quantized(rhs)`, then
+    `quantization_dimension(rhs)` not in `rhs_contracting_dimensions`.
 
 #### Examples
 


### PR DESCRIPTION
closes https://github.com/openxla/stablehlo/issues/1574
The PR implement the spec changes to support per-axis quantization scheme for `add` and `dot_general` ops. Here is the rationale for the support:

  - For `add` op:  Used for bias addition following convolution. Bias and [convolution op](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#semantics-25) outputs can  both be per-axis quantized and have the same shape, and same quantization parameters, but current `stablehlo.add` only support per-tensor quantized scheme. [Relevant dicussion](https://github.com/openxla/stablehlo/issues/1574#issuecomment-1659466321)
  - For `dot_general`:  Some uses cases of quantized models requires  support for a mixed quantization scheme where it accepts per-tensor quantized `lhs` and per-axis quantized `rhs`. The quantization schemes (per-axis/per-tensor) proposed for `dot_general` op is similar to the convolution. [Relevant discussion](https://github.com/openxla/stablehlo/issues/1574#issuecomment-1676914854)
     - We do not expect the the contracting dimension `rhs_contracting_dimensions` to include the `quantization dimension(rhs)`. The multiply-accumulation step for dot_general iterate over the elements along the contracting dimensions. Having a uniform quantization parameters (scales and zero-points) for those elements allows full-integer computations (refer to section 2.2. of https://arxiv.org/pdf/1712.05877.pdf). However, if the quantization parameters are different within the  contracting dimensions, which is what will happen if we allow `quantization_dimension(rhs)` to be in `rhs_contracting_dimensions`, then the computation must rescale integers (or dequantize) while doing multiply-accumulation which is not desirable. 



Looking forward to feedback!
cc @dansuh17, @loganchien, @rewu93, @dominicsymes
