### PR TITLE
Replace addlicense with find and grep

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -91,11 +91,10 @@ jobs:
       - name: Checking out repository
         uses: actions/checkout@v4
 
-      - name: Install addlicense
-        run: go install github.com/google/addlicense@latest
-
       - name: Run license checks
-        run: addlicense -check -ignore '.git/**' -ignore 'build/**' -ignore 'llvm*/**' .
+        run: |
+          git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"
+          ./build_tools/github_actions/lint_check_license.sh -b "${GITHUB_BASE_REF}"
 
   shell-script-check:
     if: "github.event_name == 'pull_request'"

--- a/build_tools/github_actions/lint_check_license.sh
+++ b/build_tools/github_actions/lint_check_license.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022 The StableHLO Authors.
+# Copyright 2024 The StableHLO Authors.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -51,12 +51,12 @@ for file in "${CHANGED_FILES[@]}"; do
     echo
     continue
   fi
-  if [[ "$file" =~ *.mlir ]]; then
+  if [[ "$file" = *.mlir ]]; then
     echo "Skipping MLIR assembly file: $file"
     echo
     continue
   fi
-  if [[ "$file" =~ *.md ]]; then
+  if [[ "$file" = *.md ]]; then
     echo "Skipping Markdown file: $file"
     echo
     continue

--- a/build_tools/github_actions/lint_check_license.sh
+++ b/build_tools/github_actions/lint_check_license.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Copyright 2022 The StableHLO Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+print_usage() {
+  echo "Usage: $0 [-b]"
+  echo "    -b <branch>  Base branch name, defaults to main."
+}
+
+BASE_BRANCH=main
+while getopts 'b:' flag; do
+  case "${flag}" in
+    b) BASE_BRANCH="$OPTARG" ;;
+    *) print_usage
+       exit 1 ;;
+  esac
+done
+shift $(( OPTIND - 1 ))
+
+if [[ $# -ne 0 ]] ; then
+  print_usage
+  exit 1
+fi
+
+echo "Gathering changed files..."
+echo
+mapfile -t CHANGED_FILES < <(git diff "$BASE_BRANCH" HEAD --name-only --diff-filter=d)
+if (( ${#CHANGED_FILES[@]} == 0 )); then
+  echo "Found no changed files."
+  exit 0
+fi
+
+echo "Checking the following files for licenses:
+$(printf "%s\n" "${CHANGED_FILES[@]}")"
+echo
+
+UNLICENSED_FILES=()
+for file in "${CHANGED_FILES[@]}"; do
+  if [[ "$file" == MODULE.bazel.lock ]]; then
+    echo "Skipping generated file: $file"
+    echo
+    continue
+  fi
+  if [[ "$file" =~ *.mlir ]]; then
+    echo "Skipping MLIR assembly file: $file"
+    echo
+    continue
+  fi
+  if [[ "$file" =~ *.md ]]; then
+    echo "Skipping Markdown file: $file"
+    echo
+    continue
+  fi
+  if ! head -20 "$file" | grep "Copyright" &>/dev/null; then
+    UNLICENSED_FILES+=("$file")
+  fi
+done
+
+if (( ${#UNLICENSED_FILES} )); then
+  echo "Found unlicensed files:
+$(printf "%s\n" "${UNLICENSED_FILES[@]}")"
+  exit 1
+fi
+
+echo "Found no unlicensed files."


### PR DESCRIPTION
addlicense is not maintained and is not extensible. find and grep are sufficient for our use case. Note that what the new script is doing is basically equivalent to addlicense:
- Find files that may need licenses: https://github.com/google/addlicense/blob/4caba19b7ed7818bb86bc4cd20411a246aa4a524/main.go#L197
- Look for a license: https://github.com/google/addlicense/blob/4caba19b7ed7818bb86bc4cd20411a246aa4a524/main.go#L372

Unfortunately, addlicense only handles files with extensions it knows about, and there is no way to specify additional extensions: https://github.com/google/addlicense/blob/4caba19b7ed7818bb86bc4cd20411a246aa4a524/main.go#L163

I believe the reason for this is that addlicense can also add licenses to files automatically, which requires knowing e.g. what is the comment syntax for each given file. However, in our case we add new files rarely enough that doing so manually should not be too painful. If it does turn out to be painful, I can update this script to provide an autofix mode.

See this thread for additional context: https://github.com/openxla/stablehlo/pull/2016#discussion_r1493040821