### PR TITLE
Remove extra % prefix for function inputs

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -50,7 +50,7 @@ func.func @main(
 ```ebnf
 Func        ::= 'func' '.' 'func' FuncId FuncInputs FuncOutputs '{' FuncBody '}'
 FuncInputs  ::= '(' [FuncInput {',' FuncInput}] `)`
-FuncInput   ::= '%' ValueId ':' ValueType
+FuncInput   ::= ValueId ':' ValueType
 FuncOutputs ::= ['->' FuncOutput, {',' FuncOutput}]
 FuncOutput  ::= ValueType
 FuncBody    ::= {Op}


### PR DESCRIPTION
The way the spec is currently written, a function input would be written e.g. `%%arg0` instead of `%arg0`.