### PR TITLE
Add ccache by default when building MLIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,29 +62,6 @@ else()
   set(CMAKE_CXX_STANDARD 17)
 endif()
 
-# Build with ccache if the package is present
-set(LLVM_CCACHE_BUILD OFF CACHE BOOL "Set to ON for a ccache enabled build")
-if(LLVM_CCACHE_BUILD)
-  find_program(CCACHE_PROGRAM ccache)
-  if(CCACHE_PROGRAM)
-      set(LLVM_CCACHE_MAXSIZE "" CACHE STRING "Size of ccache")
-      set(LLVM_CCACHE_DIR "" CACHE STRING "Directory to keep ccached data")
-      set(LLVM_CCACHE_PARAMS "CCACHE_CPP2=yes CCACHE_HASHDIR=yes"
-          CACHE STRING "Parameters to pass through to ccache")
-
-      set(CCACHE_PROGRAM "${LLVM_CCACHE_PARAMS} ${CCACHE_PROGRAM}")
-      if (LLVM_CCACHE_MAXSIZE)
-        set(CCACHE_PROGRAM "CCACHE_MAXSIZE=${LLVM_CCACHE_MAXSIZE} ${CCACHE_PROGRAM}")
-      endif()
-      if (LLVM_CCACHE_DIR)
-        set(CCACHE_PROGRAM "CCACHE_DIR=${LLVM_CCACHE_DIR} ${CCACHE_PROGRAM}")
-      endif()
-      set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_PROGRAM})
-  else()
-    message(FATAL_ERROR "Unable to find the program ccache. Set LLVM_CCACHE_BUILD to OFF")
-  endif()
-endif()
-
 #-------------------------------------------------------------------------------
 # MLIR/LLVM Configuration
 #-------------------------------------------------------------------------------

--- a/build_tools/build_mlir.sh
+++ b/build_tools/build_mlir.sh
@@ -27,6 +27,13 @@ CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-RelWithDebInfo}"
 # Turn on building Python bindings
 MLIR_ENABLE_BINDINGS_PYTHON="${MLIR_ENABLE_BINDINGS_PYTHON:-OFF}"
 
+# Check if ccache is available and set the compiler launcher
+if command -v ccache &>/dev/null; then
+  echo "Enabling ccache for the build."
+  export CMAKE_CXX_COMPILER_LAUNCHER=ccache
+  export CMAKE_C_COMPILER_LAUNCHER=ccache
+fi
+
 if ! [ -f "$LLVM_SRC_DIR/llvm/CMakeLists.txt" ]; then
   echo "Expected the path to LLVM to be set correctly (got '$LLVM_SRC_DIR'): can't find CMakeLists.txt"
   exit 1


### PR DESCRIPTION
* Add ccache use for build_mlir.sh script
* Remove LLVM_CCACHE_BUILD which is not used and [deprecated ](https://discourse.llvm.org/t/llvm-ccache-build-is-deprecated/68431 ) (Although our use of it is not necessarily the LLVM's version)

Note: this change was pulled out of https://github.com/openxla/stablehlo/pull/1973