### PR TITLE
Use default visibility for symbols

### DIFF
--- a/stablehlo/tests/interpret/all_gather.mlir
+++ b/stablehlo/tests/interpret/all_gather.mlir
@@ -1,14 +1,14 @@
 // RUN: stablehlo-translate --interpret -split-input-file %s
 
 module @cross_replica {
-  func.func public @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
+  func.func @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
     %result = "stablehlo.all_gather"(%arg0) {
       all_gather_dim = 1 : i64,
       replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
     } : (tensor<2x2xi64>) -> tensor<2x4xi64>
     return %result : tensor<2x4xi64>
   }
-  func.func public @main() {
+  func.func @main() {
     %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
     %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
     %results:2 = "interpreter.run_parallel"(%0, %1) {
@@ -25,7 +25,7 @@ module @cross_replica {
 // -----
 
 module @cross_replica_and_partition {
-  func.func public @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
+  func.func @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
     %result = "stablehlo.all_gather"(%arg0) {
       all_gather_dim = 1 : i64,
       replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
@@ -33,7 +33,7 @@ module @cross_replica_and_partition {
     } : (tensor<2x2xi64>) -> tensor<2x4xi64>
     return %result : tensor<2x4xi64>
   }
-  func.func public @main() {
+  func.func @main() {
     %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
     %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
     %results:2 = "interpreter.run_parallel"(%0, %1) {
@@ -50,7 +50,7 @@ module @cross_replica_and_partition {
 // -----
 
 module @cross_replica_and_partition_issue_1933 {
-  func.func public @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x8xi64> {
+  func.func @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x8xi64> {
     %result = "stablehlo.all_gather"(%arg0) {
       all_gather_dim = 1 : i64,
       replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
@@ -58,7 +58,7 @@ module @cross_replica_and_partition_issue_1933 {
     } : (tensor<2x2xi64>) -> tensor<2x8xi64>
     return %result : tensor<2x8xi64>
   }
-  func.func public @main() {
+  func.func @main() {
     %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
     %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
     %results:4 = "interpreter.run_parallel"(%1, %1, %0, %1) {
@@ -81,7 +81,7 @@ module @cross_replica_and_partition_issue_1933 {
 // -----
 
 module @flattened_ids {
-  func.func public @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
+  func.func @all_gather(%arg0 : tensor<2x2xi64>) -> tensor<2x4xi64> {
     %result = "stablehlo.all_gather"(%arg0) {
       all_gather_dim = 1 : i64,
       replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
@@ -90,7 +90,7 @@ module @flattened_ids {
     } : (tensor<2x2xi64>) -> tensor<2x4xi64>
     return %result : tensor<2x4xi64>
   }
-  func.func public @main() {
+  func.func @main() {
     %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
     %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
     %results:2 = "interpreter.run_parallel"(%0, %1) {

--- a/stablehlo/tests/interpret/all_reduce.mlir
+++ b/stablehlo/tests/interpret/all_reduce.mlir
@@ -1,7 +1,7 @@
 // RUN: stablehlo-translate --interpret -split-input-file %s
 
 module @cross_replica {
-  func.func public @all_reduce(%operand : tensor<4xi64>) -> tensor<4xi64> {
+  func.func @all_reduce(%operand : tensor<4xi64>) -> tensor<4xi64> {
     %result = "stablehlo.all_reduce"(%operand) ({
       ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
         %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
@@ -12,7 +12,7 @@ module @cross_replica {
     } : (tensor<4xi64>) -> tensor<4xi64>
     return %result : tensor<4xi64>
   }
-  func.func public @main() {
+  func.func @main() {
     %inputs0 = stablehlo.constant dense<[1, 2, 3, 4]> : tensor<4xi64>
     %inputs1 = stablehlo.constant dense<[5, 6, 7, 8]> : tensor<4xi64>
     %results:2 = "interpreter.run_parallel"(%inputs0, %inputs1) {
@@ -27,7 +27,7 @@ module @cross_replica {
 // -----
 
 module @cross_replica_and_partition {
-  func.func public @all_reduce(%operand : tensor<4xi64>) -> tensor<4xi64> {
+  func.func @all_reduce(%operand : tensor<4xi64>) -> tensor<4xi64> {
     %result = "stablehlo.all_reduce"(%operand) ({
       ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
         %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
@@ -38,7 +38,7 @@ module @cross_replica_and_partition {
     } : (tensor<4xi64>) -> tensor<4xi64>
     return %result : tensor<4xi64>
   }
-  func.func public @main() {
+  func.func @main() {
     %inputs0 = stablehlo.constant dense<[1, 2, 3, 4]> : tensor<4xi64>
     %inputs1 = stablehlo.constant dense<[5, 6, 7, 8]> : tensor<4xi64>
     %results:2 = "interpreter.run_parallel"(%inputs0, %inputs1) {
@@ -53,7 +53,7 @@ module @cross_replica_and_partition {
 // -----
 
 module @flattened_ids {
-  func.func public @all_reduce(%operand : tensor<4xi64>) -> tensor<4xi64> {
+  func.func @all_reduce(%operand : tensor<4xi64>) -> tensor<4xi64> {
     %result = "stablehlo.all_reduce"(%operand) ({
       ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
         %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
@@ -65,7 +65,7 @@ module @flattened_ids {
     } : (tensor<4xi64>) -> tensor<4xi64>
     return %result : tensor<4xi64>
   }
-  func.func public @main() {
+  func.func @main() {
     %inputs0 = stablehlo.constant dense<[1, 2, 3, 4]> : tensor<4xi64>
     %inputs1 = stablehlo.constant dense<[5, 6, 7, 8]> : tensor<4xi64>
     %results:2 = "interpreter.run_parallel"(%inputs0, %inputs1) {
@@ -80,7 +80,7 @@ module @flattened_ids {
 // -----
 
 module @ragged_replica_groups {
-  func.func public @all_reduce(%operand : tensor<4xi64>) -> tensor<4xi64> {
+  func.func @all_reduce(%operand : tensor<4xi64>) -> tensor<4xi64> {
     %result = "stablehlo.all_reduce"(%operand) ({
       ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
         %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
@@ -91,7 +91,7 @@ module @ragged_replica_groups {
     } : (tensor<4xi64>) -> tensor<4xi64>
     return %result : tensor<4xi64>
   }
-  func.func public @main() {
+  func.func @main() {
     %inputs0 = stablehlo.constant dense<[1, 2, 3, 4]> : tensor<4xi64>
     %inputs1 = stablehlo.constant dense<[5, 6, 7, 8]> : tensor<4xi64>
     %inputs2 = stablehlo.constant dense<[6, 8, 10, 12]> : tensor<4xi64>

--- a/stablehlo/tests/interpret/all_to_all.mlir
+++ b/stablehlo/tests/interpret/all_to_all.mlir
@@ -1,7 +1,7 @@
 // RUN: stablehlo-translate --interpret -split-input-file %s
 
 module @cross_replica {
-  func.func public @all_to_all(%operand : tensor<2x4xi64>) -> tensor<4x2xi64> {
+  func.func @all_to_all(%operand : tensor<2x4xi64>) -> tensor<4x2xi64> {
     %result = "stablehlo.all_to_all"(%operand) {
       split_dimension = 1 : i64,
       concat_dimension = 0 : i64,
@@ -10,7 +10,7 @@ module @cross_replica {
     } : (tensor<2x4xi64>) -> tensor<4x2xi64>
     return %result : tensor<4x2xi64>
   }
-  func.func public @main() {
+  func.func @main() {
     %inputs0 = stablehlo.constant dense<[[1, 2, 3, 4],
                                          [5, 6, 7, 8]]> : tensor<2x4xi64>
     %inputs1 = stablehlo.constant dense<[[9, 10, 11, 12],
@@ -33,7 +33,7 @@ module @cross_replica {
 // -----
 
 module @cross_partition {
-  func.func public @all_to_all(%operand : tensor<2x4xi64>) -> tensor<4x2xi64> {
+  func.func @all_to_all(%operand : tensor<2x4xi64>) -> tensor<4x2xi64> {
     %result = "stablehlo.all_to_all"(%operand) {
       split_dimension = 1 : i64,
       concat_dimension = 0 : i64,
@@ -43,7 +43,7 @@ module @cross_partition {
     } : (tensor<2x4xi64>) -> tensor<4x2xi64>
     return %result : tensor<4x2xi64>
   }
-  func.func public @main() {
+  func.func @main() {
     %inputs0 = stablehlo.constant dense<[[1, 2, 3, 4],
                                          [5, 6, 7, 8]]> : tensor<2x4xi64>
     %inputs1 = stablehlo.constant dense<[[9, 10, 11, 12],

--- a/stablehlo/tests/interpret/collective_permute.mlir
+++ b/stablehlo/tests/interpret/collective_permute.mlir
@@ -1,14 +1,14 @@
 // RUN: stablehlo-translate --interpret -split-input-file %s
 
 module @cross_replica {
-  func.func public @collective_permute(%operand : tensor<2x2xi64>) -> tensor<2x2xi64> {
+  func.func @collective_permute(%operand : tensor<2x2xi64>) -> tensor<2x2xi64> {
     %result = "stablehlo.collective_permute"(%operand) {
       source_target_pairs = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>,
       channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
     } : (tensor<2x2xi64>) -> tensor<2x2xi64>
     return %result : tensor<2x2xi64>
   }
-  func.func public @main() {
+  func.func @main() {
     %inputs0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
     %inputs1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
     %inputs2 = stablehlo.constant dense<[[9, 10], [11, 12]]> : tensor<2x2xi64>
@@ -26,14 +26,14 @@ module @cross_replica {
 // -----
 
 module @cross_partition {
-  func.func public @collective_permute(%operand : tensor<2x2xi64>) -> tensor<2x2xi64> {
+  func.func @collective_permute(%operand : tensor<2x2xi64>) -> tensor<2x2xi64> {
     %result = "stablehlo.collective_permute"(%operand) {
       source_target_pairs = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>,
       channel_handle = #stablehlo.channel_handle<handle = 1, type = 0>
     } : (tensor<2x2xi64>) -> tensor<2x2xi64>
     return %result : tensor<2x2xi64>
   }
-  func.func public @main() {
+  func.func @main() {
     %inputs0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
     %inputs1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
     %inputs2 = stablehlo.constant dense<[[9, 10], [11, 12]]> : tensor<2x2xi64>

--- a/stablehlo/tests/interpret/infeed.mlir
+++ b/stablehlo/tests/interpret/infeed.mlir
@@ -1,7 +1,7 @@
 // RUN: stablehlo-translate --interpret -split-input-file %s
 
 module @distribution_ops {
-  func.func public @infeed(%token : !stablehlo.token) ->
+  func.func @infeed(%token : !stablehlo.token) ->
                           (tensor<2x2xi64>, !stablehlo.token,
                            tensor<2x2xi64>, !stablehlo.token) {
     %results0:2 = "stablehlo.infeed"(%token) :
@@ -11,15 +11,15 @@ module @distribution_ops {
     func.return %results0#0, %results0#1, %results1#0, %results1#1 :
         tensor<2x2xi64>, !stablehlo.token, tensor<2x2xi64>, !stablehlo.token
   }
-  func.func public @infeed_queue0() -> (tensor<2x2xi64>) {
+  func.func @infeed_queue0() -> (tensor<2x2xi64>) {
     %queue0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
     func.return %queue0 : tensor<2x2xi64>
   }
-  func.func public @infeed_queue1() -> (tensor<2x2xi64>) {
+  func.func @infeed_queue1() -> (tensor<2x2xi64>) {
     %queue0 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
     func.return %queue0 : tensor<2x2xi64>
   }
-  func.func public @main() {
+  func.func @main() {
     %token = stablehlo.after_all : !stablehlo.token
     %results:4 = "interpreter.run_parallel"(%token) {
       infeed=[@infeed_queue0, @infeed_queue1],

--- a/stablehlo/tests/interpret/outfeed.mlir
+++ b/stablehlo/tests/interpret/outfeed.mlir
@@ -1,12 +1,12 @@
 // RUN: stablehlo-translate --interpret -split-input-file %s
 
 module @distribution_ops {
-  func.func public @outfeed(%inputs0 : tensor<2x2x2xi64>, %token : !stablehlo.token) -> !stablehlo.token {
+  func.func @outfeed(%inputs0 : tensor<2x2x2xi64>, %token : !stablehlo.token) -> !stablehlo.token {
     %result = "stablehlo.outfeed"(%inputs0, %token) :
         (tensor<2x2x2xi64>, !stablehlo.token) -> !stablehlo.token
     func.return %result : !stablehlo.token
   }
-  func.func public @main() {
+  func.func @main() {
     %inputs0 = stablehlo.constant dense<[[[1, 2], [3, 4]],
                                          [[5, 6], [7, 8]]]> : tensor<2x2x2xi64>
     %token = stablehlo.after_all : !stablehlo.token

--- a/stablehlo/tests/interpret/partition_id.mlir
+++ b/stablehlo/tests/interpret/partition_id.mlir
@@ -1,11 +1,11 @@
 // RUN: stablehlo-translate --interpret -split-input-file %s
 
 module @distribution_ops {
-  func.func public @partition_id() -> tensor<ui32> {
+  func.func @partition_id() -> tensor<ui32> {
     %result = stablehlo.partition_id : tensor<ui32>
     return %result : tensor<ui32>
   }
-  func.func public @main() {
+  func.func @main() {
     %results:2 = "interpreter.run_parallel"() {
       programs=[[@partition_id, @partition_id]]
     } : () -> (tensor<ui32>, tensor<ui32>)

--- a/stablehlo/tests/interpret/reduce_scatter.mlir
+++ b/stablehlo/tests/interpret/reduce_scatter.mlir
@@ -1,7 +1,7 @@
 // RUN: stablehlo-translate --interpret -split-input-file %s
 
 module @cross_replica {
-  func.func public @reduce_scatter(%operand : tensor<2x4xi64>) -> tensor<2x2xi64> {
+  func.func @reduce_scatter(%operand : tensor<2x4xi64>) -> tensor<2x2xi64> {
     %result = "stablehlo.reduce_scatter"(%operand) ({
       ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
         %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
@@ -12,7 +12,7 @@ module @cross_replica {
     } : (tensor<2x4xi64>) -> tensor<2x2xi64>
     return %result : tensor<2x2xi64>
   }
-  func.func public @main() {
+  func.func @main() {
     %inputs0 = stablehlo.constant dense<[[1, 2, 3, 4],
                                          [5, 6, 7, 8]]> : tensor<2x4xi64>
     %inputs1 = stablehlo.constant dense<[[9, 10, 11, 12],
@@ -31,7 +31,7 @@ module @cross_replica {
 // -----
 
 module @cross_replica_and_partition {
-  func.func public @reduce_scatter(%operand : tensor<2x4xi64>) -> tensor<2x2xi64> {
+  func.func @reduce_scatter(%operand : tensor<2x4xi64>) -> tensor<2x2xi64> {
     %result = "stablehlo.reduce_scatter"(%operand) ({
       ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
         %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
@@ -43,7 +43,7 @@ module @cross_replica_and_partition {
     } : (tensor<2x4xi64>) -> tensor<2x2xi64>
     return %result : tensor<2x2xi64>
   }
-  func.func public @main() {
+  func.func @main() {
     %inputs0 = stablehlo.constant dense<[[1, 2, 3, 4],
                                          [5, 6, 7, 8]]> : tensor<2x4xi64>
     %inputs1 = stablehlo.constant dense<[[9, 10, 11, 12],
@@ -62,7 +62,7 @@ module @cross_replica_and_partition {
 // -----
 
 module @flattened_ids {
-  func.func public @reduce_scatter(%operand : tensor<2x4xi64>) -> tensor<2x2xi64> {
+  func.func @reduce_scatter(%operand : tensor<2x4xi64>) -> tensor<2x2xi64> {
     %result = "stablehlo.reduce_scatter"(%operand) ({
       ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
         %0 = stablehlo.add %arg0, %arg1 : tensor<i64>
@@ -75,7 +75,7 @@ module @flattened_ids {
     } : (tensor<2x4xi64>) -> tensor<2x2xi64>
     return %result : tensor<2x2xi64>
   }
-  func.func public @main() {
+  func.func @main() {
     %inputs0 = stablehlo.constant dense<[[1, 2, 3, 4],
                                          [5, 6, 7, 8]]> : tensor<2x4xi64>
     %inputs1 = stablehlo.constant dense<[[9, 10, 11, 12],

--- a/stablehlo/tests/interpret/replica_id.mlir
+++ b/stablehlo/tests/interpret/replica_id.mlir
@@ -1,11 +1,11 @@
 // RUN: stablehlo-translate --interpret -split-input-file %s
 
 module @distribution_ops {
-  func.func public @replica_id() -> tensor<ui32> {
+  func.func @replica_id() -> tensor<ui32> {
     %result = stablehlo.replica_id : tensor<ui32>
     return %result : tensor<ui32>
   }
-  func.func public @main() {
+  func.func @main() {
     %results:2 = "interpreter.run_parallel"() {
       programs=[[@replica_id], [@replica_id]]
     } : () -> (tensor<ui32>, tensor<ui32>)

--- a/stablehlo/tests/interpret/send_recv.mlir
+++ b/stablehlo/tests/interpret/send_recv.mlir
@@ -1,7 +1,7 @@
 // RUN: stablehlo-translate --interpret -split-input-file %s
 
 module @sequential_send_recv_same_channel {
-  func.func public @send(%operand : tensor<2x2xi64>, %token : !stablehlo.token) -> (!stablehlo.token, !stablehlo.token) {
+  func.func @send(%operand : tensor<2x2xi64>, %token : !stablehlo.token) -> (!stablehlo.token, !stablehlo.token) {
     %result0 = "stablehlo.send"(%operand, %token) {
       channel_handle = #stablehlo.channel_handle<handle = 1, type = 2>,
       is_host_transfer = true
@@ -13,7 +13,7 @@ module @sequential_send_recv_same_channel {
     } : (tensor<2x2xi64>, !stablehlo.token) -> !stablehlo.token
     return %result0, %result1 : !stablehlo.token, !stablehlo.token
   }
-  func.func public @recv(%token : !stablehlo.token) -> (tensor<2x2xi64>, !stablehlo.token, tensor<2x2xi64>, !stablehlo.token) {
+  func.func @recv(%token : !stablehlo.token) -> (tensor<2x2xi64>, !stablehlo.token, tensor<2x2xi64>, !stablehlo.token) {
     %results0, %results1 = "stablehlo.recv"(%token) {
       channel_handle = #stablehlo.channel_handle<handle = 1, type = 3>,
       is_host_transfer = true
@@ -24,7 +24,7 @@ module @sequential_send_recv_same_channel {
     } : (!stablehlo.token) -> (tensor<2x2xi64>, !stablehlo.token)
     return %results0, %results1, %results2, %results3 : tensor<2x2xi64>, !stablehlo.token, tensor<2x2xi64>, !stablehlo.token
   }
-  func.func public @main() {
+  func.func @main() {
     %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
     %1 = stablehlo.after_all : !stablehlo.token
     %2:6 = "interpreter.run_parallel"(%0, %1, %1) {
@@ -40,35 +40,35 @@ module @sequential_send_recv_same_channel {
 // -----
 
 module @paralllel_send_recv_different_channels {
-  func.func public @send0(%operand : tensor<2x2xi64>, %token : !stablehlo.token) -> !stablehlo.token {
+  func.func @send0(%operand : tensor<2x2xi64>, %token : !stablehlo.token) -> !stablehlo.token {
     %result = "stablehlo.send"(%operand, %token) {
       channel_handle = #stablehlo.channel_handle<handle = 1, type = 2>,
       is_host_transfer = true
     } : (tensor<2x2xi64>, !stablehlo.token) -> !stablehlo.token
     return %result : !stablehlo.token
   }
-  func.func public @send1(%operand : tensor<2x2xi64>, %token : !stablehlo.token) -> !stablehlo.token {
+  func.func @send1(%operand : tensor<2x2xi64>, %token : !stablehlo.token) -> !stablehlo.token {
     %result = "stablehlo.send"(%operand, %token) {
       channel_handle = #stablehlo.channel_handle<handle = 2, type = 2>,
       is_host_transfer = true
     } : (tensor<2x2xi64>, !stablehlo.token) -> !stablehlo.token
     return %result : !stablehlo.token
   }
-  func.func public @recv0(%token : !stablehlo.token) -> (tensor<2x2xi64>, !stablehlo.token) {
+  func.func @recv0(%token : !stablehlo.token) -> (tensor<2x2xi64>, !stablehlo.token) {
     %results0, %results1 = "stablehlo.recv"(%token) {
       channel_handle = #stablehlo.channel_handle<handle = 1, type = 3>,
       is_host_transfer = true
     } : (!stablehlo.token) -> (tensor<2x2xi64>, !stablehlo.token)
     return %results0, %results1 : tensor<2x2xi64>, !stablehlo.token
   }
-  func.func public @recv1(%token : !stablehlo.token) -> (tensor<2x2xi64>, !stablehlo.token) {
+  func.func @recv1(%token : !stablehlo.token) -> (tensor<2x2xi64>, !stablehlo.token) {
     %results0, %results1 = "stablehlo.recv"(%token) {
       channel_handle = #stablehlo.channel_handle<handle = 2, type = 3>,
       is_host_transfer = true
     } : (!stablehlo.token) -> (tensor<2x2xi64>, !stablehlo.token)
     return %results0, %results1 : tensor<2x2xi64>, !stablehlo.token
   }
-  func.func public @main() {
+  func.func @main() {
     %0 = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
     %1 = stablehlo.constant dense<[[5, 6], [7, 8]]> : tensor<2x2xi64>
     %2 = stablehlo.after_all : !stablehlo.token


### PR DESCRIPTION
As pointed out by @mlevesquedion in https://github.com/openxla/stablehlo/pull/1983#discussion_r1480049496, the symbol visibility is public by default, and making it implicit follows the precedent of other tests in this directory.