### PR TITLE
Make setup_sanitizer include optional in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,8 +144,10 @@ add_definitions(${LLVM_DEFINITIONS})
 # Sanitizer configuration
 #-------------------------------------------------------------------------------
 
-include(SetupSanitizers)
-setup_sanitizers()
+if(STABLEHLO_ENABLE_SANITIZER)
+  include(SetupSanitizers)
+  setup_sanitizers()
+endif()
 
 #-------------------------------------------------------------------------------
 # Python configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ else()
 endif()
 
 # Add the CMake modules specific to StableHLO
-list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 if(LLVM_ENABLE_ZLIB)
   find_package(ZLIB)
@@ -144,10 +144,8 @@ add_definitions(${LLVM_DEFINITIONS})
 # Sanitizer configuration
 #-------------------------------------------------------------------------------
 
-if(STABLEHLO_ENABLE_SANITIZER)
-  include(SetupSanitizers)
-  setup_sanitizers()
-endif()
+include(SetupSanitizers)
+setup_sanitizers()
 
 #-------------------------------------------------------------------------------
 # Python configuration


### PR DESCRIPTION
Fixes https://github.com/openxla/stablehlo/issues/1962#issuecomment-1919576685

Context: 
This breaks torch-mlir's CMake build when bumping stablehlo. 

The CMake build [fails](https://github.com/llvm/torch-mlir/actions/runs/7729517677/job/21072878412?pr=2821) with setup_sanitizers. Probably related to https://github.com/openxla/stablehlo/pull/1959 (cc: @fzakaria , @mlevesquedion ). I see the default for `STABLEHLO_ENABLE_SANITIZER` being `OFF`, but this code probably needs to be enclosed in an `if-endif`:
```
include(SetupSanitizers)
setup_sanitizers()
```
Error:
```
  -- Building StableHLO as an external LLVM project
  -- Building with -fPIC
  CMake Error at /_work/torch-mlir/torch-mlir/externals/stablehlo/CMakeLists.txt:147 (include):
    include could not find requested file:
  
      SetupSanitizers
  
  
  CMake Error at /_work/torch-mlir/torch-mlir/externals/stablehlo/CMakeLists.txt:148 (setup_sanitizers):
    Unknown CMake command "setup_sanitizers".
  
  
  -- Configuring incomplete, errors occurred!
```