### PR TITLE
Check quantized-storage-type to be a signless integer

### DIFF
--- a/stablehlo/dialect/Base.td
+++ b/stablehlo/dialect/Base.td
@@ -57,7 +57,7 @@ class StableHLO_UniformQuantizedSignedInt<int width>
            CPred<"$_self.cast<mlir::quant::UniformQuantizedType>()" #
                  ".getStorageTypeIntegralWidth() == " # width>,
            CPred<"$_self.cast<mlir::quant::UniformQuantizedType>()" #
-                 ".isSigned()">]>,
+                 ".getStorageType().cast<mlir::IntegerType>().isSignless()">]>,
     "QI" # width # " type"> {
   string name = "UniformQuantizedSignedInt";
   int bitwidth = width;
@@ -68,7 +68,7 @@ class StableHLO_UniformQuantizedPerAxisSignedInt<int width>
            CPred<"$_self.cast<mlir::quant::UniformQuantizedPerAxisType>()" #
                  ".getStorageTypeIntegralWidth() == " # width>,
            CPred<"$_self.cast<mlir::quant::UniformQuantizedPerAxisType>()" #
-                 ".isSigned()">]>,
+                 ".getStorageType().cast<mlir::IntegerType>().isSignless()">]>,
     "QI" # width # " type"> {
   string name = "UniformQuantizedPerAxisSignedInt";
   int bitwidth = width;

--- a/stablehlo/tests/ops_stablehlo_quantized.mlir
+++ b/stablehlo/tests/ops_stablehlo_quantized.mlir
@@ -807,3 +807,11 @@ func.func @negative_select_and_scatter_quantization(%arg0: tensor<10x24x24x64x!q
   } : (tensor<10x24x24x64x!quant.uniform<i8:f32:0, {0.1:-30}>>, tensor<10x23x23x64x!quant.uniform<i8:f32:0, {0.1:-30}>>, tensor<!quant.uniform<i8:f32:0, {0.1:-30}>>) -> tensor<10x24x24x64x!quant.uniform<i8:f32:0, {0.1:-30}>>
   func.return %0 : tensor<10x24x24x64x!quant.uniform<i8:f32:0, {0.1:-30}>>
 }
+
+// -----
+
+func.func @illegal_storage_type_for_quantized_element_type(%arg0: tensor<4x!quant.uniform<si8:f32, 1.000000e+00>>) -> tensor<4xf32> {
+  // expected-error@+1 {{operand #0 must be tensor of 4/8/16/32-bit uniform quantized signed integer or 4/8/16/32-bit uniform quantized unsigned integer or 4/8/16/32-bit uniform quantized per axis signed integer or 4/8/16/32-bit uniform quantized per axis unsigned integer values, but got 'tensor<4x!quant.uniform<i8:f32, 1.000000e+00>>}}
+  %0 = "stablehlo.uniform_dequantize"(%arg0) : (tensor<4x!quant.uniform<si8:f32, 1.000000e+00>>) -> tensor<4xf32>
+  func.return %0 : tensor<4xf32>
+}


### PR DESCRIPTION
Current StablehLO quantized signed int [cs](https://github.com/openxla/stablehlo/blob/4a26ddee5fdbe178a84f219513bfc48f565919b7/stablehlo/dialect/Base.td#L60) uses `mlir::quant::QuantizedType::isSIgned` to decide on the signed-ness of the storage type.

StableHLO, as bootstrapped from MHLO, inherits `signless` integers (added in MHLO for some legacy reasons) to be treated as signed integer. This is not captured by the check `mlir::quant::QuantizedType::isSigned` because of the following reason.

 
Based on [this](https://github.com/llvm/llvm-project/blob/16e74fd48988ac95551d0f64e1b36f78a82a89a2/mlir/include/mlir/Dialect/Quant/QuantTypes.h#L102), `mlir::quant::QuantizedType::isSIgned()` is true if the associated bit in [flag](https://github.com/llvm/llvm-project/blob/16e74fd48988ac95551d0f64e1b36f78a82a89a2/mlir/lib/Dialect/Quant/IR/TypeDetail.h#L30) is 1. Here are a few ways to set  that flag as true. 

```
 auto signed_flag_bit = storage_type.cast<mlir::IntegerType>().isSignless();
... mlir::quant::UniformQuantizedPerAxisType::get(
     is_signed, storage_type, expressed_type, scales, zero_points,
     quantization_dimension, storage_min, storage_max);

or

 auto signed_flag_bit = storage_type.cast<mlir::IntegerType>().isSigned();
... mlir::quant::UniformQuantizedPerAxisType::get(
     is_signed, storage_type, expressed_type, scales, zero_points,
     quantization_dimension, storage_min, storage_max);
```

In other words, It is on the producers of `mlir::quant::QuantizedType` to set that bit based on **their interpretation of signedness**, which in case of StableHLO is signedless. That means the a `true` value of `mlir::quant::QuantizedType::isSIgned()` is not enough to ensure that the desired signed-ness of storage type.
 
## Suggested change

Replace

```
CPred<"$_self.cast<mlir::quant::UniformQuantizedType>()" #
                 ".isSigned()">]>,
```

with 

```
           CPred<"$_self.cast<mlir::quant::UniformQuantizedType>()" #
                 ".getStorageType().cast<mlir::IntegerType>().isSignless()">]>,

```

IMO, we can skip the check `mlir::quant::UniformQuantizedType::isSigned()` altogether as is it not sufficient nor necessary.  

Context: https://github.com/openxla/stablehlo/issues/1812#issuecomment-1963280512
