### PR TITLE
Ignore all files that shouldn't have licenses

### DIFF
--- a/build_tools/github_actions/lint_check_license.sh
+++ b/build_tools/github_actions/lint_check_license.sh
@@ -45,10 +45,19 @@ $(printf "%s\n" "${CHANGED_FILES[@]}")"
 echo
 
 SKIPPED_SUFFIXES=(
-  MODULE.bazel.lock
+  .bazelversion
+  .clang-format
+  .gitignore
+  .markdownlint.yaml
+  .md
   .mlir
   .mlir.bc
-  .md
+  .png
+  .svg
+  LICENSE
+  MODULE.bazel.lock
+  WORKSPACE.bazel
+  llvm_version.txt
 )
 
 UNLICENSED_FILES=()


### PR DESCRIPTION
Unblocks #2029

I ran the license checker with `find` as input instead of `git diff` to find all the relevant files and exempted the files that don't already have licenses.