### PR TITLE
Remove redundant downgrade test

### DIFF
--- a/stablehlo/tests/vhlo/vhlo_to_version_downgrade_invalid.0_16_0.mlir
+++ b/stablehlo/tests/vhlo/vhlo_to_version_downgrade_invalid.0_16_0.mlir
@@ -121,11 +121,3 @@ func.func @select_and_scatter_with_promotable_types(
         tensor<10x24x24x64xf64>
   func.return
 }
-
-// -----
-
-// expected-error @+1 {{failed to legalize operation 'vhlo.func_v1' that was explicitly marked illegal}}
-func.func @type_per_axis_quantization(%arg0: tensor<2x!quant.uniform<i8:f32:0, {34.0:16, 34.0:16}>>) -> tensor<2x!quant.uniform<i8:f32:0, {34.0:16, 34.0:16}>> {
-  %0 = stablehlo.add %arg0, %arg0 : tensor<2x!quant.uniform<i8:f32:0, {34.0:16, 34.0:16}>>
-  func.return %0 : tensor<2x!quant.uniform<i8:f32:0, {34.0:16, 34.0:16}>>
-}


### PR DESCRIPTION
This is covered by the invalid 0.17.0 test, don't need it in both. We tend to only have the illegal downgrade test at the boundary where it would occur