### PR TITLE
Improve caching keys for Bazel

### DIFF
--- a/.github/workflows/buildAndTestBazel.yml
+++ b/.github/workflows/buildAndTestBazel.yml
@@ -59,7 +59,9 @@ jobs:
       uses: actions/cache@v3
       with:
         path: "~/.cache/bazel"
-        key: ${{ runner.os }}-stablehlo_build_assets-${{ steps.llvm-version.outputs.version }}-bazelbuild
+        key: ${{ runner.os }}-stablehlo_bazelbuild-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel') }}
+        restore-keys: |
+          ${{ runner.os }}-bazel-stablehlo_bazelbuild-
 
     - name: Build StableHLO
       shell: bash


### PR DESCRIPTION
Improve caching key based on [documentation](https://github.com/actions/cache/blob/a2ed59d39b352305bdd2f628719a53b2cc4f9613/examples.md?plain=1#L673)

* key hashes the relevant files that can cause variance
* removed LLVM version in the key since it's already in the WORKSPACE file
* added `restore-keys` which hydrates another cache for potential re-use