### PR TITLE
Refactor portable api to use main registration method

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -958,6 +958,7 @@ cc_library(
     ],
     strip_include_prefix = ".",
     deps = [
+        ":register",
         ":stablehlo_ops",
         ":stablehlo_serialization",
         ":version",

--- a/stablehlo/api/CMakeLists.txt
+++ b/stablehlo/api/CMakeLists.txt
@@ -19,6 +19,7 @@ add_mlir_dialect_library(StablehloPortableApi
   LINK_LIBS PUBLIC
   ChloOps
   StablehloOps
+  StablehloRegister
   StablehloSerialization
   Version
   VhloOps

--- a/stablehlo/api/PortableApi.cpp
+++ b/stablehlo/api/PortableApi.cpp
@@ -21,6 +21,7 @@ limitations under the License.
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Parser/Parser.h"
+#include "stablehlo/dialect/Register.h"
 #include "stablehlo/dialect/Serialization.h"
 #include "stablehlo/dialect/StablehloOps.h"
 #include "stablehlo/dialect/Version.h"
@@ -28,13 +29,6 @@ limitations under the License.
 
 namespace mlir {
 namespace stablehlo {
-namespace {
-void loadSerializationDialects(MLIRContext* context) {
-  context->loadDialect<mlir::func::FuncDialect>();
-  context->loadDialect<mlir::stablehlo::StablehloDialect>();
-  context->loadDialect<mlir::vhlo::VhloDialect>();
-}
-}  // namespace
 
 std::string getCurrentVersion() {
   return mlir::vhlo::Version::getCurrentVersion().toString();
@@ -48,7 +42,9 @@ LogicalResult serializePortableArtifact(StringRef moduleStr,
                                         StringRef targetVersion,
                                         raw_ostream& os) {
   MLIRContext context;
-  loadSerializationDialects(&context);
+  mlir::DialectRegistry registry;
+  mlir::stablehlo::registerAllDialects(registry);
+  context.appendDialectRegistry(registry);
   auto module = mlir::parseSourceString<mlir::ModuleOp>(moduleStr, &context);
   if (!module || failed(module->verifyInvariants())) return failure();
 

--- a/stablehlo/api/PortableApi.cpp
+++ b/stablehlo/api/PortableApi.cpp
@@ -29,6 +29,13 @@ limitations under the License.
 
 namespace mlir {
 namespace stablehlo {
+namespace {
+void loadSerializationDialects(MLIRContext& context) {
+  mlir::DialectRegistry registry;
+  mlir::stablehlo::registerAllDialects(registry);
+  context.appendDialectRegistry(registry);
+}
+}  // namespace
 
 std::string getCurrentVersion() {
   return mlir::vhlo::Version::getCurrentVersion().toString();
@@ -42,9 +49,7 @@ LogicalResult serializePortableArtifact(StringRef moduleStr,
                                         StringRef targetVersion,
                                         raw_ostream& os) {
   MLIRContext context;
-  mlir::DialectRegistry registry;
-  mlir::stablehlo::registerAllDialects(registry);
-  context.appendDialectRegistry(registry);
+  loadSerializationDialects(context);
   auto module = mlir::parseSourceString<mlir::ModuleOp>(moduleStr, &context);
   if (!module || failed(module->verifyInvariants())) return failure();
 
@@ -54,7 +59,7 @@ LogicalResult serializePortableArtifact(StringRef moduleStr,
 LogicalResult deserializePortableArtifact(StringRef artifactStr,
                                           raw_ostream& os) {
   MLIRContext context;
-  loadSerializationDialects(&context);
+  loadSerializationDialects(context);
   auto module = deserializePortableArtifact(artifactStr, &context);
   if (!module) return failure();
 


### PR DESCRIPTION
Less moving pieces. Will also get the QuantizationDialect registration that was added earlier.

We end up registering _some_ dialects that aren't needed in serialization, but the cost is likely not worth the duplication.