### PR TITLE
Avoid duplicating extra class declarations

### DIFF
--- a/stablehlo/dialect/ChloOps.td
+++ b/stablehlo/dialect/ChloOps.td
@@ -59,13 +59,14 @@ def CHLO_Dialect : Dialect {
 
 class CHLO_Op<string mnemonic, list<Trait> traits> :
     Op<CHLO_Dialect, mnemonic, traits> {
-  let extraClassDeclaration = [{
+  string commonClassDeclaration = [{
     // Relax the strict default implementation with one that allows
     // for StableHLO-specific differences.
     static bool isCompatibleReturnTypes(TypeRange l, TypeRange r) {
       return mlir::hlo::isCompatibleForHloTypeInference(l, r);
     }
   }];
+  let extraClassDeclaration = commonClassDeclaration;
 }
 
 include "stablehlo/dialect/ChloEnums.td"
@@ -111,11 +112,6 @@ class CHLO_BroadcastBinaryElementwiseOp<
     `(` type($lhs) `,` type($rhs) `)` `->` type(results)
   }];
 
-  let extraClassDeclaration = [{
-    static bool isCompatibleReturnTypes(TypeRange l, TypeRange r) {
-      return mlir::hlo::isCompatibleForHloTypeInference(l, r);
-    }
-  }];
 }
 
 def CHLO_BroadcastAddOp : CHLO_BroadcastBinaryElementwiseOp<"broadcast_add",
@@ -468,14 +464,11 @@ class CHLO_UnaryElementwiseOp<string mnemonic, list<Trait> traits,
     $operand attr-dict `:` type($operand) `->` type($result)
   }];
 
-  let extraClassDeclaration = [{
+  let extraClassDeclaration = commonClassDeclaration # [{
     LogicalResult reifyReturnTypeShapes(OpBuilder& builder, ValueRange operands,
         SmallVectorImpl<Value>& reifiedReturnShapes) {
       return ::mlir::hlo::deriveShapeFromOperand(&builder, getOperation(),
           operands.front(), &reifiedReturnShapes);
-    }
-    static bool isCompatibleReturnTypes(TypeRange l, TypeRange r) {
-      return mlir::hlo::isCompatibleForHloTypeInference(l, r);
     }
   }];
 }

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -42,13 +42,14 @@ def StableHLO_Dialect : Dialect {
 
 class StableHLO_Op<string mnemonic, list<Trait> traits> :
     Op<StableHLO_Dialect, mnemonic, traits> {
-  let extraClassDeclaration = [{
+  string commonClassDeclaration = [{
     // Relax the strict default implementation with one that allows
     // for StableHLO-specific differences.
     static bool isCompatibleReturnTypes(TypeRange l, TypeRange r) {
       return mlir::hlo::isCompatibleForHloTypeInference(l, r);
     }
   }];
+  let extraClassDeclaration = commonClassDeclaration;
 }
 
 include "stablehlo/dialect/StablehloEnums.td"
@@ -57,13 +58,7 @@ include "stablehlo/dialect/StablehloTypes.td"
 
 class StableHLO_ShapedInterfaceOp<string mnemonic, list<Trait> traits> :
     StableHLO_Op<mnemonic, traits # [DeclareOpInterfaceMethods<InferShapedTypeOpInterface,
-    ["reifyReturnTypeShapes"]>]> {
-  let extraClassDeclaration = [{
-    static bool isCompatibleReturnTypes(TypeRange l, TypeRange r) {
-      return mlir::hlo::isCompatibleForHloTypeInference(l, r);
-    }
-  }];
-}
+    ["reifyReturnTypeShapes"]>]> {}
 
 //===----------------------------------------------------------------------===//
 // StableHLO nullary op definitions.
@@ -181,16 +176,13 @@ class StableHLO_UnaryElementwiseOp<string mnemonic, list<Trait> traits,
     InferShapedTypeOpInterface, SameOperandsAndResultShape]> {
   let arguments = (ins OperandType:$operand);
   let results = (outs ResultType:$result);
-  let extraClassDeclaration = [{
+  let extraClassDeclaration = commonClassDeclaration # [{
     LogicalResult reifyReturnTypeShapes(
         OpBuilder& builder, ValueRange operands,
         SmallVectorImpl<Value>& reifiedReturnShapes) {
       return ::mlir::hlo::deriveShapeFromOperand(&builder, getOperation(),
                                                 operands.front(),
                                                 &reifiedReturnShapes);
-    }
-    static bool isCompatibleReturnTypes(TypeRange l, TypeRange r) {
-      return mlir::hlo::isCompatibleForHloTypeInference(l, r);
     }
   }];
 
@@ -667,16 +659,13 @@ class StableHLO_BinaryElementwiseOp<string mnemonic, list<Trait> traits,
     OperandType:$rhs
   );
 
-  let extraClassDeclaration = [{
+  let extraClassDeclaration = commonClassDeclaration # [{
     LogicalResult reifyReturnTypeShapes(
         OpBuilder& builder, ValueRange operands,
         SmallVectorImpl<Value>& reifiedReturnShapes) {
       return ::mlir::hlo::deriveShapeFromOperand(&builder, getOperation(),
                                                  operands.front(),
                                                  &reifiedReturnShapes);
-    }
-    static bool isCompatibleReturnTypes(TypeRange l, TypeRange r) {
-      return mlir::hlo::isCompatibleForHloTypeInference(l, r);
     }
   }];
 
@@ -1275,7 +1264,7 @@ def StableHLO_WhileOp: StableHLO_Op<"while", [
 
   let hasVerifier = 1;
 
-  let extraClassDeclaration = [{
+  let extraClassDeclaration = commonClassDeclaration # [{
     // Method of OpAsmOpInterface used during custom printing to name the block
     // arguments in the nested regions. We name both the condition and the body
     // regions entry arguments the same way, with a `iterArg` prefix. Since the
@@ -1285,10 +1274,6 @@ def StableHLO_WhileOp: StableHLO_Op<"while", [
     void getAsmBlockArgumentNames(Region &region, OpAsmSetValueNameFn setNameFn) {
       for (BlockArgument arg : region.getArguments())
         setNameFn(arg, "iterArg");
-    }
-
-    static bool isCompatibleReturnTypes(TypeRange l, TypeRange r) {
-      return mlir::hlo::isCompatibleForHloTypeInference(l, r);
     }
   }];
   let hasCustomAssemblyFormat = 1;


### PR DESCRIPTION
I noticed some duplication and wondered if it was possible to remove it. Then I stumbled upon this thread which provided a solution: https://discourse.llvm.org/t/how-to-add-new-content-to-extraclassdeclaration-in-subclasses/71537

The idea is to declare the common class declaration in the base class and concatenate it with the child-specific declarations.

In some cases, the field was being overriden only to be set to the same value as the parent. In such cases, I simply removed the override.