### PR TITLE
Add shellcheck lint to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -96,3 +96,17 @@ jobs:
 
       - name: Run license checks
         run: addlicense -check -ignore '.git/**' -ignore 'build/**' -ignore 'llvm*/**' .
+
+  shell-script-check:
+    if: "github.event_name == 'pull_request'"
+    runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-22.04'  }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checking out repository
+        uses: actions/checkout@v4
+
+      # shellcheck is installed by default on Ubuntu runners: https://github.com/actions/runner-images/blob/37a171e44de1f134793d7f0cbff137ca481942ab/images/ubuntu/Ubuntu2204-Readme.md
+      - name: Run shellcheck
+        run: ./build_tools/github_actions/lint_shellcheck.sh

--- a/build_tools/github_actions/ci_build_cmake_code_coverage.sh
+++ b/build_tools/github_actions/ci_build_cmake_code_coverage.sh
@@ -70,7 +70,7 @@ REPORT_DATE="$(date +'%Y_%m_%d_%H-%M-%S')"
 REPORT_DIR="$OUTPUT_DIR/ccov_$REPORT_DATE"
 LCOV_DATA="$REPORT_DIR/cov.info"
 
-mkdir -p $REPORT_DIR
+mkdir -p "$REPORT_DIR"
 
 lcov --directory "$STABLEHLO_BUILD_DIR"  \
      --base-directory "stablehlo" \
@@ -84,12 +84,12 @@ lcov --directory "$STABLEHLO_BUILD_DIR"  \
 # Capture code coverage output
 if [[ $GENERATE_HTML == true ]]; then
   exec 5>&1
-  CCOV_OUT=$(genhtml $LCOV_DATA \
-      --output-directory $REPORT_DIR \
-      --ignore-errors source \
-      --show-details \
-      --sort \
-      --prefix $(pwd) | tee /dev/fd/5)
+  genhtml "$LCOV_DATA" \
+    --output-directory "$REPORT_DIR" \
+    --ignore-errors source \
+    --show-details \
+    --sort \
+    --prefix "$(pwd)" | tee /dev/fd/5
   echo "HTML report at:"
   echo "  $REPORT_DIR"
 fi

--- a/build_tools/github_actions/lint_buildifier.sh
+++ b/build_tools/github_actions/lint_buildifier.sh
@@ -18,6 +18,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if ! command -v buildifier &> /dev/null; then
+  echo "Error: buildifier is not installed. Aborting."
+  exit 1
+fi
+
 # shellcheck disable=SC2155
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly STABLEHLO_ROOT_DIR="${SCRIPT_DIR}/../.."

--- a/build_tools/github_actions/lint_buildifier.sh
+++ b/build_tools/github_actions/lint_buildifier.sh
@@ -13,16 +13,13 @@
 # limitations under the License.
 
 # This runs buildifier on relevant files
-# This runs markdownlint-cli with the specified files, using Docker.
-# If passing the files as a glob, be sure to wrap in quotes. For more info,
-# see https://github.com/igorshubovych/markdownlint-cli#globbing
 
 set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly SCRIPT_DIR
+# shellcheck disable=SC2155
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly STABLEHLO_ROOT_DIR="${SCRIPT_DIR}/../.."
 
 cd "$STABLEHLO_ROOT_DIR"

--- a/build_tools/github_actions/lint_clang_format.sh
+++ b/build_tools/github_actions/lint_clang_format.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2022 The StableHLO Authors.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,7 +36,7 @@ if [[ $# -ne 0 ]] ; then
 fi
 
 echo "Gathering changed files..."
-CHANGED_FILES=$(git diff $BASE_BRANCH HEAD --name-only --diff-filter=d | grep '.*\.h\|.*\.cpp' | xargs)
+CHANGED_FILES=$(git diff "$BASE_BRANCH" HEAD --name-only --diff-filter=d | grep '.*\.h\|.*\.cpp' | xargs)
 if [[ -z "$CHANGED_FILES" ]]; then
   echo "No files to format."
   exit 0
@@ -44,7 +45,7 @@ fi
 echo "Running clang-format [mode=$FORMAT_MODE]..."
 echo "  Files: $CHANGED_FILES"
 if [[ $FORMAT_MODE == 'fix' ]]; then
-  clang-format --style=google -i $CHANGED_FILES
+  clang-format --style=google -i "$CHANGED_FILES"
 else
-  clang-format --style=google --dry-run --Werror $CHANGED_FILES
+  clang-format --style=google --dry-run --Werror "$CHANGED_FILES"
 fi

--- a/build_tools/github_actions/lint_markdown.sh
+++ b/build_tools/github_actions/lint_markdown.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2022 The StableHLO Authors.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +27,8 @@ if [[ $# -gt 2 ]] ; then
   exit 1
 fi
 
-readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR;
 readonly STABLEHLO_ROOT_DIR="${SCRIPT_DIR}/../.."
 
 # These must be relative to the repo root because that's the context
@@ -41,6 +43,6 @@ then
 fi
 
 # Run markdownlint-cli in Docker to avoid node versioning issues
-docker run -v $STABLEHLO_ROOT_DIR:/workdir \
+docker run -v "$STABLEHLO_ROOT_DIR:/workdir" \
     ghcr.io/igorshubovych/markdownlint-cli:v0.32.2 \
     --config $CONFIG "$@"

--- a/build_tools/github_actions/lint_markdown.sh
+++ b/build_tools/github_actions/lint_markdown.sh
@@ -27,8 +27,8 @@ if [[ $# -gt 2 ]] ; then
   exit 1
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly SCRIPT_DIR;
+# shellcheck disable=SC2155
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly STABLEHLO_ROOT_DIR="${SCRIPT_DIR}/../.."
 
 # These must be relative to the repo root because that's the context

--- a/build_tools/github_actions/lint_shellcheck.sh
+++ b/build_tools/github_actions/lint_shellcheck.sh
@@ -20,6 +20,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if ! command -v shellcheck &> /dev/null; then
+  echo "Error: shellcheck is not installed. Aborting."
+  exit 1
+fi
+
 # shellcheck disable=SC2155
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly STABLEHLO_ROOT_DIR="${SCRIPT_DIR}/../.."

--- a/build_tools/github_actions/lint_shellcheck.sh
+++ b/build_tools/github_actions/lint_shellcheck.sh
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This runs shellcheck on relevant files
+# This runs shellcheck on relevant files. shellcheck is a shell script analysis
+# tool that can find bugs and subtle issues in shell scripts:
+# https://www.shellcheck.net/
 
 set -o errexit
 set -o nounset

--- a/build_tools/github_actions/lint_shellcheck.sh
+++ b/build_tools/github_actions/lint_shellcheck.sh
@@ -21,17 +21,21 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+readonly SCRIPT_DIR;
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly SCRIPT_DIR
 readonly STABLEHLO_ROOT_DIR="${SCRIPT_DIR}/../.."
 
 cd "$STABLEHLO_ROOT_DIR"
 
 IFS=$'\n'
-mapfile -t targets < <(find . -type f -name '*.bazel' -not -path './llvm*')
+mapfile -t targets < <(find . -type f -name '*.sh' -not -path './llvm*' -printf '%P\0')
 
-if ! buildifier --mode=check --lint=warn --warnings=all -r "${targets[@]}"; then
-  echo "Error: buildifier failed. Please run: buildifier --mode=fix --lint=fix --warnings=all -r " "${targets[@]}"
-  echo "You may need to install a specific version of buildifier (see the GitHub Actions workflow)."
+echo "Running shellcheck:"
+shellcheck --version
+
+if ! shellcheck --severity=info "${targets[@]}"; then
+  echo "Error: shellcheck failed. Please run the following command to fix all issues:"
+  echo "shellcheck --severity=info --format=diff" "${targets[@]}" "| git apply"
+  echo "You may need to install a specific version of shellcheck (see above output)."
   exit 1
 fi

--- a/build_tools/github_actions/lint_shellcheck.sh
+++ b/build_tools/github_actions/lint_shellcheck.sh
@@ -20,8 +20,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly SCRIPT_DIR;
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC2155
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly STABLEHLO_ROOT_DIR="${SCRIPT_DIR}/../.."
 
 cd "$STABLEHLO_ROOT_DIR"
@@ -32,9 +32,9 @@ mapfile -t targets < <(find . -type f -name '*.sh' -not -path './llvm*' -printf 
 echo "Running shellcheck:"
 shellcheck --version
 
-if ! shellcheck --severity=info "${targets[@]}"; then
+if ! shellcheck --severity=style "${targets[@]}"; then
   echo "Error: shellcheck failed. Please run the following command to fix all issues:"
-  echo "shellcheck --severity=info --format=diff" "${targets[@]}" "| git apply"
+  echo "shellcheck --severity=style --format=diff" "${targets[@]}" "| git apply"
   echo "You may need to install a specific version of shellcheck (see above output)."
   exit 1
 fi

--- a/build_tools/github_actions/lint_shellcheck.sh
+++ b/build_tools/github_actions/lint_shellcheck.sh
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This runs buildifier on relevant files
-# This runs markdownlint-cli with the specified files, using Docker.
-# If passing the files as a glob, be sure to wrap in quotes. For more info,
-# see https://github.com/igorshubovych/markdownlint-cli#globbing
+# This runs shellcheck on relevant files
 
 set -o errexit
 set -o nounset

--- a/build_tools/github_actions/lint_version.sh
+++ b/build_tools/github_actions/lint_version.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2023 The StableHLO Authors.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +24,7 @@ set_version_var() {
   VERSION_STR=$(cat $VERSION_H | grep getCurrentVersion -A1 | grep -o 'Version([0-9], .*)')
   REGEX="Version\(([0-9]+), ([0-9]+), ([0-9]+)\)"
   if [[ $VERSION_STR =~ $REGEX ]]; then
-    VERSION=(${BASH_REMATCH[1]} ${BASH_REMATCH[2]} ${BASH_REMATCH[3]})
+    VERSION=("${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}")
   else
     echo "Error: Could not find current version string in $VERSION_H" >&2
     exit 1
@@ -33,7 +34,6 @@ set_version_var
 
 ## Check if compatibility tests exist for version `X_Y_0`
 COMPAT_TEST_BASE="stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo"
-COMPAT_TEST="$COMPAT_TEST_BASE.mlir"
 TEST_VERSION="${VERSION[0]}_${VERSION[1]}_0"
 VERSIONED_COMPAT_TEST="$COMPAT_TEST_BASE.$TEST_VERSION.mlir"
 VERSIONED_COMPAT_TEST_BC="$COMPAT_TEST_BASE.$TEST_VERSION.mlir.bc"

--- a/build_tools/github_actions/lint_whitespace_checks.sh
+++ b/build_tools/github_actions/lint_whitespace_checks.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2022 The StableHLO Authors.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,12 +35,13 @@ if [[ $# -ne 0 ]] ; then
 fi
 
 get_source_files() {
-  git diff $BASE_BRANCH HEAD --name-only --diff-filter=d | grep '.*\.cpp$\|.*\.h$\|.*\.md$\|.*\.mlir$\|.*\.sh$\|.*\.td$\|.*\.txt$\|.*\.yml$\|.*\.yaml$' | xargs
+  git diff "$BASE_BRANCH" HEAD --name-only --diff-filter=d | grep '.*\.cpp$\|.*\.h$\|.*\.md$\|.*\.mlir$\|.*\.sh$\|.*\.td$\|.*\.txt$\|.*\.yml$\|.*\.yaml$' | xargs
 }
 echo "Checking whitespace:"
 echo "  $(get_source_files)"
 
 files_without_eof_newline() {
+  # shellcheck disable=SC2016
   [[ -z $(get_source_files) ]] || get_source_files | xargs -L1 bash -c 'test "$(tail -c 1 "$0")" && echo "$0"'
 }
 
@@ -48,11 +50,12 @@ files_with_trailing_whitespace() {
 }
 
 fix_files_without_eof_newline() {
-  echo $1 | xargs  --no-run-if-empty sed -i -e '$a\'
+  # shellcheck disable=SC2016,SC1003
+  echo "$1" | xargs --no-run-if-empty sed -i -e '$a\'
 }
 
 fix_files_with_trailing_whitespace() {
-  echo $1 | xargs --no-run-if-empty sed -i 's/[ \t]*$//'
+  echo "$1" | xargs --no-run-if-empty sed -i 's/[ \t]*$//'
 }
 
 EOF_NL=$(files_without_eof_newline)
@@ -64,11 +67,11 @@ if [[ $FORMAT_MODE == 'fix' ]]; then
   echo "Fixing trailing whitespaces..."
   fix_files_with_trailing_whitespace "$TRAIL_WS"
 else
-  if [ ! -z "$EOF_NL$TRAIL_WS" ]; then
+  if [ -n "$EOF_NL$TRAIL_WS" ]; then
     echo "Missing newline at EOF:"
-    echo $EOF_NL
+    echo "$EOF_NL"
     echo "Has trailing whitespace:"
-    echo $TRAIL_WS
+    echo "$TRAIL_WS"
     echo
     echo "Auto-fix using:"
     echo "  $ ./build_tools/github_actions/lint_whitespace_checks.sh -f"


### PR DESCRIPTION
shellcheck is a shell script analysis tool that can find bugs and subtle issues in shell scripts: https://www.shellcheck.net/

As part of adding the check, this commit also fixes any issues that are currently surfaced by shellcheck. These fell into the following categories:
- Adding missing shebangs to scripts because shellcheck recommendations depend on the shell being used.
- [SC2086](https://www.shellcheck.net/wiki/SC2086) (info): Double quote to prevent globbing and word splitting.
- [SC2034](https://www.shellcheck.net/wiki/SC2034) (warning): <variable> appears unused. Verify use (or export if used externally).
- [SC2207](https://www.shellcheck.net/wiki/SC2207) (warning): Prefer mapfile or read -a to split command output (or quote to avoid splitting).
- [SC2185](https://www.shellcheck.net/wiki/SC2185) (info): Some finds don't have a default path. Specify '.' explicitly.
- [SC2068](https://www.shellcheck.net/wiki/SC2068) (error): Double quote array expansions to avoid re-splitting elements.
- [SC2145](https://www.shellcheck.net/wiki/SC2145) (error): Argument mixes string and array. Use * or separate argument.
- [SC2236](https://www.shellcheck.net/wiki/SC2236) (style): Use -n instead of ! -z.
- [SC2155](https://www.shellcheck.net/wiki/SC2155) (warning): Declare and assign separately to avoid masking return values. (We have a few cases of this where we define `readonly` variables using a command that could fail.)

I am proposing that we use a lint level of `style`, which is the minimum level provided by shellcheck (so we will be running all lints). Most of the lints reported by shellcheck were of the `info` variety, due to variables being expanded outside of quotes (e.g. `echo $x` instead of `echo "$x"`). However there were a few warnings and errors as well, and one "style" lint which I believe is a no-brainer (use `-n` instead of `! -z`).

I am also adding suppression comments for the following:
- [SC2016](https://www.shellcheck.net/wiki/SC2016) (info): Expressions don't expand in single quotes, use double quotes for that. (There are a few places where we actually do not want `$...` to be expanded.)
- [SC1003](https://www.shellcheck.net/wiki/SC1003) (info): Want to escape a single quote? echo 'This is how it'\''s done'. (This occurs in a specific use of `sed` to add a newline to files: `sed -i -e '$a\'` -- apparently shellcheck doesn't know about this idiom.)