### PR TITLE
Add custom builder to reduce op allowing type inference

### DIFF
--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1476,6 +1476,14 @@ def StableHLO_ReduceOp: StableHLO_ShapedInterfaceOp<"reduce", [
   );
   let regions = (region SizedRegion<1>:$body /*reduce_i4*/);
 
+  // Builder
+  // The following custom builder allows inferring the operation type using the
+  // 'element_types' of the arguments of the 'body'.
+  let builders = [
+    OpBuilder<(ins "ValueRange":$inputs, "ValueRange":$init_values,
+      "DenseIntElementsAttr":$dimensions, "TypeRange":$element_types)>,
+  ];
+
   let results = (outs Variadic<HLO_Tensor>);
 
   let hasCustomAssemblyFormat = 1;

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1481,7 +1481,7 @@ def StableHLO_ReduceOp: StableHLO_ShapedInterfaceOp<"reduce", [
   // 'element_types' of the arguments of the 'body'.
   let builders = [
     OpBuilder<(ins "ValueRange":$inputs, "ValueRange":$init_values,
-      "DenseIntElementsAttr":$dimensions, "TypeRange":$element_types)>,
+      "DenseI64ArrayAttr":$dimensions, "TypeRange":$element_types)>,
   ];
 
   let results = (outs Variadic<HLO_Tensor>);


### PR DESCRIPTION
The PR implements the a custom `reduce` op builder similar to what we have for mhlo [code](https://github.com/openxla/xla/blob/50aec2b3b54ce7a861f45bc3b0ae9b2cc2ee2a28/xla/mlir_hlo/mhlo/IR/hlo_ops.cc#L3917). 

## Background
https://github.com/openxla/stablehlo/pull/1869 allows the block arguments of reduce op to have different element types than that of the input arguments of reduce op and the output element type of the reduce op has to equal to those block arguments. As a consequence the output type of reduce op can no longer be inferred from the operand types. The auto-generated builders creates a reduce op with empty block and, as  a result, does not allow inferring the type.

The proposed solution is to create a custom builder which takes the element-type of the block arguments as arguments allowing result type inference.