### PR TITLE
Convert lambda call to a function call

### DIFF
--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -68,10 +68,10 @@ namespace hlo {
 //===----------------------------------------------------------------------===//
 
 // Checks if the vector `nums` has duplicates.
-const auto hasDuplicates = [](const ArrayRef<int64_t> nums) {
+bool hasDuplicates(ArrayRef<int64_t> nums) {
   llvm::SmallDenseSet<int64_t> set(nums.begin(), nums.end());
   return set.size() != nums.size();
-};
+}
 
 bool tensorsHaveSameElType(TypeRange types, bool ignoreFpPrecision = true) {
   if (!types.empty()) {
@@ -3279,16 +3279,15 @@ LogicalResult verifyBroadcastInDimOp(std::optional<Location> location,
                              dimensionsSize, ") does not match operand rank (",
                              operandRank, ")");
 
-  auto dimensions = llvm::to_vector(broadcastDimensions);
   // broadcast_in_dim_c4
-  if (hasDuplicates(dimensions))
+  if (hasDuplicates(broadcastDimensions))
     return emitOptionalError(location,
                              "broadcast_dimensions should not have duplicates");
 
   auto resultType = result.getType().cast<RankedTensorType>();
   auto resultRank = resultType.getRank();
   for (size_t i = 0; i != dimensionsSize; ++i) {
-    auto dimIndex = dimensions[i];
+    auto dimIndex = broadcastDimensions[i];
     // broadcast_in_dim_c3
     if (dimIndex < 0 || dimIndex >= resultRank)
       return emitOptionalError(location,


### PR DESCRIPTION
The `hasDuplicates` function was originally factored out because it is used frequently. However it was still defined as lambda, so I've updated it to be a function.

There was also an unnecessary conversion to a vector (the underlying data does not change), so I've removed the conversion too.