### PR TITLE
Remove generator expression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,14 +113,24 @@ endif()
 
 include(CheckCXXCompilerFlag)
 include(CheckLinkerFlag)
-add_link_options("$<$<BOOL:${STABLEHLO_ENABLE_LLD}>:-fuse-ld=lld>")
+if (STABLEHLO_ENABLE_LLD)
+  message(STATUS "Enabling LLD as the linker")
+  add_link_options("-fuse-ld=lld")
+endif()
+
 if(STABLEHLO_ENABLE_SPLIT_DWARF)
     check_cxx_compiler_flag(-gsplit-dwarf STABLEHLO_SUPPORTS_SPLIT_DWARF)
-    add_compile_options("$<$<BOOL:${STABLEHLO_SUPPORTS_SPLIT_DWARF}>:-gsplit-dwarf;-ggnu-pubnames>")
+    if (STABLEHLO_SUPPORTS_SPLIT_DWARF)
+      message(STATUS "Enabling split-dwarf build")
+      add_compile_options(-gsplit-dwarf -ggnu-pubnames)
+    endif()
     check_linker_flag(CXX "-Wl,--gdb-index" STABLEHLO_SUPPORTS_GDB_INDEX)
     # If we set LLD it doesn't seem to affect the check_linker_flag above.
     # Account for it with the generator expression OR
-    add_link_options("$<$<OR:$<BOOL:${STABLEHLO_SUPPORTS_GDB_INDEX}>,$<BOOL:${STABLEHLO_ENABLE_LLD}>>:-Wl,--gdb-index>")
+    if (STABLEHLO_SUPPORTS_GDB_INDEX OR STABLEHLO_ENABLE_LLD)
+      message(STATUS "Enabling GDB index in binary")
+      add_link_options("-Wl,--gdb-index")
+    endif()
 endif()
 
 include(TableGen)


### PR DESCRIPTION
Based on feedback from
https://gitlab.kitware.com/cmake/cmake/-/issues/25649 removed the generator expression in favor of if statement.

Example output:
```
-- Building StableHLO with an installed MLIR
-- Using MLIRConfig.cmake in: /usr/local/google/home/fmzakari/code/github.com/openxla/stablehlo/build/../llvm-build/lib/cmake/mlir
-- Using LLVMConfig.cmake in: /usr/local/google/home/fmzakari/code/github.com/openxla/stablehlo/llvm-build/lib/cmake/llvm
-- Enabling LLD as the linker
-- Enabling split-dwarf build
-- Enabling GDB index in binary
-- Building with -fPIC
-- Configuring done (0.2s)
-- Generating done (0.1s)
-- Build files have been written to: /usr/local/google/home/fmzakari/code/github.com/openxla/stablehlo/build
```