### PR TITLE
Add interpreter for ConvolutionOp

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2317,15 +2317,17 @@ For quantized types, performs `dequantize_op_quantize(
   // "i" is input feature dimension, "o" is output feature dimension,
   // "0/1/etc" are spatial dimensions.
   dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f]>,
-  feature_group_count = 1 : i64,
   batch_group_count = 1 : i64,
+  feature_group_count = 1 : i64,
   precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
-} : (tensor<1x4x4x1xi32>, tensor<3x3x1x1xi32>) -> tensor<1x2x2x1xi32>
+} : (tensor<1x4x4x1xi64>, tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64>
 // %result: [[
 //            [[10], [26]],
 //            [[46], [62]]
 //          ]]
 ```
+
+&nbsp;[More Examples](../stablehlo/tests/interpret/convolution.mlir)
 
 ### cosine
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -70,7 +70,7 @@ one of the following tracking labels.
 | concatenate              | yes           | yes          | yes            | yes             | yes         |
 | constant                 | yes           | yes          | yes            | yes             | yes         |
 | convert                  | yes           | yes          | infeasible     | yes             | yes         |
-| convolution              | yes           | yes          | infeasible     | revisit         | no          |
+| convolution              | yes           | yes          | infeasible     | revisit         | yes         |
 | cosine                   | yes           | yes          | yes            | yes             | yes         |
 | count_leading_zeros      | yes           | yes          | yes            | yes             | yes         |
 | create_token             | no            | yes\*        | yes\*          | yes             | revisit     |

--- a/stablehlo/reference/Index.cpp
+++ b/stablehlo/reference/Index.cpp
@@ -44,14 +44,14 @@ bool Sizes::inBounds(const Sizes &bounds) const {
 
 IndexSpaceIterator Sizes::index_begin() const {
   if (any_of(*this, [](int64_t dimSize) { return dimSize == 0; }))
-    return IndexSpaceIterator(*this, std::nullopt);
+    return IndexSpaceIterator(*this);
 
   Index initialIndex(size());
   return IndexSpaceIterator(*this, initialIndex);
 }
 
 IndexSpaceIterator Sizes::index_end() const {
-  return IndexSpaceIterator(*this, std::nullopt);
+  return IndexSpaceIterator(*this);
 }
 
 Sizes operator+(const Sizes &x, const Sizes &y) {

--- a/stablehlo/reference/Index.h
+++ b/stablehlo/reference/Index.h
@@ -121,6 +121,8 @@ using Index = Sizes;
 class IndexSpaceIterator {
  public:
   /// \name Constructor
+  IndexSpaceIterator(Sizes shape) : shape_(shape) { index_ = std::nullopt; }
+
   IndexSpaceIterator(Sizes shape, std::optional<Index> index)
       : shape_(shape), index_(index) {
     if (index && !index->inBounds(shape)) index_ = std::nullopt;

--- a/stablehlo/reference/Index.h
+++ b/stablehlo/reference/Index.h
@@ -124,8 +124,8 @@ class IndexSpaceIterator {
   IndexSpaceIterator(Sizes shape) : shape_(shape) { index_ = std::nullopt; }
 
   IndexSpaceIterator(Sizes shape, std::optional<Index> index)
-      : shape_(shape), index_(index) {
-    if (index && !index->inBounds(shape)) index_ = std::nullopt;
+      : shape_(shape), index_(std::nullopt) {
+    if (index && index->inBounds(shape)) index_ = index;
   }
 
   /// Get the current index.

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -54,6 +54,27 @@ Index evalIndex(Tensor tensor) {
   return result;
 }
 
+Tensor evalDotGeneralOp(const Tensor &lhs, const Tensor &rhs,
+                        const Axes &lhsBatchingDimensions,
+                        const Axes &rhsBatchingDimensions,
+                        const Axes &lhsContractingDimensions,
+                        const Axes &rhsContractingDimensions) {
+  SmallVector<ShapedTypeComponents> inferredDotGeneralType;
+  if (failed(hlo::inferDotGeneralOp(
+          /*location=*/{}, lhs.getType(), rhs.getType(),
+          /*lhsBatchingDimensions=*/{}, /*rhsBatchingDimensions*/ {},
+          lhsContractingDimensions, rhsContractingDimensions,
+          /*precisionConfig=*/{}, inferredDotGeneralType)))
+    report_fatal_error(
+        invalidArgument("Could not infer DotGeneralOp's return type"));
+
+  return evalDotGeneralOp(
+      lhs, rhs, lhsBatchingDimensions, rhsBatchingDimensions,
+      lhsContractingDimensions, rhsContractingDimensions,
+      RankedTensorType::get(inferredDotGeneralType[0].getDims(),
+                            lhs.getElementType()));
+}
+
 Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
                  const Sizes &edgePaddingLow, const Sizes &edgePaddingHigh,
                  const Sizes &interiorPadding) {
@@ -143,6 +164,12 @@ Tensor evalSliceOp(const Tensor &operand, const Index &index) {
   return evalSliceOp(operand, start, limit, strides);
 }
 
+Sizes extractElements(ArrayRef<int64_t> arr, ArrayRef<int64_t> indices) {
+  Sizes elements;
+  for (int64_t index : indices) elements.push_back(arr[index]);
+  return elements;
+}
+
 void failOnDecomposableOp(Operation &op) {
   report_fatal_error(invalidArgument(
       "Operation %s is unsupported at the moment. "
@@ -151,6 +178,13 @@ void failOnDecomposableOp(Operation &op) {
       "Visit https://github.com/openxla/stablehlo/issues/1571 to learn more "
       "about the workaround and the roadmap for supporting this operation.",
       op.getName().getStringRef().str().c_str()));
+}
+
+template <typename T>
+DenseIntElementsAttr getDenseIntElementsAttr(Type elementType, T values,
+                                             SmallVector<int64_t> valuesShape) {
+  return DenseIntElementsAttr::get(
+      RankedTensorType::get(valuesShape, elementType), values);
 }
 
 SmallVector<SmallVector<uint32_t>> getReplicaGroups(
@@ -166,6 +200,65 @@ SmallVector<SmallVector<uint32_t>> getReplicaGroups(
     }
   }
   return replicaGroups;
+}
+
+Tensor evalConvolutionOp(
+    const Tensor &lhs, const Tensor &rhs, ArrayRef<int64_t> windowStrides,
+    ArrayRef<std::pair<int64_t, int64_t>> padding,
+    ArrayRef<int64_t> lhsDilation, ArrayRef<int64_t> rhsDilation,
+    ArrayRef<bool> windowReversal, Axis inputBatchDimension,
+    Axis inputFeatureDimension, const Axes &inputSpatialDimensions,
+    Axis kernelInputFeatureDimension, Axis kernelOutputFeatureDimension,
+    const Axes &kernelSpatialDimensions, Axis outputBatchDimension,
+    Axis outputFeatureDimension, const Axes &outputSpatialDimensions,
+    int64_t featureGroupCount, int64_t batchGroupCount,
+    std::optional<ArrayAttr> precisionConfig, ShapedType resultType) {
+  SmallVector<int64_t> paddingVector;
+  for (auto pair : padding) {
+    paddingVector.push_back(pair.first);
+    paddingVector.push_back(pair.second);
+  }
+
+  SmallVector<ShapedTypeComponents> inferredConvolutionType;
+  if (failed(hlo::inferConvolutionOp(
+          /*location=*/{}, lhs.getType(), rhs.getType(), windowStrides,
+          /*padding=*/
+          getDenseIntElementsAttr(
+              IntegerType::get(lhs.getType().getContext(), 64), paddingVector,
+              SmallVector<int64_t>(padding.size(), 2)),
+          lhsDilation, rhsDilation, windowReversal, inputBatchDimension,
+          inputFeatureDimension, ArrayRef<int64_t>(inputSpatialDimensions),
+          kernelInputFeatureDimension, kernelOutputFeatureDimension,
+          ArrayRef<int64_t>(kernelSpatialDimensions), outputBatchDimension,
+          outputFeatureDimension, ArrayRef<int64_t>(outputSpatialDimensions),
+          /*featureGroupCount=*/1, batchGroupCount,
+          /*precisionConfig=*/{}, inferredConvolutionType)))
+    report_fatal_error(
+        invalidArgument("Could not infer ConvolutionOp's return type"));
+
+  return evalConvolutionOp(
+      lhs, rhs, windowStrides, padding, lhsDilation, rhsDilation,
+      windowReversal, inputBatchDimension, inputFeatureDimension,
+      inputSpatialDimensions, kernelInputFeatureDimension,
+      kernelOutputFeatureDimension, kernelSpatialDimensions,
+      outputBatchDimension, outputFeatureDimension, outputSpatialDimensions,
+      featureGroupCount, batchGroupCount,
+      RankedTensorType::get(inferredConvolutionType[0].getDims(),
+                            resultType.getElementType()));
+}
+
+// Returns `result` with the effect of applying `permutation`
+// (= [dimA] + dimsB + [dimC]) to `input` (= [n] + hw + [c]) such that
+// result[permutation[i]] = input[i].
+template <typename T>
+SmallVector<T> concatAndPermute(T n, SmallVector<T> hw, T c,
+                                const Axes &permutation) {
+  SmallVector<T> result(permutation.size());
+  result[permutation[0]] = n;
+  result[permutation[permutation.size() - 1]] = c;
+  for (uint64_t i = 1; i < permutation.size() - 1; ++i)
+    result[permutation[i]] = hw[i - 1];
+  return result;
 }
 
 Tensor constant(Element initValue) {
@@ -420,6 +513,52 @@ SmallVector<InterpreterValue> eval(Region &region,
       auto operand = scope.findTensor(convertOp.getOperand());
       auto result = evalConvertOp(operand, convertOp.getType());
       scope.add(convertOp.getResult(), result);
+    } else if (auto convolutionOp = dyn_cast<ConvolutionOp>(op)) {
+      auto lhs = scope.findTensor(convolutionOp.getLhs());
+      auto rhs = scope.findTensor(convolutionOp.getRhs());
+      auto rank = lhs.getRank();
+
+      SmallVector<int64_t> windowStrides(rank - 2, 1);
+      if (auto windowStridesAttr = convolutionOp.getWindowStridesAttr())
+        windowStrides = SmallVector<int64_t>(windowStridesAttr.asArrayRef());
+
+      SmallVector<std::pair<int64_t, int64_t>> padding(rank - 2, {0, 0});
+      if (auto paddingAttr = convolutionOp.getPaddingAttr()) {
+        auto paddingOrErr = hlo::convertPaddingAttribute(paddingAttr, {});
+        if (failed(paddingOrErr))
+          report_fatal_error(invalidArgument("Invalid padding format found."));
+        padding = *paddingOrErr;
+      }
+
+      SmallVector<int64_t> lhsDilation(rank - 2, 1);
+      if (auto lhsDilationAttr = convolutionOp.getLhsDilationAttr())
+        lhsDilation = SmallVector<int64_t>(lhsDilationAttr.asArrayRef());
+
+      SmallVector<int64_t> rhsDilation(rank - 2, 1);
+      if (auto rhsDilationAttr = convolutionOp.getRhsDilationAttr())
+        rhsDilation = SmallVector<int64_t>(rhsDilationAttr.asArrayRef());
+
+      SmallVector<bool> windowReversal(rank - 2, false);
+      if (auto windowReversalAttr = convolutionOp.getWindowReversalAttr())
+        windowReversal = SmallVector<bool>(windowReversalAttr.asArrayRef());
+
+      auto result = evalConvolutionOp(
+          lhs, rhs, windowStrides, padding, lhsDilation, rhsDilation,
+          windowReversal,
+          convolutionOp.getDimensionNumbers().getInputBatchDimension(),
+          convolutionOp.getDimensionNumbers().getInputFeatureDimension(),
+          Axes(convolutionOp.getDimensionNumbers().getInputSpatialDimensions()),
+          convolutionOp.getDimensionNumbers().getKernelInputFeatureDimension(),
+          convolutionOp.getDimensionNumbers().getKernelOutputFeatureDimension(),
+          Axes(
+              convolutionOp.getDimensionNumbers().getKernelSpatialDimensions()),
+          convolutionOp.getDimensionNumbers().getOutputBatchDimension(),
+          convolutionOp.getDimensionNumbers().getOutputFeatureDimension(),
+          Axes(
+              convolutionOp.getDimensionNumbers().getOutputSpatialDimensions()),
+          convolutionOp.getFeatureGroupCount(),
+          convolutionOp.getBatchGroupCount(), convolutionOp.getType());
+      scope.add(convolutionOp.getResult(), result);
     } else if (auto cosineOp = dyn_cast<CosineOp>(op)) {
       auto operand = scope.findTensor(cosineOp.getOperand());
       auto result = evalCosineOp(operand, cosineOp.getType());
@@ -1234,6 +1373,151 @@ Tensor evalConvertOp(const Tensor &operand, ShapedType resultType) {
   Tensor result(resultType);
   for (auto it = result.index_begin(); it != result.index_end(); ++it)
     result.set(*it, convert(result.getElementType(), operand.get(*it)));
+  return result;
+}
+
+Tensor evalConvolutionOp(
+    const Tensor &lhs, const Tensor &rhs, ArrayRef<int64_t> windowStrides,
+    ArrayRef<std::pair<int64_t, int64_t>> padding,
+    ArrayRef<int64_t> lhsDilation, ArrayRef<int64_t> rhsDilation,
+    ArrayRef<bool> windowReversal, Axis inputBatchDimension,
+    Axis inputFeatureDimension, const Axes &inputSpatialDimensions,
+    Axis kernelInputFeatureDimension, Axis kernelOutputFeatureDimension,
+    const Axes &kernelSpatialDimensions, Axis outputBatchDimension,
+    Axis outputFeatureDimension, const Axes &outputSpatialDimensions,
+    int64_t featureGroupCount, int64_t batchGroupCount, ShapedType resultType) {
+  Tensor result(resultType);
+
+  if (featureGroupCount > 1) {
+    auto lhses = split(lhs, featureGroupCount, inputFeatureDimension,
+                       resultType.getContext());
+    auto rhses = split(rhs, featureGroupCount, kernelOutputFeatureDimension,
+                       resultType.getContext());
+    SmallVector<Tensor> results;
+    for (auto [left, right] : llvm::zip(lhses, rhses))
+      results.push_back(evalConvolutionOp(
+          left, right, windowStrides, padding, lhsDilation, rhsDilation,
+          windowReversal, inputBatchDimension, inputFeatureDimension,
+          inputSpatialDimensions, kernelInputFeatureDimension,
+          kernelOutputFeatureDimension, kernelSpatialDimensions,
+          outputBatchDimension, outputFeatureDimension, outputSpatialDimensions,
+          /*featureGroupCount=*/1, batchGroupCount, /*precisionConfig=*/{},
+          resultType));
+
+    return evalConcatenateOp(results, outputFeatureDimension, result.getType());
+  }
+
+  if (batchGroupCount > 1) {
+    auto lhses = split(lhs, batchGroupCount, inputBatchDimension,
+                       resultType.getContext());
+    auto rhses = split(rhs, batchGroupCount, kernelOutputFeatureDimension,
+                       resultType.getContext());
+    SmallVector<Tensor> results;
+    for (auto [left, right] : llvm::zip(lhses, rhses))
+      results.push_back(evalConvolutionOp(
+          left, right, windowStrides, padding, lhsDilation, rhsDilation,
+          windowReversal, inputBatchDimension, inputFeatureDimension,
+          inputSpatialDimensions, kernelInputFeatureDimension,
+          kernelOutputFeatureDimension, kernelSpatialDimensions,
+          outputBatchDimension, outputFeatureDimension, outputSpatialDimensions,
+          featureGroupCount, /*batchGroupCount=*/1, /*precisionConfig=*/{},
+          resultType));
+
+    return evalConcatenateOp(results, outputFeatureDimension, result.getType());
+  }
+
+  Axes lhsPermutation;
+  lhsPermutation.push_back(inputBatchDimension);
+  lhsPermutation.append(inputSpatialDimensions.begin(),
+                        inputSpatialDimensions.end());
+  lhsPermutation.push_back(inputFeatureDimension);
+
+  auto lhsWindowDimensions =
+      concatAndPermute(lhs.getShape()[inputBatchDimension],
+                       extractElements(rhs.getShape(), kernelSpatialDimensions),
+                       lhs.getShape()[inputFeatureDimension], lhsPermutation);
+
+  auto lhsWindowStrides =
+      concatAndPermute(1L, llvm::to_vector(windowStrides), 1L, lhsPermutation);
+
+  auto lhsBaseDilations =
+      concatAndPermute(0L, Sizes(lhsDilation) - 1, 0L, lhsPermutation);
+
+  auto lhsWindowDilations =
+      concatAndPermute(1L, llvm::to_vector(rhsDilation), 1L, lhsPermutation);
+
+  Sizes lhsPaddingLow, lhsPaddingHigh;
+  for (auto paddingPair : concatAndPermute({0, 0}, llvm::to_vector(padding),
+                                           {0, 0}, lhsPermutation)) {
+    lhsPaddingLow.push_back(paddingPair.first);
+    lhsPaddingHigh.push_back(paddingPair.second);
+  }
+
+  auto paddingValue = makeScalar(convert(result.getElementType(), 0.0));
+  auto paddedLhs = evalPadOp(lhs, paddingValue, lhsPaddingLow, lhsPaddingHigh,
+                             Sizes(lhsBaseDilations));
+
+  IndexSpaceIterator outputSpatialIndexIt(
+      extractElements(result.getShape(), outputSpatialDimensions),
+      Index(outputSpatialDimensions.size()));
+  IndexSpaceIterator outputSpatialIndexItEnd(
+      extractElements(result.getShape(), outputSpatialDimensions));
+  for (; outputSpatialIndexIt != outputSpatialIndexItEnd;
+       ++outputSpatialIndexIt) {
+    Sizes lhsWindowStart;
+    for (auto [i, offset] : llvm::enumerate(
+             concatAndPermute(0L, *outputSpatialIndexIt, 0L, lhsPermutation)))
+      lhsWindowStart.push_back(lhsWindowStrides[i] * offset);
+
+    Sizes limitIndices;
+    for (size_t i = 0; i < lhsWindowStart.size(); ++i)
+      limitIndices.push_back(std::min(
+          lhsWindowStart[i] + lhsWindowDimensions[i] * lhsWindowDilations[i],
+          paddedLhs.getShape()[i]));
+
+    auto lhsWindow = evalSliceOp(paddedLhs, lhsWindowStart, limitIndices,
+                                 Sizes(lhsWindowDilations));
+
+    Axes reverseDims;
+    for (auto [i, isReverse] : llvm::enumerate(windowReversal))
+      if (isReverse) reverseDims.push_back(inputSpatialDimensions[i]);
+    auto reversedLhsWindow =
+        evalReverseOp(lhsWindow, reverseDims, lhsWindow.getType());
+
+    Axes lhsContractingDimensions(inputSpatialDimensions);
+    lhsContractingDimensions.push_back(inputFeatureDimension);
+
+    Axes rhsContractingDimensions(kernelSpatialDimensions);
+    rhsContractingDimensions.push_back(kernelInputFeatureDimension);
+
+    auto dotProduct =
+        evalDotGeneralOp(reversedLhsWindow, rhs, /*lhsBatchingDimensions=*/{},
+                         /*rhsBatchingDimensions=*/{}, lhsContractingDimensions,
+                         rhsContractingDimensions);
+
+    Sizes resultNonSpatialDims;
+    for (auto i = 0; i < result.getRank(); ++i)
+      if (llvm::find(outputSpatialDimensions, i) ==
+          outputSpatialDimensions.end())
+        resultNonSpatialDims.push_back(result.getShape()[i]);
+
+    Axes resultPermutation;
+    resultPermutation.push_back(outputBatchDimension);
+    resultPermutation.append(outputSpatialDimensions.begin(),
+                             outputSpatialDimensions.end());
+    resultPermutation.push_back(outputFeatureDimension);
+
+    IndexSpaceIterator resultNonSpatialIt(resultNonSpatialDims,
+                                          Index(resultNonSpatialDims.size()));
+    for (auto dotProductIt = dotProduct.index_begin();
+         dotProductIt != dotProduct.index_end();
+         ++dotProductIt, ++resultNonSpatialIt) {
+      Index resultIndex(
+          concatAndPermute((*resultNonSpatialIt)[0], *outputSpatialIndexIt,
+                           (*resultNonSpatialIt)[1], resultPermutation));
+      result.set(resultIndex, dotProduct.get(*dotProductIt));
+    }
+  }
   return result;
 }
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -55,8 +55,6 @@ Index evalIndex(Tensor tensor) {
 }
 
 Tensor evalDotGeneralOp(const Tensor &lhs, const Tensor &rhs,
-                        const Axes &lhsBatchingDimensions,
-                        const Axes &rhsBatchingDimensions,
                         const Axes &lhsContractingDimensions,
                         const Axes &rhsContractingDimensions) {
   SmallVector<ShapedTypeComponents> inferredDotGeneralType;
@@ -69,7 +67,7 @@ Tensor evalDotGeneralOp(const Tensor &lhs, const Tensor &rhs,
         invalidArgument("Could not infer DotGeneralOp's return type"));
 
   return evalDotGeneralOp(
-      lhs, rhs, lhsBatchingDimensions, rhsBatchingDimensions,
+      lhs, rhs, /*lhsBatchingDimensions=*/{}, /*rhsBatchingDimensions*/ {},
       lhsContractingDimensions, rhsContractingDimensions,
       RankedTensorType::get(inferredDotGeneralType[0].getDims(),
                             lhs.getElementType()));
@@ -1489,8 +1487,7 @@ Tensor evalConvolutionOp(
     rhsContractingDimensions.push_back(kernelInputFeatureDimension);
 
     auto dotProduct =
-        evalDotGeneralOp(reversedLhsWindow, rhs, /*lhsBatchingDimensions=*/{},
-                         /*rhsBatchingDimensions=*/{}, lhsContractingDimensions,
+        evalDotGeneralOp(reversedLhsWindow, rhs, lhsContractingDimensions,
                          rhsContractingDimensions);
 
     Sizes resultNonSpatialDims;

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -77,6 +77,16 @@ Tensor evalConcatenateOp(ArrayRef<Tensor> inputs, Axis dimension,
                          ShapedType resultType);
 Tensor evalConstantOp(ElementsAttr value);
 Tensor evalConvertOp(const Tensor &operand, ShapedType resultType);
+Tensor evalConvolutionOp(
+    const Tensor &lhs, const Tensor &rhs, ArrayRef<int64_t> windowStrides,
+    ArrayRef<std::pair<int64_t, int64_t>> padding,
+    ArrayRef<int64_t> lhsDilation, ArrayRef<int64_t> rhsDilation,
+    ArrayRef<bool> windowReversal, Axis inputBatchDimension,
+    Axis inputFeatureDimension, const Axes &inputSpatialDimensions,
+    Axis kernelInputFeatureDimension, Axis kernelOutputFeatureDimension,
+    const Axes &kernelSpatialDimensions, Axis outputBatchDimension,
+    Axis outputFeatureDimension, const Axes &outputSpatialDimensions,
+    int64_t featureGroupCount, int64_t batchGroupCount, ShapedType resultType);
 Tensor evalCosineOp(const Tensor &operand, ShapedType resultType);
 Tensor evalDivideOp(const Tensor &lhs, const Tensor &rhs,
                     ShapedType resultType);

--- a/stablehlo/tests/interpret/convolution.mlir
+++ b/stablehlo/tests/interpret/convolution.mlir
@@ -54,7 +54,7 @@ func.func @convolution_batch_group_count_4() {
 
 // -----
 
-func.func @convolution_feature_group_count_4() {
+func.func @convolution_feature_group_count_2() {
   %lhs = stablehlo.constant dense<[[
                                     [[1], [2], [5], [6]],
                                     [[3], [4], [7], [8]],

--- a/stablehlo/tests/interpret_convolution.mlir
+++ b/stablehlo/tests/interpret_convolution.mlir
@@ -1,0 +1,79 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @convolution_op_test_si64() {
+  %lhs = stablehlo.constant dense<[[
+                                    [[1], [2], [5], [6]],
+                                    [[3], [4], [7], [8]],
+                                    [[10], [11], [14], [15]],
+                                    [[12], [13], [16], [17]]
+                                  ]]> : tensor<1x4x4x1xi64>
+  %rhs = stablehlo.constant dense<1> : tensor<3x3x1x1xi64>
+  %result = stablehlo.convolution(%lhs, %rhs)
+    dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+    window = {
+      stride = [4, 4],
+      lhs_dilate = [2, 2]
+    } {
+      batch_group_count = 1 : i64,
+      feature_group_count = 1 : i64,
+      precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+    }
+  : (tensor<1x4x4x1xi64>, tensor<3x3x1x1xi64>) -> tensor<1x2x2x1xi64>
+  check.expect_eq_const %result, dense<[[
+                                          [[10], [26]],
+                                          [[46], [62]]
+                                        ]]> : tensor<1x2x2x1xi64>
+  func.return
+}
+
+// -----
+
+func.func @convolution_batch_group_count_4() {
+  %lhs = stablehlo.constant dense<[[
+                                    [[1], [2], [5], [6]],
+                                    [[3], [4], [7], [8]],
+                                    [[10], [11], [14], [15]],
+                                    [[12], [13], [16], [17]]
+                                  ]]> : tensor<1x4x4x1xi64>
+  %rhs = stablehlo.constant dense<1> : tensor<1x2x1x4xi64>
+  %result = stablehlo.convolution(%lhs, %rhs)
+    dim_numbers = [0, b, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+    window = {
+      stride = [4, 4],
+      lhs_dilate = [2, 2]
+    } {
+      batch_group_count = 4 : i64,
+      feature_group_count = 1 : i64,
+      precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+    }
+  : (tensor<1x4x4x1xi64>, tensor<1x2x1x4xi64>) -> tensor<1x1x2x4xi64>
+  check.expect_eq_const %result, dense<[[[[1, 3, 10, 12],
+                                          [5, 7, 14, 16]]]]> : tensor<1x1x2x4xi64>
+  func.return
+}
+
+// -----
+
+func.func @convolution_feature_group_count_4() {
+  %lhs = stablehlo.constant dense<[[
+                                    [[1], [2], [5], [6]],
+                                    [[3], [4], [7], [8]],
+                                    [[10], [11], [14], [15]],
+                                    [[12], [13], [16], [17]]
+                                  ]]> : tensor<1x4x4x1xi64>
+  %rhs = stablehlo.constant dense<1> : tensor<1x2x1x4xi64>
+  %result = stablehlo.convolution(%lhs, %rhs)
+    dim_numbers = [b, 0, f, 1]x[0, i, 1, o]->[b, 0, 1, f],
+    window = {
+      stride = [4, 4],
+      lhs_dilate = [2, 2]
+    } {
+      batch_group_count = 1 : i64,
+      feature_group_count = 2 : i64,
+      precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+    }
+  : (tensor<1x4x4x1xi64>, tensor<1x2x1x4xi64>) -> tensor<1x2x1x4xi64>
+  check.expect_eq_const %result, dense<[[[[3, 3, 11, 11]],
+                                         [[21, 21, 29, 29]]]]> : tensor<1x2x1x4xi64>
+  func.return
+}


### PR DESCRIPTION
Since the interpreter implementation is already a mouthful, I've split #1314 to separate the implementation from the remaining checklist items. Once this is merged, I'll work on the remaining to update the rest of the docs.

closes #970 