### PR TITLE
Exclude MLIR bytecode files from license check

### DIFF
--- a/build_tools/github_actions/lint_check_license.sh
+++ b/build_tools/github_actions/lint_check_license.sh
@@ -44,22 +44,24 @@ echo "Checking the following files for licenses:
 $(printf "%s\n" "${CHANGED_FILES[@]}")"
 echo
 
+SKIPPED_SUFFIXES=(
+  MODULE.bazel.lock
+  .mlir
+  .mlir.bc
+  .md
+)
+
 UNLICENSED_FILES=()
 for file in "${CHANGED_FILES[@]}"; do
-  if [[ "$file" == MODULE.bazel.lock ]]; then
-    echo "Skipping generated file: $file"
-    echo
-    continue
-  fi
-  if [[ "$file" = *.mlir ]]; then
-    echo "Skipping MLIR assembly file: $file"
-    echo
-    continue
-  fi
-  if [[ "$file" = *.md ]]; then
-    echo "Skipping Markdown file: $file"
-    echo
-    continue
+  skip=0
+  for suffix in "${SKIPPED_SUFFIXES[@]}"; do
+    if [[ "$file" = *$suffix ]]; then
+      skip=1
+    fi
+  done
+  if (( skip )); then
+    echo "Skipping file: $file"
+    continue;
   fi
   if ! head -20 "$file" | grep "Copyright" &>/dev/null; then
     UNLICENSED_FILES+=("$file")


### PR DESCRIPTION
Also, don't add an extra line between each skip, and use the same message for each type of skipped file (easier to read).

I tested the script locally by creating files with various suffixes and confirmed that the skipped suffixes are indeed skipped (and files with a non-skipped suffix are not skipped).