### PR TITLE
Simplify creation of `TensorType`  variants using `TensorType::clone`

### DIFF
--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -188,11 +188,7 @@ LogicalResult deriveShapeFromOperand(
 }
 
 ShapedType getSameShapeTensorType(ShapedType shapedType, Type elementType) {
-  if (auto rankedTensorTy = shapedType.dyn_cast<RankedTensorType>())
-    return RankedTensorType::get(rankedTensorTy.getShape(), elementType,
-                                 rankedTensorTy.getEncoding());
-  if (auto unrankedTensorTy = shapedType.dyn_cast<UnrankedTensorType>())
-    return UnrankedTensorType::get(elementType);
+  if (shapedType.isa<TensorType>()) return shapedType.clone(elementType);
   llvm::report_fatal_error("unsupported type");
 }
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1406,17 +1406,8 @@ LogicalResult inferAbsOp(std::optional<Location>, Value operand,
   if (auto complexTy = elementTy.dyn_cast<ComplexType>())
     elementTy = complexTy.getElementType();
 
-  Type resultTy;
   // abs_c1
-  if (auto rankedOperandTy = operandTy.dyn_cast<RankedTensorType>()) {
-    resultTy = RankedTensorType::get(operandTy.getShape(), elementTy,
-                                     rankedOperandTy.getEncoding());
-  } else if (operandTy.hasRank()) {
-    resultTy = RankedTensorType::get(operandTy.getShape(), elementTy);
-  } else {
-    resultTy = UnrankedTensorType::get(elementTy);
-  }
-  inferredReturnTypes.push_back(resultTy);
+  inferredReturnTypes.push_back(operandTy.clone(elementTy));
   return success();
 }
 


### PR DESCRIPTION
Let's use `TensorType::clone` which is customized to create TensorType variants (`RankedTensorType` and `UnRankedTensorType`).