### PR TITLE
Use new constant function instead of deleted makeScalar function

### DIFF
--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -1115,9 +1115,8 @@ Tensor evalCollectiveBroadcastOp(
     return process->rendezvous(*processGroup, channelId, operand)
         .lookup((*processGroup)[0]);
 
-  return evalBroadcastInDimOp(
-      makeScalar(convert(operand.getElementType(), 0.0)), {},
-      operand.getType());
+  return evalBroadcastInDimOp(constant(0.0, operand.getElementType()), {},
+                              operand.getType());
 }
 
 Tensor evalCollectivePermuteOp(


### PR DESCRIPTION
This seems to be from https://github.com/openxla/stablehlo/pull/1987 (see https://github.com/openxla/stablehlo/actions/runs/7808382192/job/21298492956).

Not sure how presubmit failed to catch this. I think what happened is the following:

1. https://github.com/openxla/stablehlo/pull/1987 was uploaded and passed presubmit.
2. https://github.com/openxla/stablehlo/pull/1983 was submitted, adding a new use of `makeScalar`.
3. https://github.com/openxla/stablehlo/pull/1987 was submitted, deleting `makeScalar` and causing tests to fail at HEAD.

What I don't understand is why this sequence of operations is possible in the first place. I feel like when https://github.com/openxla/stablehlo/pull/1983 was submitted, the earlier passing presubmit on https://github.com/openxla/stablehlo/pull/1987 should have been invalidated, blocking submit. I guess presubmits only re-run if you add a commit? So in this case since there was no new commit and no conflict, no new commit needed to be pushed and the presubmits were not run again.

In the grand scheme of things, I think this is fairly minor, but we may want to investigate whether we can prevent this somehow by tweaking some configuration settings or something.