### PR TITLE
Perform initialization in pass initialize method

### DIFF
--- a/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
@@ -2573,27 +2573,33 @@ struct StablehloLegalizeToLinalgPass
     : impl::StablehloLegalizeToLinalgPassBase<StablehloLegalizeToLinalgPass> {
   using StablehloLegalizeToLinalgPassBase::StablehloLegalizeToLinalgPassBase;
 
-  void runOnOperation() override {
-    auto *context = &getContext();
-    auto target = ConversionTarget{*context};
-    auto patterns = RewritePatternSet{context};
-    auto typeConverter = std::make_unique<LinalgTypeConverter>();
-
-    target.addLegalDialect<
+  LogicalResult initialize(MLIRContext *context) override {
+    target = std::make_shared<ConversionTarget>(*context);
+    target->addLegalDialect<
         bufferization::BufferizationDialect, arith::ArithDialect,
         complex::ComplexDialect, linalg::LinalgDialect, math::MathDialect,
         tensor::TensorDialect, sparse_tensor::SparseTensorDialect,
         scf::SCFDialect, shape::ShapeDialect>();
-    target.addLegalOp<UnrealizedConversionCastOp>();
+    target->addLegalOp<UnrealizedConversionCastOp>();
 
-    populateConversionPatterns(context, *typeConverter, &patterns,
+    RewritePatternSet patterns_(context);
+    populateConversionPatterns(context, converter, &patterns_,
                                enablePrimitiveOps);
+    patterns = std::move(patterns_);
 
-    if (failed(applyPartialConversion(getOperation(), target,
-                                      std::move(patterns)))) {
+    return success();
+  }
+
+  void runOnOperation() override {
+    if (failed(applyPartialConversion(getOperation(), *target, patterns))) {
       return signalPassFailure();
     }
   }
+
+ private:
+  std::shared_ptr<ConversionTarget> target;
+  FrozenRewritePatternSet patterns;
+  LinalgTypeConverter converter;
 };
 }  // namespace
 }  // namespace mlir::stablehlo

--- a/stablehlo/tests/TestUtils.cpp
+++ b/stablehlo/tests/TestUtils.cpp
@@ -94,14 +94,22 @@ struct ReifyReturnTypeShapesPattern : public RewritePattern {
 #include "stablehlo/tests/TestUtils.h.inc"
 
 struct HloTestInferPass : public impl::HloTestInferPassBase<HloTestInferPass> {
+  LogicalResult initialize(MLIRContext *context) override {
+    RewritePatternSet patterns_(context);
+    patterns_.add<InferReturnTypesPattern>(context);
+    patterns_.add<ReifyReturnTypeShapesPattern>(context);
+    patterns = std::move(patterns_);
+    return success();
+  }
+
   void runOnOperation() override {
-    RewritePatternSet patterns(&getContext());
-    patterns.add<InferReturnTypesPattern>(&getContext());
-    patterns.add<ReifyReturnTypeShapesPattern>(&getContext());
     if (failed(
             applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
       return signalPassFailure();
   }
+
+ private:
+  FrozenRewritePatternSet patterns;
 };
 
 #define GEN_PASS_REGISTRATION

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -1064,33 +1064,39 @@ struct StablehloRefineShapesPass
     : public impl::StablehloRefineShapesPassBase<StablehloRefineShapesPass> {
   using StablehloRefineShapesPassBase::StablehloRefineShapesPassBase;
 
-  void runOnOperation() override {
-    auto func = getStablehloRefineShapesTarget(getOperation());
-    if (!func) return signalPassFailure();
-
+  LogicalResult initialize(MLIRContext* context) override {
     // The algorithm behind this pass consists of a single traversal of the
     // function. This is sufficient because we only support one function per
     // program at the moment.
     // TODO(#1048): Find out why .maxIterations = 1 no longer works.
     // There have been recent refactors to applyPatternsAndFoldGreedily
     // upstream, and that might be the reason.
-    GreedyRewriteConfig config;
     config.useTopDownTraversal = true;
     config.enableRegionSimplification = true;
     config.maxIterations = 2;
     config.maxNumRewrites = GreedyRewriteConfig::kNoLimit;
     config.strictMode = GreedyRewriteStrictness::AnyOp;
 
-    RewritePatternSet patterns(&getContext());
+    RewritePatternSet patterns_(context);
+    populateStablehloRefineShapesPatterns(&patterns_, context);
+    patterns = std::move(patterns_);
 
-    populateStablehloRefineShapesPatterns(&patterns, &getContext());
-    if (failed(
-            applyPatternsAndFoldGreedily(func, std::move(patterns), config))) {
+    return success();
+  }
+
+  void runOnOperation() override {
+    auto func = getStablehloRefineShapesTarget(getOperation());
+    if (!func) return signalPassFailure();
+
+    if (failed(applyPatternsAndFoldGreedily(func, patterns, config))) {
       func.emitError("Failed to converge StablehloRefineShapes in ")
           << config.maxIterations << " iterations";
-      return signalPassFailure();
     }
   }
+
+ private:
+  FrozenRewritePatternSet patterns;
+  GreedyRewriteConfig config;
 };
 
 }  // namespace


### PR DESCRIPTION
This is unlikely to give us performance gains since most of our passes run on modules anyway (so the initialization probably already occurs only once), but it is cleaner to separate the initialization of a pass from the actual running of the pass.

The code in `initialize` will run when the pass runs regardless of whether there is at least one instance of the target operation. However, modules are pretty much always present so this is unlikely to change anything.