### PR TITLE
Update status of approved and merged RFCs

### DIFF
--- a/rfcs/20230622-quantized-reduction.md
+++ b/rfcs/20230622-quantized-reduction.md
@@ -1,6 +1,6 @@
 # RFC: StableHLO quantization for reduction ops
 
-Status: Review<br/>
+Status: Approved<br/>
 Initial version: 06/22/2023<br/>
 updated: 07/13/2023: Minor refactoring of the examples.<br/>
 Last updated: 08/11/2023: Revision of the proposal to introduce an

--- a/rfcs/20230704-dynamism-101.md
+++ b/rfcs/20230704-dynamism-101.md
@@ -1,8 +1,8 @@
 # RFC: Dynamism 101
 
-Status: Under review<br/>
+Status: Approved<br/>
 Initial version: 7/4/2023<br/>
-Last updated: 7/4/2023<br/>
+Last updated: 1/16/2024<br/>
 Discussion thread: [openxla-discuss](https://groups.google.com/a/openxla.org/g/openxla-discuss/c/HJRvFBum65k/m/7QtJxgB9AQAJ).
 
 ## Summary

--- a/rfcs/20231017-collective-broadcast.md
+++ b/rfcs/20231017-collective-broadcast.md
@@ -1,6 +1,6 @@
 # [RFC] Add collective_broadcast to the StableHLO specification
 
-Status: Review<br/>
+Status: Approved<br/>
 Initial version: 10/17/20223<br/>
 Last updated: 11/1/2023<br/>
 Discussion thread: [GitHub](https://github.com/openxla/stablehlo/pull/1809)


### PR DESCRIPTION
Usually we try to modify the "Status" line to show approved right before merging. Looks like we forgot to do that for a few RFCs. Updating accordingly.