### PR TITLE
Print clang-format version in CI

### DIFF
--- a/build_tools/github_actions/lint_clang_format.sh
+++ b/build_tools/github_actions/lint_clang_format.sh
@@ -39,6 +39,8 @@ if [[ $# -ne 0 ]] ; then
   exit 1
 fi
 
+clang-format --version
+
 echo "Gathering changed files..."
 mapfile -t CHANGED_FILES < <(git diff "$BASE_BRANCH" HEAD --name-only --diff-filter=d | grep '.*\.h\|.*\.cpp')
 if (( ${#CHANGED_FILES[@]} == 0 )); then


### PR DESCRIPTION
The version of clang-format available in CI seems to be different from the one on my machine, but I can't easily see what the version of clang-format running in CI is, so I can't really debug. Print the version so that moving forward if someone runs afoul of the check they can repro and fix.