### PR TITLE
Fix incorrect restore-key in cache action

### DIFF
--- a/.github/workflows/buildAndTestBazel.yml
+++ b/.github/workflows/buildAndTestBazel.yml
@@ -61,7 +61,7 @@ jobs:
         path: "~/.cache/bazel"
         key: ${{ runner.os }}-stablehlo_bazelbuild-${{ hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel') }}
         restore-keys: |
-          ${{ runner.os }}-bazel-stablehlo_bazelbuild-
+          ${{ runner.os }}-stablehlo_bazelbuild-
 
     - name: Build StableHLO
       shell: bash


### PR DESCRIPTION
Fix incorrect prefix in the restore-keys for the GitHub action for bazel builds.