### PR TITLE
Migrate Shape legalizations to StableHLO

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -927,6 +927,7 @@ cc_library(
     srcs = [
         "stablehlo/transforms/ChloLegalizeToStablehlo.cpp",
         "stablehlo/transforms/PassPipelines.cpp",
+        "stablehlo/transforms/ShapeLegalizeToStablehlo.cpp",
         "stablehlo/transforms/StablehloAggressiveSimplification.cpp",
         "stablehlo/transforms/StablehloCanonicalizeDynamism.cpp",
         "stablehlo/transforms/StablehloInstrumentWithProbe.cpp",
@@ -955,6 +956,7 @@ cc_library(
         ":vhlo_ops",
         ":vhlo_types",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:CommonFolders",
         "@llvm-project//mlir:ComplexDialect",
         "@llvm-project//mlir:FuncDialect",

--- a/stablehlo/tests/shape_legalize_to_stablehlo.mlir
+++ b/stablehlo/tests/shape_legalize_to_stablehlo.mlir
@@ -1,0 +1,338 @@
+// RUN: stablehlo-opt --shape-legalize-to-stablehlo --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL: func.func @compute_reshape_shape
+func.func @compute_reshape_shape(%arg0: index, %arg1: tensor<2xi32>) -> tensor<2xi32> {
+  %0 = stablehlo.compute_reshape_shape %arg0, %arg1 : (index, tensor<2xi32>) -> tensor<2xi32>
+  func.return %0 : tensor<2xi32>
+  //      CHECK: %[[ARG0_I32:.*]] = builtin.unrealized_conversion_cast %arg0 : index to tensor<i32>
+  // CHECK-NEXT: %[[TMP0:.*]] = stablehlo.constant dense<-1> : tensor<i32>
+  // CHECK-NEXT: %[[INPUT_SIZE0x1:.*]] = stablehlo.slice %arg1 [0:1] : (tensor<2xi32>) -> tensor<1xi32>
+  // CHECK-NEXT: %[[INPUT_SIZE0:.*]] = stablehlo.reshape %[[INPUT_SIZE0x1]] : (tensor<1xi32>) -> tensor<i32>
+  // CHECK-NEXT: %[[TMP1:.*]] = stablehlo.multiply %[[TMP0]], %[[INPUT_SIZE0]] : tensor<i32>
+  // CHECK-NEXT: %[[INPUT_SIZE1x1:.*]] = stablehlo.slice %arg1 [1:2] : (tensor<2xi32>) -> tensor<1xi32>
+  // CHECK-NEXT: %[[INPUT_SIZE1:.*]] = stablehlo.reshape %[[INPUT_SIZE1x1]] : (tensor<1xi32>) -> tensor<i32>
+  // CHECK-NEXT: %[[INPUT_SIZE_PRODUCT:.*]] = stablehlo.multiply %[[TMP1]], %[[INPUT_SIZE1]] : tensor<i32>
+  // CHECK-NEXT: %[[COMPUTED_SIZE:.*]] = stablehlo.divide %[[ARG0_I32]], %[[INPUT_SIZE_PRODUCT]] : tensor<i32>
+  // CHECK-NEXT: %[[M1:.*]] = stablehlo.constant dense<-1> : tensor<i32>
+  // CHECK-NEXT: %[[INPUT_SIZE0_EQ_M1:.*]] = stablehlo.compare  EQ, %3, %[[M1]],  NOTYPE : (tensor<i32>, tensor<i32>) -> tensor<i1>
+  // CHECK-NEXT: %[[RESULT_SIZE0:.*]] = stablehlo.select %[[INPUT_SIZE0_EQ_M1]], %[[COMPUTED_SIZE]], %3 : tensor<i1>, tensor<i32>
+  // CHECK-NEXT: %[[RESULT_SIZE0x1:.*]] = stablehlo.reshape %[[RESULT_SIZE0]] : (tensor<i32>) -> tensor<1xi32>
+  // CHECK-NEXT: %[[INPUT_SIZE1_EQ_M1:.*]] = stablehlo.compare  EQ, %6, %[[M1]],  NOTYPE : (tensor<i32>, tensor<i32>) -> tensor<i1>
+  // CHECK-NEXT: %[[RESULT_SIZE1:.*]] = stablehlo.select %[[INPUT_SIZE1_EQ_M1]], %[[COMPUTED_SIZE]], %6 : tensor<i1>, tensor<i32>
+  // CHECK-NEXT: %[[RESULT_SIZE1x1:.*]] = stablehlo.reshape %[[RESULT_SIZE1]] : (tensor<i32>) -> tensor<1xi32>
+  // CHECK-NEXT: %[[RESULT:.*]] = stablehlo.concatenate %[[RESULT_SIZE0x1]], %[[RESULT_SIZE1x1]], dim = 0 : (tensor<1xi32>, tensor<1xi32>) -> tensor<2xi32>
+  // CHECK-NEXT: return %[[RESULT]] : tensor<2xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @num_elements_tensor_to_index
+func.func @num_elements_tensor_to_index(%arg0: tensor<2xindex>) -> index {
+  %0 = shape.num_elements %arg0 : tensor<2xindex> -> index
+  func.return %0 : index
+  //      CHECK: %[[ARG0_I32:.*]] = builtin.unrealized_conversion_cast %arg0 : tensor<2xindex> to tensor<2xi32>
+  // CHECK-NEXT: %[[TMP0:.*]] = stablehlo.constant dense<1> : tensor<i32>
+  // CHECK-NEXT: %[[SIZE0x1:.*]] = stablehlo.slice %[[ARG0_I32]] [0:1] : (tensor<2xi32>) -> tensor<1xi32>
+  // CHECK-NEXT: %[[SIZE0:.*]] = stablehlo.reshape %[[SIZE0x1]] : (tensor<1xi32>) -> tensor<i32>
+  // CHECK-NEXT: %[[TMP1:.*]] = stablehlo.multiply %[[TMP0]], %[[SIZE0]] : tensor<i32>
+  // CHECK-NEXT: %[[SIZE1x1:.*]] = stablehlo.slice %[[ARG0_I32]] [1:2] : (tensor<2xi32>) -> tensor<1xi32>
+  // CHECK-NEXT: %[[SIZE1:.*]] = stablehlo.reshape %[[SIZE1x1]] : (tensor<1xi32>) -> tensor<i32>
+  // CHECK-NEXT: %[[RESULT_I32:.*]] = stablehlo.multiply %[[TMP1]], %[[SIZE1]] : tensor<i32>
+  // CHECK-NEXT: %[[RESULT_INDEX:.*]] = builtin.unrealized_conversion_cast %[[RESULT_I32]] : tensor<i32> to index
+  // CHECK-NEXT: return %[[RESULT_INDEX]] : index
+}
+
+// -----
+
+func.func @num_elements_shape_to_xxx(%arg0: !shape.shape) -> !shape.size {
+  // expected-error@+1 {{failed to legalize operation 'shape.num_elements' that was explicitly marked illegal}}
+  %0 = shape.num_elements %arg0 : !shape.shape -> !shape.size
+  func.return %0 : !shape.size
+}
+
+// -----
+
+func.func @num_elements_xxx_to_size(%arg0: tensor<2xindex>) -> !shape.size {
+  // expected-error@+1 {{failed to legalize operation 'shape.num_elements' that was explicitly marked illegal}}
+  %0 = shape.num_elements %arg0 : tensor<2xindex> -> !shape.size
+  func.return %0 : !shape.size
+}
+
+// -----
+
+// CHECK-LABEL: func.func @shape_of_ranked
+func.func @shape_of_ranked_to_index(%arg0: tensor<?x1xf32>) -> tensor<2xindex> {
+  %0 = shape.shape_of %arg0 : tensor<?x1xf32> -> tensor<2xindex>
+  func.return %0 : tensor<2xindex>
+  //      CHECK: %[[SIZE0x1:.*]] = stablehlo.get_dimension_size %arg0, dim = 0 : (tensor<?x1xf32>) -> tensor<i32>
+  // CHECK-NEXT: %[[SIZE0:.*]] = stablehlo.reshape %[[SIZE0x1]] : (tensor<i32>) -> tensor<1xi32>
+  // CHECK-NEXT: %[[SIZE1x1:.*]] = stablehlo.get_dimension_size %arg0, dim = 1 : (tensor<?x1xf32>) -> tensor<i32>
+  // CHECK-NEXT: %[[SIZE1:.*]] = stablehlo.reshape %[[SIZE1x1]] : (tensor<i32>) -> tensor<1xi32>
+  // CHECK-NEXT: %[[RESULT_I32:.*]] = stablehlo.concatenate %[[SIZE0]], %[[SIZE1]], dim = 0 : (tensor<1xi32>, tensor<1xi32>) -> tensor<2xi32>
+  // CHECK-NEXT: %[[RESULT_INDEX:.*]] = builtin.unrealized_conversion_cast %[[RESULT_I32]] : tensor<2xi32> to tensor<2xindex>
+  // CHECK-NEXT: return %[[RESULT_INDEX]] : tensor<2xindex>
+}
+
+// -----
+
+func.func @shape_of_unranked_to_xxx(%arg0: tensor<*xf32>) -> tensor<?xindex> {
+  // expected-error@+1 {{failed to legalize operation 'shape.shape_of' that was explicitly marked illegal}}
+  %0 = shape.shape_of %arg0 : tensor<*xf32> -> tensor<?xindex>
+  func.return %0 : tensor<?xindex>
+}
+
+// -----
+
+func.func @shape_of_ranked_to_shape(%arg0: tensor<?x1xf32>) -> !shape.shape {
+  // expected-error@+1 {{failed to legalize operation 'shape.shape_of' that was explicitly marked illegal}}
+  %0 = shape.shape_of %arg0 : tensor<?x1xf32> -> !shape.shape
+  func.return %0 : !shape.shape
+}
+
+// -----
+
+// CHECK-LABEL: func.func @tensor_dim
+func.func @tensor_dim(%arg0: tensor<?x?xf32>) -> index {
+  %c0 = arith.constant 0 : index
+  %dim = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  func.return %dim : index
+  //      CHECK: %[[DIM_SIZE:.*]] = stablehlo.get_dimension_size %arg0, dim = 0 : (tensor<?x?xf32>) -> tensor<i32>
+  // CHECK-NEXT: %[[DIM_SIZE_INDEX:.*]] = builtin.unrealized_conversion_cast %[[DIM_SIZE]] : tensor<i32> to index
+  // CHECK-NEXT: return %[[DIM_SIZE_INDEX]] : index
+}
+
+// -----
+
+func.func @tensor_dim_dynamic(%arg0: tensor<?x?xf32>, %arg1: index) -> index {
+  // expected-error@+1 {{failed to legalize operation 'tensor.dim' that was explicitly marked illegal}}
+  %dim = tensor.dim %arg0, %arg1 : tensor<?x?xf32>
+  func.return %dim : index
+}
+
+// -----
+
+// CHECK-LABEL: func.func @tensor_from_elements
+func.func @tensor_from_elements(%arg0: index) -> tensor<2xindex> {
+  %c0 = arith.constant 0 : index
+  %0 = tensor.from_elements %arg0, %c0 : tensor<2xindex>
+  func.return %0 : tensor<2xindex>
+  //      CHECK: %[[ELEMENT1_SCALAR:.*]] = builtin.unrealized_conversion_cast %arg0 : index to tensor<i32>
+  // CHECK-NEXT: %[[ELEMENT1:.*]] = stablehlo.reshape %[[ELEMENT1_SCALAR]] : (tensor<i32>) -> tensor<1xi32>
+  // CHECK-NEXT: %[[ELEMENT2:.*]] = stablehlo.constant dense<0> : tensor<1xi32>
+  // CHECK-NEXT: %[[CONCAT:.*]] = stablehlo.concatenate %[[ELEMENT1]], %[[ELEMENT2]], dim = 0 : (tensor<1xi32>, tensor<1xi32>) -> tensor<2xi32>
+  // CHECK-NEXT: %[[CONCAT_INDEX:.*]] = builtin.unrealized_conversion_cast %[[CONCAT]] : tensor<2xi32> to tensor<2xindex>
+  // CHECK-NEXT: return %[[CONCAT_INDEX]] : tensor<2xindex>
+}
+
+// -----
+
+func.func @tensor_from_elements_i8(%arg0: i8) -> tensor<2xi8> {
+  %c0 = arith.constant 0 : i8
+  // expected-error@+1 {{failed to legalize operation 'tensor.from_elements' that was explicitly marked illegal}}
+  %0 = tensor.from_elements %arg0, %c0 : tensor<2xi8>
+  func.return %0 : tensor<2xi8>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @tensor_from_elements_scalar
+func.func @tensor_from_elements_scalar(%arg0: i64) -> tensor<i64> {
+  %0 = tensor.from_elements %arg0 : tensor<i64>
+  func.return %0 : tensor<i64>
+  //      CHECK: %[[RESULT:.*]] = builtin.unrealized_conversion_cast %arg0 : i64 to tensor<i64>
+  // CHECK-NEXT: return %[[RESULT]] : tensor<i64>
+}
+
+// -----
+
+func.func @tensor_from_elements_rank2(%arg0: index) -> tensor<2x1xindex> {
+  %c0 = arith.constant 0 : index
+  // expected-error@+1 {{failed to legalize operation 'tensor.from_elements' that was explicitly marked illegal}}
+  %0 = tensor.from_elements %arg0, %c0 : tensor<2x1xindex>
+  func.return %0 : tensor<2x1xindex>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @shape_broadcast
+func.func @shape_broadcast(%arg0: tensor<4xindex>, %arg1: tensor<4xindex>) -> tensor<4xindex> {
+  %0 = shape.broadcast %arg0, %arg1 : tensor<4xindex>, tensor<4xindex> -> tensor<4xindex>
+  func.return %0 : tensor<4xindex>
+  //      CHECK: %[[LHS:.*]] = builtin.unrealized_conversion_cast %arg0 : tensor<4xindex> to tensor<4xi32>
+  // CHECK-NEXT: %[[RHS:.*]] = builtin.unrealized_conversion_cast %arg1 : tensor<4xindex> to tensor<4xi32>
+  // CHECK-NEXT: %[[BROADCAST:.*]] = stablehlo.maximum %[[LHS]], %[[RHS]] : tensor<4xi32>
+  // CHECK-NEXT: %[[BROADCAST_INDEX:.*]] = builtin.unrealized_conversion_cast %[[BROADCAST]] : tensor<4xi32> to tensor<4xindex>
+  // CHECK-NEXT: return %[[BROADCAST_INDEX]] : tensor<4xindex>
+}
+
+// -----
+
+func.func @shape_broadcast_different_dims(%arg0: tensor<4xindex>, %arg1: tensor<6xindex>) -> tensor<6xindex> {
+  %0 = shape.broadcast %arg0, %arg1 : tensor<4xindex>, tensor<6xindex> -> tensor<6xindex>
+  func.return %0 : tensor<6xindex>
+  //      CHECK: %[[LHS:.*]] = builtin.unrealized_conversion_cast %arg0 : tensor<4xindex> to tensor<4xi32>
+  // CHECK-NEXT: %[[RHS:.*]] = builtin.unrealized_conversion_cast %arg1 : tensor<6xindex> to tensor<6xi32>
+  // CHECK-NEXT: %[[PAD:.*]] = stablehlo.constant dense<1> : tensor<2xi32>
+  // CHECK-NEXT: %[[LHS_PAD:.*]] = stablehlo.concatenate %[[PAD]], %[[LHS]], dim = 0 : (tensor<2xi32>, tensor<4xi32>) -> tensor<6xi32>
+  // CHECK-NEXT: %[[BROADCAST:.*]] = stablehlo.maximum %[[LHS_PAD]], %[[RHS]] : tensor<6xi32>
+  // CHECK-NEXT: %[[BROADCAST_INDEX:.*]] = builtin.unrealized_conversion_cast %[[BROADCAST]] : tensor<6xi32> to tensor<6xindex>
+  // CHECK-NEXT: return %[[BROADCAST_INDEX]] : tensor<6xindex>
+}
+
+// -----
+
+func.func @shape_broadcast_result_shape(%arg0: tensor<4xindex>, %arg1: tensor<4xindex>) -> !shape.shape {
+  // expected-error@+1 {{failed to legalize operation 'shape.broadcast' that was explicitly marked illegal}}
+  %0 = shape.broadcast %arg0, %arg1 : tensor<4xindex>, tensor<4xindex> -> !shape.shape
+  func.return %0 : !shape.shape
+}
+
+// -----
+
+func.func @shape_broadcast_input_shape(%arg0: !shape.shape, %arg1: !shape.shape) -> !shape.shape {
+  // expected-error@+1 {{failed to legalize operation 'shape.broadcast' that was explicitly marked illegal}}
+  %0 = shape.broadcast %arg0, %arg1 : !shape.shape, !shape.shape -> !shape.shape
+  func.return %0 : !shape.shape
+}
+
+// -----
+
+func.func @shape_broadcast_too_many_operands(%arg0: tensor<4xindex>, %arg1: tensor<4xindex>, %arg2: tensor<4xindex>) -> tensor<4xindex> {
+  // expected-error@+1 {{failed to legalize operation 'shape.broadcast' that was explicitly marked illegal}}
+  %0 = shape.broadcast %arg0, %arg1, %arg2 : tensor<4xindex>, tensor<4xindex>, tensor<4xindex> -> tensor<4xindex>
+  func.return %0 : tensor<4xindex>
+}
+
+// -----
+
+func.func @shape_cstr_broadcastable(%arg0: tensor<2xindex>, %arg1: tensor<2xindex>) -> !shape.witness {
+  // expected-error@+1 {{failed to legalize operation 'shape.cstr_broadcastable' that was explicitly marked illegal}}
+  %0 = shape.cstr_broadcastable %arg0, %arg1 : tensor<2xindex>, tensor<2xindex>
+  func.return %0 : !shape.witness
+}
+
+// -----
+
+func.func @mhlo_cstr_reshapable(%arg0: index, %arg1: tensor<2xindex>, %arg2: tensor<?x2xf32>) -> tensor<?x4xf32> {
+  // expected-error@+1 {{failed to legalize operation 'stablehlo.cstr_reshapable' that was explicitly marked illegal}}
+  %0 = stablehlo.cstr_reshapable %arg0, %arg1 : (index, tensor<2xindex>) -> !shape.witness
+  %1 = shape.assuming %0 -> (tensor<?x4xf32>) {
+    %2 = stablehlo.dynamic_reshape %arg2, %arg1 : (tensor<?x2xf32>, tensor<2xindex>) -> tensor<?x4xf32>
+    shape.assuming_yield %2 : tensor<?x4xf32>
+  }
+  func.return %1 : tensor<?x4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @const_shape
+func.func @const_shape() -> tensor<2xindex> {
+  %0 = shape.const_shape [6, 4] : tensor<2xindex>
+  return %0 : tensor<2xindex>
+  //      CHECK: %[[CST:.*]] = stablehlo.constant dense<[6, 4]> : tensor<2xi32>
+  // CHECK-NEXT: %[[CST_INDEX:.*]] = builtin.unrealized_conversion_cast %[[CST]] : tensor<2xi32> to tensor<2xindex>
+  // CHECK-NEXT: return %[[CST_INDEX]] : tensor<2xindex>
+}
+
+// -----
+
+// CHECK-LABEL: func @index_cast_index_to_i32
+func.func @index_cast_index_to_i32(%arg0: tensor<2xindex>) -> tensor<2xi32> {
+  %0 = arith.index_cast %arg0 : tensor<2xindex> to tensor<2xi32>
+  return %0 : tensor<2xi32>
+  // CHECK-NEXT: %[[CST_I32:.*]] = builtin.unrealized_conversion_cast %arg0 : tensor<2xindex> to tensor<2xi32>
+  // CHECK-NEXT: return %[[CST_I32]] : tensor<2xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func @index_cast_i32_to_index
+func.func @index_cast_i32_to_index(%arg0: tensor<2xi32>) -> tensor<2xindex> {
+  %0 = arith.index_cast %arg0 : tensor<2xi32> to tensor<2xindex>
+  return %0 : tensor<2xindex>
+  // CHECK-NEXT: %[[CST_INDEX:.*]] = builtin.unrealized_conversion_cast %arg0 : tensor<2xi32> to tensor<2xindex>
+  // CHECK-NEXT: return %[[CST_INDEX]] : tensor<2xindex>
+}
+
+// -----
+
+// CHECK-LABEL: func @index_cast_scalar_index_to_i32
+func.func @index_cast_scalar_index_to_i32(%arg0: index) -> i32 {
+  //      CHECK: %[[CAST_I32:.*]] = builtin.unrealized_conversion_cast %arg0 : index to tensor<i32>
+  // CHECK-NEXT: %[[CAST_INDEX:.*]] = builtin.unrealized_conversion_cast %[[CAST_I32]] : tensor<i32> to i32
+  // CHECK-NEXT: return %[[CAST_INDEX]] : i32
+  %0 = arith.index_cast %arg0 : index to i32
+  return %0 : i32
+}
+
+// -----
+
+// CHECK-LABEL: func @index_cast_scalar_index_to_i64
+func.func @index_cast_scalar_index_to_i64(%arg0: index) -> i64 {
+  //      CHECK: %[[CAST_I32:.*]] = builtin.unrealized_conversion_cast %arg0 : index to tensor<i32>
+  // CHECK-NEXT: %[[CONVERT:.*]] = stablehlo.convert %[[CAST_I32]] : (tensor<i32>) -> tensor<i64>
+  // CHECK-NEXT: %[[CAST_INDEX:.*]] = builtin.unrealized_conversion_cast %[[CONVERT]] : tensor<i64> to i64
+  // CHECK-NEXT: return %[[CAST_INDEX]] : i64
+  %0 = arith.index_cast %arg0 : index to i64
+  return %0 : i64
+}
+
+// -----
+
+func.func @index_cast_index_to_i8(%arg0: tensor<2xindex>) -> tensor<2xi8> {
+  // expected-error@+1 {{failed to legalize operation 'arith.index_cast' that was explicitly marked illegal}}
+  %0 = arith.index_cast %arg0 : tensor<2xindex> to tensor<2xi8>
+  return %0 : tensor<2xi8>
+}
+
+// -----
+
+func.func @index_cast_i8_to_index(%arg0: tensor<2xi8>) -> tensor<2xindex> {
+  // expected-error@+1 {{failed to legalize operation 'arith.index_cast' that was explicitly marked illegal}}
+  %0 = arith.index_cast %arg0 : tensor<2xi8> to tensor<2xindex>
+  return %0 : tensor<2xindex>
+}
+
+// -----
+
+func.func @index_cast_scalar_i32_to_index(%arg0: i32) -> index {
+  // expected-error@+1 {{failed to legalize operation 'arith.index_cast' that was explicitly marked illegal}}
+  %0 = arith.index_cast %arg0 : i32 to index
+  return %0 : index
+}
+
+// -----
+
+// CHECK-LABEL: func @muli
+func.func @muli(%arg0: index, %arg1: index) -> index {
+  %0 = arith.muli %arg0, %arg1 : index
+  return %0 : index
+  //      CHECK: %[[LHS:.*]] = builtin.unrealized_conversion_cast %arg0 : index to tensor<i32>
+  // CHECK-NEXT: %[[RHS:.*]] = builtin.unrealized_conversion_cast %arg1 : index to tensor<i32>
+  // CHECK-NEXT: %[[RES:.*]] = stablehlo.multiply %[[LHS]], %[[RHS]] : tensor<i32>
+  // CHECK-NEXT: %[[RES_INDEX:.*]] = builtin.unrealized_conversion_cast %[[RES]] : tensor<i32> to index
+  // CHECK-NEXT: return %[[RES_INDEX]] : index
+}
+
+// -----
+
+// CHECK-LABEL: func @muli_const
+func.func @muli_const() -> index {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %0 = arith.muli %c1, %c2 : index
+  return %0 : index
+  //      CHECK: %[[LHS:.*]] = stablehlo.constant dense<1> : tensor<i32>
+  // CHECK-NEXT: %[[RHS:.*]] = stablehlo.constant dense<2> : tensor<i32>
+  // CHECK-NEXT: %[[RES:.*]] = stablehlo.multiply %[[LHS]], %[[RHS]] : tensor<i32>
+  // CHECK-NEXT: %[[RES_INDEX:.*]] = builtin.unrealized_conversion_cast %[[RES]] : tensor<i32> to index
+  // CHECK-NEXT: return %[[RES_INDEX]] : index
+}
+
+// -----
+
+func.func @muli_i32(%arg0: i32, %arg1: i32) -> i32 {
+  // expected-error@+1 {{failed to legalize operation 'arith.muli' that was explicitly marked illegal}}
+  %0 = arith.muli %arg0, %arg1 : i32
+  return %0 : i32
+}

--- a/stablehlo/transforms/CMakeLists.txt
+++ b/stablehlo/transforms/CMakeLists.txt
@@ -24,6 +24,7 @@ add_mlir_dialect_library(StablehloPasses
   PARTIAL_SOURCES_INTENDED
   ChloLegalizeToStablehlo.cpp
   PassPipelines.cpp
+  ShapeLegalizeToStablehlo.cpp
   StablehloAggressiveSimplification.cpp
   StablehloCanonicalizeDynamism.cpp
   StablehloInstrumentWithProbe.cpp
@@ -39,6 +40,7 @@ add_mlir_dialect_library(StablehloPasses
   LINK_LIBS PUBLIC
   ChloOps
   InterpreterOps
+  MLIRArithDialect
   MLIRComplexDialect
   MLIRFuncDialect
   MLIRFunctionInterfaces

--- a/stablehlo/transforms/Passes.h
+++ b/stablehlo/transforms/Passes.h
@@ -66,6 +66,10 @@ void populateStablehloCanonicalizationPatterns(MLIRContext *context,
                                                RewritePatternSet *patterns,
                                                PatternBenefit benefit = 1);
 
+/// Collection of shape dialect to StableHLO patterns.
+void populateShapeToStablehloPatterns(MLIRContext *context,
+                                      RewritePatternSet *patterns);
+
 //// Pass pipelines ////
 
 // StableHLO consumers can add this pipeline to convert portable artifacts to

--- a/stablehlo/transforms/Passes.td
+++ b/stablehlo/transforms/Passes.td
@@ -106,3 +106,15 @@ def StablehloAggressiveSimplificationPass :
     InterfacePass<"stablehlo-aggressive-simplification", "mlir::FunctionOpInterface"> {
   let summary = "Canonicalizes StableHLO operations";
 }
+
+def ShapeLegalizeToStablehloPass : Pass<"shape-legalize-to-stablehlo", "func::FuncOp"> {
+  let summary = "Legalize shape-related ops to HLO.";
+  let description = [{
+    An experimental pass that legalizes shape-related ops to StableHLO ops.
+
+    Bringing shape and data computations together via an optional pass will
+    make it possible for the StableHLO ecosystem to potentially leverage the
+    compilation pipelines that use HLO operations to model dynamism.
+  }];
+  let dependentDialects = ["mlir::stablehlo::StablehloDialect"];
+}

--- a/stablehlo/transforms/ShapeLegalizeToStablehlo.cpp
+++ b/stablehlo/transforms/ShapeLegalizeToStablehlo.cpp
@@ -1,0 +1,600 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+   Copyright 2023 The StableHLO Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+#include "llvm/ADT/SmallVector.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/DialectRegistry.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/IR/Value.h"
+#include "mlir/IR/ValueRange.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Support/TypeID.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "stablehlo/dialect/StablehloOps.h"
+#include "stablehlo/transforms/Passes.h"
+
+namespace mlir {
+namespace stablehlo {
+
+#define GEN_PASS_DEF_SHAPELEGALIZETOSTABLEHLOPASS
+#include "stablehlo/transforms/Passes.h.inc"
+
+namespace {
+
+bool hasI32Style(Value value) {
+  auto type = value.getType().dyn_cast<ShapedType>();
+  return type && type.getElementType().isInteger(32);
+}
+
+// Cast from index-based shape representation used in the Shape dialect to the
+// i32-based representation used in HLO:
+//   * index => tensor<i32>.
+//   * tensor<Nxindex> => tensor<Nxi32>.
+//   * All i32-based types from above => themselves.
+// There is no convenient op that can express this, so we're using
+// unrealized_conversion_cast (with the idea that all these casts will
+// annihilate at the end of the pass).
+Value castToI32(PatternRewriter& rewriter, Location loc, Value value) {
+  Type resultType;
+  if (value.getType().isIndex())
+    resultType = RankedTensorType::get({}, rewriter.getI32Type());
+  if (auto valueType = value.getType().dyn_cast<ShapedType>()) {
+    if (!valueType.hasStaticShape()) return {};
+    if (valueType.getElementType().isInteger(32)) return value;
+    if (valueType.getElementType().isIndex())
+      resultType =
+          RankedTensorType::get(valueType.getShape(), rewriter.getI32Type());
+  }
+  if (!resultType) return {};
+  auto cast =
+      rewriter.create<UnrealizedConversionCastOp>(loc, resultType, value);
+  return cast.getResult(0);
+}
+
+bool hasIndexStyle(Value value) {
+  if (value.getType().isIndex()) return true;
+  auto type = value.getType().dyn_cast<ShapedType>();
+  return type && type.getElementType().isIndex();
+}
+
+// Cast from the i32-based shape representation used in HLO to the index-based
+// representation used in the Shape dialect:
+//   * tensor<i32> => index.
+//   * tensor<Nxi32> => tensor<Nxindex>.
+//   * All index-based types from above => themselves.
+// There is no convenient op that can express this, so we're using
+// unrealized_conversion_cast (with the idea that all these casts will
+// annihilate at the end of the pass).
+Value castToIndex(PatternRewriter& rewriter, Location loc, Value value) {
+  Type resultType;
+  if (value.getType().isIndex()) return value;
+  if (auto valueType = value.getType().dyn_cast<ShapedType>()) {
+    if (!valueType.hasStaticShape()) return {};
+    if (valueType.getElementType().isInteger(32)) {
+      if (valueType.getRank() == 0) {
+        resultType = rewriter.getIndexType();
+      } else {
+        resultType = RankedTensorType::get(valueType.getShape(),
+                                           rewriter.getIndexType());
+      }
+    }
+    if (valueType.getElementType().isIndex()) return value;
+  }
+  if (!resultType) return {};
+  auto cast =
+      rewriter.create<UnrealizedConversionCastOp>(loc, resultType, value);
+  return cast.getResult(0);
+}
+
+struct ConvertComputeReshapeShapeOpPattern
+    : public OpRewritePattern<ComputeReshapeShapeOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(ComputeReshapeShapeOp op,
+                                PatternRewriter& rewriter) const override {
+    // Cast num_elements from index to tensor<i32>.
+    // Cast dynamic_shape from tensor<Nxindex> to tensor<Nxi32> if needed.
+    // (stablehlo.compute_reshape_shape supports both index- and integer-based
+    // dynamic_shape operands).
+    // This cannot error out given how the operation is currently defined.
+    auto numElementsI32 = castToI32(rewriter, op.getLoc(), op.getNumElements());
+    auto dynamicShapeI32x1 =
+        castToI32(rewriter, op.getLoc(), op.getDynamicShape());
+    if (!numElementsI32 || !dynamicShapeI32x1)
+      return rewriter.notifyMatchFailure(op, "cast to i32 failed");
+    auto rank = dynamicShapeI32x1.getType().cast<ShapedType>().getNumElements();
+
+    // Obtain individual input dimension sizes and also compute the product of
+    // all these dimension sizes.
+    auto i32Type = RankedTensorType::get({}, rewriter.getI32Type());
+    Value dynamicNumElementsI32 = rewriter.create<ConstantOp>(
+        op.getLoc(), DenseIntElementsAttr::get<int32_t>(i32Type, -1));
+    SmallVector<Value> dynamicSizesI32;
+    for (auto i = 0; i < rank; ++i) {
+      auto dynamicSizeI32x1 = rewriter.create<SliceOp>(
+          op.getLoc(), dynamicShapeI32x1, rewriter.getDenseI64ArrayAttr(i),
+          rewriter.getDenseI64ArrayAttr(i + 1),
+          rewriter.getDenseI64ArrayAttr(1));
+      auto dynamicSizeI32 =
+          rewriter.create<ReshapeOp>(op.getLoc(), i32Type, dynamicSizeI32x1);
+      dynamicSizesI32.push_back(dynamicSizeI32);
+      dynamicNumElementsI32 = rewriter.create<MulOp>(
+          op.getLoc(), dynamicNumElementsI32, dynamicSizeI32);
+    }
+
+    // Compute the dimension size that corresponds to -1 in dynamic_shape.
+    // If such a dimension doesn't exist, then this value doesn't matter.
+    auto computedSizeI32 = rewriter.create<DivOp>(op.getLoc(), numElementsI32,
+                                                  dynamicNumElementsI32);
+
+    // Compute individual output dimension sizes, replacing a potential -1
+    // with the value computed above.
+    auto i32x1Type = RankedTensorType::get({1}, rewriter.getI32Type());
+    Value minusOneI32 = rewriter.create<ConstantOp>(
+        op.getLoc(), DenseIntElementsAttr::get<int32_t>(i32Type, -1));
+    SmallVector<Value> resultSizesI32x1;
+    for (auto i = 0; i < rank; ++i) {
+      auto eqMinusOne =
+          rewriter.create<CompareOp>(op.getLoc(), dynamicSizesI32[i],
+                                     minusOneI32, ComparisonDirection::EQ);
+      auto resultSizeI32 = rewriter.create<SelectOp>(
+          op.getLoc(), eqMinusOne, computedSizeI32, dynamicSizesI32[i]);
+      auto resultSizeI32x1 =
+          rewriter.create<ReshapeOp>(op.getLoc(), i32x1Type, resultSizeI32);
+      resultSizesI32x1.push_back(resultSizeI32x1);
+    }
+    auto resultI32 =
+        rewriter.create<ConcatenateOp>(op.getLoc(), resultSizesI32x1,
+                                       /*dimension=*/0);
+
+    // Cast the result to tensor<Nxindex> if needed.
+    // (stablehlo.compute_reshape_shape supports both index- and integer-based
+    // results).
+    // This cannot error out given how the operation is currently defined.
+    auto resultIndex = hasI32Style(op.getResult())
+                           ? resultI32
+                           : castToIndex(rewriter, op.getLoc(), resultI32);
+    if (!resultIndex || resultIndex.getType() != op.getResult().getType())
+      return rewriter.notifyMatchFailure(op, "cast to index failed");
+    rewriter.replaceOp(op, resultIndex);
+    return success();
+  }
+};
+
+struct ConvertNumElementsOpPattern
+    : public OpRewritePattern<shape::NumElementsOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(shape::NumElementsOp op,
+                                PatternRewriter& rewriter) const override {
+    // Cast shape from tensor<Nxindex> to tensor<Nxi32>.
+    // This will error out if shape is !shape.shape.
+    auto shapeI32 = castToI32(rewriter, op.getLoc(), op.getShape());
+    if (!shapeI32) return rewriter.notifyMatchFailure(op, "cast to i32 failed");
+    auto rank = shapeI32.getType().cast<ShapedType>().getNumElements();
+
+    // Compute the product of the individual dimension sizes.
+    // Using this representation instead of ReduceOp because it is more
+    // amenable to optimizations. (Reduce can be folded only if the entire
+    // shape is static, but individual multiplications can be folded if
+    // individual dimensions are static).
+    auto resultI32Type = RankedTensorType::get({}, rewriter.getI32Type());
+    Value resultI32 = rewriter.create<ConstantOp>(
+        op.getLoc(), DenseIntElementsAttr::get<int32_t>(resultI32Type, 1));
+    for (auto i = 0; i < rank; ++i) {
+      auto sizeI32x1 = rewriter.create<SliceOp>(
+          op.getLoc(), shapeI32, rewriter.getDenseI64ArrayAttr(i),
+          rewriter.getDenseI64ArrayAttr(i + 1),
+          rewriter.getDenseI64ArrayAttr(1));
+      auto sizeI32 =
+          rewriter.create<ReshapeOp>(op.getLoc(), resultI32Type, sizeI32x1);
+      resultI32 = rewriter.create<MulOp>(op.getLoc(), resultI32, sizeI32);
+    }
+
+    // Cast result from tensor<i32> to index.
+    // This will error out if the result is !shape.size.
+    auto resultIndex = castToIndex(rewriter, op.getLoc(), resultI32);
+    if (!resultIndex || resultIndex.getType() != op.getResult().getType())
+      return rewriter.notifyMatchFailure(op, "cast to index failed");
+    rewriter.replaceOp(op, resultIndex);
+    return success();
+  }
+};
+
+struct ConvertShapeOfOpPattern : public OpRewritePattern<shape::ShapeOfOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(shape::ShapeOfOp op,
+                                PatternRewriter& rewriter) const override {
+    auto operandType = op.getArg().getType().dyn_cast<RankedTensorType>();
+    if (!operandType)
+      return rewriter.notifyMatchFailure(op, "expected ranked operand");
+
+    // Produce an StableHLO equivalent of this shape::ShapeOfOp.
+    // This is a very laborious representation because StableHLO is currently
+    // lacking convenient tools to express this.
+    SmallVector<Value> sizesI32x1;
+    for (auto i = 0; i < operandType.getRank(); ++i) {
+      auto sizeI32 =
+          rewriter.create<GetDimensionSizeOp>(op.getLoc(), op.getArg(), i);
+      auto sizeI32x1 = rewriter.create<ReshapeOp>(
+          op.getLoc(), RankedTensorType::get({1}, rewriter.getI32Type()),
+          sizeI32);
+      sizesI32x1.push_back(sizeI32x1);
+    }
+    auto shapeI32 = rewriter.create<ConcatenateOp>(op.getLoc(), sizesI32x1,
+                                                   /*dimension=*/0);
+
+    // Cast result from tensor<Nxi32> to tensor<Nxindex>.
+    // This will error out if the result is !shape.shape.
+    auto shapeIndex = castToIndex(rewriter, op.getLoc(), shapeI32);
+    if (!shapeIndex || shapeIndex.getType() != op.getResult().getType())
+      return rewriter.notifyMatchFailure(op, "cast to index failed");
+    rewriter.replaceOp(op, shapeIndex);
+    return success();
+  }
+};
+
+struct ConvertConstShapeOpPattern
+    : public OpRewritePattern<shape::ConstShapeOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(shape::ConstShapeOp op,
+                                PatternRewriter& rewriter) const override {
+    auto operandType = op.getResult().getType().dyn_cast<RankedTensorType>();
+    if (!operandType)
+      return rewriter.notifyMatchFailure(op, "expected ranked operand");
+
+    llvm::SmallVector<int32_t> shape;
+    for (int i : op.getShape().getValues<int64_t>()) {
+      shape.push_back(i);
+    }
+    auto newConst = rewriter.create<ConstantOp>(
+        op.getLoc(), DenseElementsAttr::get(
+                         RankedTensorType::get({operandType.getDimSize(0)},
+                                               rewriter.getI32Type()),
+                         ArrayRef(shape)));
+    auto newConstIndex = castToIndex(rewriter, op.getLoc(), newConst);
+    rewriter.replaceOp(op, newConstIndex);
+    return success();
+  }
+};
+
+struct ConvertIndexCastOpPattern : public OpRewritePattern<arith::IndexCastOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(arith::IndexCastOp op,
+                                PatternRewriter& rewriter) const override {
+    Value result = op.getIn();
+    if (hasIndexStyle(op.getIn()) && !op.getIn().getType().isa<ShapedType>()) {
+      // Handle a special case of index -> i64.
+      // This is converted to the following sequence:
+      //   unrealized_conversion_cast index -> tensor<i32>
+      //   stablehlo.convert tensor<i32> -> tensor<i64>
+      //   unrealized_conversion_cast tensor<i64> -> i64
+      result = castToI32(rewriter, op.getLoc(), result);
+      if (!op.getOut().getType().isInteger(32)) {
+        result = rewriter.create<ConvertOp>(op.getLoc(), result,
+                                            op.getOut().getType());
+      }
+      rewriter.replaceOp(op, rewriter.create<UnrealizedConversionCastOp>(
+                                 op.getLoc(), op.getOut().getType(), result));
+      return success();
+    }
+
+    if (hasIndexStyle(result)) {
+      result = castToI32(rewriter, op.getLoc(), result);
+    } else if (!hasI32Style(result)) {
+      return rewriter.notifyMatchFailure(op,
+                                         "expected input with index/i32 style");
+    }
+
+    if (hasIndexStyle(op.getOut())) {
+      result = castToIndex(rewriter, op.getLoc(), result);
+    } else if (!hasI32Style(op.getOut())) {
+      return rewriter.notifyMatchFailure(
+          op, "expected output with index/i32 style");
+    }
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+struct ConvertMulIOpPattern : public OpRewritePattern<arith::MulIOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(arith::MulIOp op,
+                                PatternRewriter& rewriter) const override {
+    // We only handle index types.
+    if (!hasIndexStyle(op.getLhs()) || !hasIndexStyle(op.getRhs()) ||
+        !hasIndexStyle(op.getResult())) {
+      return rewriter.notifyMatchFailure(op, "expected index type");
+    }
+    Value lhs = op.getLhs();
+    if (auto constIndex =
+            dyn_cast_or_null<arith::ConstantIndexOp>(lhs.getDefiningOp())) {
+      lhs = rewriter.create<ConstantOp>(
+          op.getLoc(), DenseIntElementsAttr::get<int32_t>(
+                           RankedTensorType::get({}, rewriter.getI32Type()),
+                           static_cast<int32_t>(constIndex.value())));
+    } else {
+      lhs = castToI32(rewriter, op.getLoc(), op.getLhs());
+    }
+    Value rhs = op.getRhs();
+    if (auto constIndex =
+            dyn_cast_or_null<arith::ConstantIndexOp>(rhs.getDefiningOp())) {
+      rhs = rewriter.create<ConstantOp>(
+          op.getLoc(), DenseIntElementsAttr::get<int32_t>(
+                           RankedTensorType::get({}, rewriter.getI32Type()),
+                           static_cast<int32_t>(constIndex.value())));
+    } else {
+      rhs = castToI32(rewriter, op.getLoc(), op.getRhs());
+    }
+    Value result = rewriter.create<MulOp>(op.getLoc(), lhs, rhs);
+    rewriter.replaceOp(op, castToIndex(rewriter, op.getLoc(), result));
+    return success();
+  }
+};
+
+// Pads input tensor<N x i32> by X ones from the left. The number X is
+// determined by input pad. Result is tensor<(X+N) x i32>, where the first X
+// elements are ones.
+Value padFromLeft(PatternRewriter& rewriter, Location loc, Value input,
+                  int64_t pad) {
+  Value padI32 = rewriter.create<ConstantOp>(
+      loc, DenseIntElementsAttr::get<int32_t>(
+               RankedTensorType::get({pad}, rewriter.getI32Type()), 1));
+  return rewriter.create<ConcatenateOp>(loc, ValueRange{padI32, input},
+                                        /*dimension=*/0);
+}
+
+struct ConvertShapeBroadcastOpPattern
+    : public OpRewritePattern<shape::BroadcastOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(shape::BroadcastOp op,
+                                PatternRewriter& rewriter) const override {
+    // As defined, op inputs must be 1D tensor or !shape.shape.
+    // We only support inputs of two input 1D tensors.
+    if (op.getShapes().size() != 2) return failure();
+    auto shape1 = castToI32(rewriter, op.getLoc(), op.getShapes().front());
+    auto shape2 = castToI32(rewriter, op.getLoc(), op.getShapes().back());
+    if (!shape1 || !shape2) return failure();
+    auto tensorType1 = shape1.getType().dyn_cast<RankedTensorType>();
+    auto tensorType2 = shape2.getType().dyn_cast<RankedTensorType>();
+    if (!tensorType1 || !tensorType2) return failure();
+
+    // If the two operand shapes are of different sizes, the smaller one is
+    // padded with 1's from the left.
+    if (tensorType1.getDimSize(0) < tensorType2.getDimSize(0)) {
+      shape1 =
+          padFromLeft(rewriter, op.getLoc(), shape1,
+                      tensorType2.getDimSize(0) - tensorType1.getDimSize(0));
+    } else if (tensorType1.getDimSize(0) > tensorType2.getDimSize(0)) {
+      shape2 =
+          padFromLeft(rewriter, op.getLoc(), shape2,
+                      tensorType1.getDimSize(0) - tensorType2.getDimSize(0));
+    }
+
+    // By definition, broadcasted dims are:
+    //   result[i] = lhs[i] if lhs[i] == rhs[i]
+    //             = lhs[i] if rhs[i] == 1
+    //             = rhs[i] if lhs[i] == 1
+    //
+    // We assume that there is shape.cstr_broadcastable check done elsewhere to
+    // make sure the shapes are broadcastable, then we can calculate broadcast
+    // result simply using MaxOp. In case the shapes are not broadcastable, the
+    // result extent tensor is undefined according to spec. So this
+    // implementation is technically correct.
+    auto broadcasted = rewriter.create<MaxOp>(op->getLoc(), shape1, shape2);
+
+    auto broadcastedIndex = castToIndex(rewriter, op.getLoc(), broadcasted);
+    if (!broadcastedIndex ||
+        broadcastedIndex.getType() != op.getResult().getType())
+      return rewriter.notifyMatchFailure(op, "cast to index failed");
+    rewriter.replaceOp(op, broadcastedIndex);
+    return success();
+  }
+};
+
+struct ConvertTensorDimPattern : public OpRewritePattern<tensor::DimOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(tensor::DimOp op,
+                                PatternRewriter& rewriter) const override {
+    // We only support getting static index.
+    auto constIndex =
+        dyn_cast_or_null<arith::ConstantIndexOp>(op.getIndex().getDefiningOp());
+    if (!constIndex) {
+      return failure();
+    }
+
+    auto dim = rewriter.create<GetDimensionSizeOp>(op->getLoc(), op.getSource(),
+                                                   constIndex.value());
+    auto dimIndex = castToIndex(rewriter, op.getLoc(), dim);
+    rewriter.replaceOp(op, dimIndex);
+    return success();
+  }
+};
+
+struct ConvertTensorFromElementsPattern
+    : public OpRewritePattern<tensor::FromElementsOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(tensor::FromElementsOp op,
+                                PatternRewriter& rewriter) const override {
+    auto tensorType =
+        op.getResult().getType().dyn_cast_or_null<RankedTensorType>();
+    if (!tensorType) {
+      return failure();
+    }
+    if (tensorType.getRank() == 0) {
+      // Handle the special cast of tensor.from_elements i64 -> tensor<i64>
+      // This is converted to unrealized_conversin_cast i64 -> tensor<i64>,
+      // which is later cancelled with previous unrealized_conversin_cast op.
+      rewriter.replaceOp(
+          op, rewriter.create<UnrealizedConversionCastOp>(
+                  op.getLoc(), op.getResult().getType(), op.getElements()[0]));
+      return success();
+    }
+
+    // We only handle 1D tensor with index types. tensor.from_elements spec
+    // allows the same element type only for all input/output.
+    if (tensorType.getRank() != 1) return failure();
+    if (!hasIndexStyle(op.getResult())) return failure();
+
+    SmallVector<Value> elementI32x1;
+    for (size_t i = 0; i < op.getElements().size(); ++i) {
+      if (auto constIndex = dyn_cast_or_null<arith::ConstantIndexOp>(
+              op.getElements()[i].getDefiningOp())) {
+        elementI32x1.push_back(rewriter.create<ConstantOp>(
+            op.getLoc(), DenseIntElementsAttr::get<int32_t>(
+                             RankedTensorType::get({1}, rewriter.getI32Type()),
+                             static_cast<int32_t>(constIndex.value()))));
+      } else {
+        elementI32x1.push_back(rewriter.create<ReshapeOp>(
+            op.getLoc(), RankedTensorType::get({1}, rewriter.getI32Type()),
+            castToI32(rewriter, op->getLoc(), op.getElements()[i])));
+      }
+    }
+    Value tensorI32 = rewriter.create<ConcatenateOp>(op.getLoc(), elementI32x1,
+                                                     /*dimension=*/0);
+
+    tensorI32 = hasI32Style(op.getResult())
+                    ? tensorI32
+                    : castToIndex(rewriter, op.getLoc(), tensorI32);
+    if (!tensorI32 || tensorI32.getType() != op.getResult().getType())
+      return rewriter.notifyMatchFailure(op, "cast to index failed");
+    rewriter.replaceOp(op, tensorI32);
+    return success();
+  }
+};
+
+template <typename OpType>
+struct CastOperandsPattern : public OpRewritePattern<OpType> {
+  using OpRewritePattern<OpType>::OpRewritePattern;
+  LogicalResult matchAndRewrite(OpType op,
+                                PatternRewriter& rewriter) const override {
+    if (!llvm::any_of(op->getOperands(), hasIndexStyle))
+      return rewriter.notifyMatchFailure(op, "no operands need a cast to i32");
+
+    // If op has operands of type tensor<Nxindex>, cast them to tensor<Nxi32>.
+    // If producers of these operands have been transformed into casts from
+    // tensor<Nxi32> to tensor<Nxindex>, then these casts will annihilate with
+    // each other upon canonicalization.
+    SmallVector<Value> operandsI32;
+    for (auto operand : op->getOperands()) {
+      if (hasIndexStyle(operand)) {
+        operandsI32.push_back(castToI32(rewriter, op.getLoc(), operand));
+      } else {
+        operandsI32.push_back(operand);
+      }
+    }
+
+    rewriter.replaceOpWithNewOp<OpType>(op, op->getResultTypes(), operandsI32,
+                                        op->getAttrs());
+    return success();
+  }
+};
+
+struct ShapeLegalizeToStablehloPass
+    : public impl::ShapeLegalizeToStablehloPassBase<
+          ShapeLegalizeToStablehloPass> {
+  using ShapeLegalizeToStablehloPassBase::ShapeLegalizeToStablehloPassBase;
+
+  void runOnOperation() override {
+    // In order to make dynamic StableHLO programs compatible with HLO, we need
+    // to get rid of all non-StableHLO ops.
+    //
+    // As an example, a cursory inspection of the TF/XLA bridge, which provides
+    // one data point of an StableHLO producer that can generate dynamic
+    // programs, reveals the following non-StableHLO ops:
+    //   * shape.broadcast
+    //   * shape.concat
+    //   * shape.cstr_broadcastable
+    //   * shape.cstr_eq
+    //   * shape.dim
+    //   * shape.split_at
+    //   * shape.to_extent_tensor
+    //   * shape.assuming
+    //   * shape.assuming_yield
+    //   * tensor.dim
+    //   * tensor.extract
+    //   * tensor.from_elements
+    //
+    // Most of these ops are convertible to StableHLO, but the representation is
+    // going to be pretty laborious for many of them. Luckily, canonicalization
+    // is able to remove unnecessary cruft. At the moment, this pass is a
+    // work in progress, so not all of these ops are supported.
+    //
+    ConversionTarget target(getContext());
+    target.addIllegalDialect<shape::ShapeDialect>();
+    target.addIllegalDialect<tensor::TensorDialect>();
+    target.addIllegalOp<stablehlo::ComputeReshapeShapeOp>();
+    target.addIllegalOp<arith::IndexCastOp>();
+    target.addIllegalOp<arith::MulIOp>();
+    target.addDynamicallyLegalDialect<stablehlo::StablehloDialect>(
+        [](Operation* op) {
+          return !llvm::any_of(op->getOperands(), hasIndexStyle);
+        });
+    target.addLegalOp<tensor::CastOp>();
+    target.addLegalOp<UnrealizedConversionCastOp>();
+
+    // The patterns do what one might expect, converting between MLIR-style
+    // and HLO-style shape computations.
+    //
+    // The only complication is that MLIR style uses index/tensor<Nxindex>
+    // whereas HLO style uses tensor<i32>/vararg of tensor<i32>. We bridge
+    // this gap by producing unrealized_conversion_cast ops, which we expect
+    // to ultimately annihilate with each other upon canonicalization if
+    // everything went right.
+    MLIRContext* context = &getContext();
+    RewritePatternSet patterns(context);
+    populateShapeToStablehloPatterns(context, &patterns);
+
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns))))
+      return signalPassFailure();
+  }
+};
+
+}  // namespace
+
+void populateShapeToStablehloPatterns(MLIRContext* context,
+                                      RewritePatternSet* patterns) {
+  patterns->add<ConvertComputeReshapeShapeOpPattern>(context);
+  patterns->add<ConvertConstShapeOpPattern>(context);
+  patterns->add<ConvertMulIOpPattern>(context);
+  patterns->add<ConvertIndexCastOpPattern>(context);
+  patterns->add<ConvertNumElementsOpPattern>(context);
+  patterns->add<ConvertShapeOfOpPattern>(context);
+  patterns->add<ConvertShapeBroadcastOpPattern>(context);
+  patterns->add<CastOperandsPattern<DynamicBroadcastInDimOp>>(context);
+  patterns->add<CastOperandsPattern<DynamicReshapeOp>>(context);
+  patterns->add<ConvertTensorDimPattern>(context);
+  patterns->add<ConvertTensorFromElementsPattern>(context);
+}
+
+}  // namespace stablehlo
+}  // namespace mlir


### PR DESCRIPTION
As described in https://groups.google.com/a/openxla.org/g/openxla-discuss/c/httnobiya7U

Migrate Shape->MHLO to Shape->StableHLO. Shape computations are produced in CHLO decompositions so it makes sense to keep these together. This will allow for full CHLO->StableHLO legalization.