### PR TITLE
Use bash strict mode in license check script

### DIFF
--- a/build_tools/github_actions/lint_check_license.sh
+++ b/build_tools/github_actions/lint_check_license.sh
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 print_usage() {
   echo "Usage: $0 [-b]"
   echo "    -b <branch>  Base branch name, defaults to main."
@@ -68,7 +72,7 @@ for file in "${CHANGED_FILES[@]}"; do
   fi
 done
 
-if (( ${#UNLICENSED_FILES} )); then
+if (( ${#UNLICENSED_FILES[@]} )); then
   echo "Found unlicensed files:
 $(printf "%s\n" "${UNLICENSED_FILES[@]}")"
   exit 1


### PR DESCRIPTION
When I added the script in https://github.com/openxla/stablehlo/pull/2018, I bootstrapped it from a script that didn't use strict mode. Around the same time, I sent https://github.com/openxla/stablehlo/pull/2012 for review, but forgot to apply the change to this new script as well.

Also, change the condition on whether UNLICENSED_FILES contains any
elements to avoid triggering nounset.