### PR TITLE
Fix issues that were missed due to CI script issues

### DIFF
--- a/stablehlo/transforms/StablehloAggressiveSimplification.cpp
+++ b/stablehlo/transforms/StablehloAggressiveSimplification.cpp
@@ -126,9 +126,8 @@ struct AddOpCanon final : OpRewritePattern<mlir::stablehlo::AddOp> {
 
     // The canonical form has the constant operand as the RHS.
     if (isa<IntegerType>(type.getElementType()) && lhsAttr && !rhsAttr) {
-      rewriter.modifyOpInPlace(op, [op, lhs, rhs] {
-        op->setOperands(ValueRange{rhs, lhs});
-      });
+      rewriter.modifyOpInPlace(
+          op, [op, lhs, rhs] { op->setOperands(ValueRange{rhs, lhs}); });
       return success();
     }
 
@@ -221,9 +220,8 @@ struct MulOpCanon final : OpRewritePattern<mlir::stablehlo::MulOp> {
 
     // The canonical form has the constant operand as the RHS.
     if (isa<IntegerType>(type.getElementType()) && lhsAttr && !rhsAttr) {
-      rewriter.modifyOpInPlace(op, [op, lhs, rhs] {
-        op->setOperands(ValueRange{rhs, lhs});
-      });
+      rewriter.modifyOpInPlace(
+          op, [op, lhs, rhs] { op->setOperands(ValueRange{rhs, lhs}); });
       return success();
     }
 


### PR DESCRIPTION
I'm surprised there weren't any whitespace check misses, and I'm confused as to why there were clang-format issues, given that the check ran successfully when the code was introduced: https://github.com/openxla/stablehlo/actions/runs/7809371206/job/21301436418

Hopefully with #2012 script failures should not go unnoticed. 