### PR TITLE
Add explicit error reporting to transform passes

### DIFF
--- a/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
+++ b/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
@@ -308,8 +308,11 @@ struct StablehloCanonicalizeDynamismPass
 
     RewritePatternSet patterns(&getContext());
     populateStablehloCanonicalizeDynamismPatterns(&patterns, &getContext());
-    if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns),
-                                            config))) {
+    auto func = getOperation();
+    if (failed(
+            applyPatternsAndFoldGreedily(func, std::move(patterns), config))) {
+      func.emitError("Failed to converge StablehloRefineShapes in ")
+          << config.maxIterations << " iterations";
       return signalPassFailure();
     }
   }

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -1082,9 +1082,12 @@ struct StablehloRefineShapesPass
     config.strictMode = GreedyRewriteStrictness::AnyOp;
 
     RewritePatternSet patterns(&getContext());
+    
     populateStablehloRefineShapesPatterns(&patterns, &getContext());
     if (failed(
             applyPatternsAndFoldGreedily(func, std::move(patterns), config))) {
+      func.emitError("Failed to converge StablehloRefineShapes in ")
+          << config.maxIterations << " iterations";
       return signalPassFailure();
     }
   }


### PR DESCRIPTION
Currently pass failures are silent (only written to `llvm::dbgs`) in these passes Adding explicit error reporting will at least make it clear what pass has failed.
