### PR TITLE
Add a python API for reference interpreter

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -431,6 +431,7 @@ cc_library(
         ":reference_ops",
         ":reference_process",
         ":reference_scope",
+        ":reference_tensor",
         ":reference_value",
         ":register",
         "@llvm-project//llvm:Support",

--- a/stablehlo/integrations/python/CMakeLists.txt
+++ b/stablehlo/integrations/python/CMakeLists.txt
@@ -85,6 +85,7 @@ declare_mlir_python_extension(StablehloPythonExtensions.Main
     StablehloCAPI
   PRIVATE_LINK_LIBS
     StablehloPortableApi
+    StablehloReferenceApi
     StablehloSerialization
     LLVMSupport
 )

--- a/stablehlo/integrations/python/StablehloModule.cpp
+++ b/stablehlo/integrations/python/StablehloModule.cpp
@@ -514,9 +514,7 @@ PYBIND11_MODULE(_stablehlo, m) {
         }
 
         std::vector<MlirAttribute> pyResults;
-        for (auto res : *results) {
-          pyResults.push_back(wrap(res));
-        }
+        for (auto res : *results) pyResults.push_back(wrap(res));
         return pyResults;
       },
       py::arg("module"), py::arg("args"));

--- a/stablehlo/integrations/python/StablehloModule.cpp
+++ b/stablehlo/integrations/python/StablehloModule.cpp
@@ -11,14 +11,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <vector>
+
 #include "mlir-c/IR.h"
 #include "mlir/Bindings/Python/PybindAdaptors.h"
 #include "mlir/CAPI/IR.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "stablehlo/dialect/Serialization.h"
 #include "stablehlo/integrations/c/StablehloAttributes.h"
 #include "stablehlo/integrations/c/StablehloDialect.h"
 #include "stablehlo/integrations/c/StablehloTypes.h"
 #include "stablehlo/integrations/python/PortableApi.h"
+#include "stablehlo/reference/Api.h"
 
 namespace py = pybind11;
 
@@ -482,6 +486,41 @@ PYBIND11_MODULE(_stablehlo, m) {
   // Portable APIs
   //
   mlir::stablehlo::AddPortableApi(m);
+
+  //
+  // Reference APIs
+  //
+  m.def(
+      "eval_module",
+      [](MlirModule module,
+         std::vector<MlirAttribute> &args) -> std::vector<MlirAttribute> {
+        std::vector<mlir::DenseElementsAttr> inputs;
+        for (auto arg : args) {
+          auto attr = unwrap(arg).dyn_cast<mlir::DenseElementsAttr>();
+          if (!attr) {
+            PyErr_SetString(PyExc_ValueError,
+                            "input args must be DenseElementsAttr");
+            return {};
+          }
+          inputs.push_back(attr);
+        }
+
+        mlir::stablehlo::InterpreterConfiguration config;
+        auto results =
+            mlir::stablehlo::evalModule(unwrap(module), inputs, config);
+        if (!results) {
+          PyErr_SetString(PyExc_ValueError,
+                          results.getError().message().c_str());
+          return {};
+        }
+
+        std::vector<MlirAttribute> pyResults;
+        for (auto res : *results) {
+          pyResults.push_back(wrap(res));
+        }
+        return pyResults;
+      },
+      py::arg("module"), py::arg("args"));
 
   //
   // Serialization APIs.

--- a/stablehlo/integrations/python/StablehloModule.cpp
+++ b/stablehlo/integrations/python/StablehloModule.cpp
@@ -508,9 +508,8 @@ PYBIND11_MODULE(_stablehlo, m) {
         mlir::stablehlo::InterpreterConfiguration config;
         auto results =
             mlir::stablehlo::evalModule(unwrap(module), inputs, config);
-        if (!results) {
-          PyErr_SetString(PyExc_ValueError,
-                          results.getError().message().c_str());
+        if (failed(results)) {
+          PyErr_SetString(PyExc_ValueError, "interpreter failed");
           return {};
         }
 

--- a/stablehlo/integrations/python/tests/stablehlo.py
+++ b/stablehlo/integrations/python/tests/stablehlo.py
@@ -257,11 +257,9 @@ def test_reference_api():
     with ir.Context() as context:
       stablehlo.register_dialect(context)
       m = ir.Module.parse(ASM_FORMAT.format(tensor_type))
-      module_str = str(m)
       args = [ir.DenseIntElementsAttr.get(arg)]
 
-    res = stablehlo.eval_module(m, args)
-    actual = np.array(res[0])
+    actual = np.array(stablehlo.eval_module(m, args)[0])
     expected = arg + arg
     assert (actual == expected).all()
 
@@ -273,11 +271,10 @@ def test_serialization_apis():
   with ir.Context() as context:
     stablehlo.register_dialect(context)
     m = ir.Module.parse(ASM_FORMAT.format("2xf32"))
-    module_str = str(m)
     assert m is not None
     serialized = stablehlo.serialize_portable_artifact(m, curr_version)
     deserialized = stablehlo.deserialize_portable_artifact(context, serialized)
-    assert module_str == str(deserialized)
+    assert str(m) == str(deserialized)
 
 @run
 def test_str_serialization_apis():
@@ -291,10 +288,9 @@ def test_str_serialization_apis():
   with ir.Context() as context:
     stablehlo.register_dialect(context)
     m = ir.Module.parse(ASM_FORMAT.format("2xf32"))
-    module_str = str(m)
     assert m is not None
     bytecode = module_to_bytecode(m)
     serialized = stablehlo.serialize_portable_artifact(bytecode, curr_version)
     deserialized = stablehlo.deserialize_portable_artifact(serialized)
     deserialized_module = ir.Module.parse(deserialized)
-    assert module_str == str(deserialized_module)
+    assert str(m) == str(deserialized_module)

--- a/stablehlo/integrations/python/tests/stablehlo.py
+++ b/stablehlo/integrations/python/tests/stablehlo.py
@@ -272,9 +272,10 @@ def test_serialization_apis():
     stablehlo.register_dialect(context)
     m = ir.Module.parse(ASM_FORMAT.format("2xf32"))
     assert m is not None
+    module_str = str(m)
     serialized = stablehlo.serialize_portable_artifact(m, curr_version)
     deserialized = stablehlo.deserialize_portable_artifact(context, serialized)
-    assert str(m) == str(deserialized)
+    assert module_str == str(deserialized)
 
 @run
 def test_str_serialization_apis():
@@ -289,8 +290,9 @@ def test_str_serialization_apis():
     stablehlo.register_dialect(context)
     m = ir.Module.parse(ASM_FORMAT.format("2xf32"))
     assert m is not None
+    module_str = str(m)
     bytecode = module_to_bytecode(m)
     serialized = stablehlo.serialize_portable_artifact(bytecode, curr_version)
     deserialized = stablehlo.deserialize_portable_artifact(serialized)
     deserialized_module = ir.Module.parse(deserialized)
-    assert str(m) == str(deserialized_module)
+    assert module_str == str(deserialized_module)

--- a/stablehlo/integrations/python/tests/stablehlo.py
+++ b/stablehlo/integrations/python/tests/stablehlo.py
@@ -248,7 +248,7 @@ def test_reference_api():
     ("1xi8", np.asarray([4], np.int8)),
     ("1xi16", np.asarray([5], np.int16)),
     ("1xi32", np.asarray([-6], np.int32)),
-    # Numpy uint types interpreter as int - skipping np.uint tests
+    # Numpy's uint treated as int by DenseElementsAttr, skipping np.uint tests
     ("2x2xf16", np.asarray([1, 2, 3, 4], np.float16).reshape(2,2)),
     ("2x1x2xf16", np.asarray([1, 2, 3, 4], np.float16).reshape(2,1,2)),
   ]

--- a/stablehlo/integrations/python/tests/stablehlo.py
+++ b/stablehlo/integrations/python/tests/stablehlo.py
@@ -241,14 +241,14 @@ def test_reference_api():
   # Formatted as (tensor_type, np_value)
   # Program runs arg + arg, which is used for expected value
   tests = [
-    # No numpy types for f8
+    # No numpy types for f8 - skipping fp8 tests
     ("f16", np.asarray(1, np.float16)),
     ("f32", np.asarray(2, np.float32)),
     ("f64", np.asarray(3, np.double)),
     ("1xi8", np.asarray([4], np.int8)),
     ("1xi16", np.asarray([5], np.int16)),
     ("1xi32", np.asarray([-6], np.int32)),
-    # Numpy uint types interpreter as int
+    # Numpy uint types interpreter as int - skipping np.uint tests
     ("2x2xf16", np.asarray([1, 2, 3, 4], np.float16).reshape(2,2)),
     ("2x1x2xf16", np.asarray([1, 2, 3, 4], np.float16).reshape(2,1,2)),
   ]

--- a/stablehlo/reference/Api.cpp
+++ b/stablehlo/reference/Api.cpp
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 #include "stablehlo/reference/Api.h"
+
 #include <cstdint>
 
 #include "llvm/ADT/STLExtras.h"
@@ -123,7 +124,6 @@ LogicalResult validateEntrySignature(func::FuncOp func,
            << "incorrect number of arguments specified, provided "
            << inputs.size() << " inputs but function expected"
            << func.getNumArguments();
-  
 
   TypeRange signature = func.getArgumentTypes();
   for (int64_t i = 0; i < func.getNumArguments(); ++i) {
@@ -186,8 +186,8 @@ FailureOr<SmallVector<DenseElementsAttr>> evalModule(
   return results;
 }
 
-FailureOr<OwningOpRef<ModuleOp>> parseStablehloModule(
-    const std::string &mlir, MLIRContext &context) {
+FailureOr<OwningOpRef<ModuleOp>> parseStablehloModule(const std::string &mlir,
+                                                      MLIRContext &context) {
   llvm::SourceMgr source_mgr;
   source_mgr.AddNewSourceBuffer(llvm::MemoryBuffer::getMemBuffer(mlir),
                                 llvm::SMLoc());

--- a/stablehlo/reference/Api.h
+++ b/stablehlo/reference/Api.h
@@ -19,6 +19,7 @@ limitations under the License.
 #include <string>
 
 #include "llvm/Support/ErrorOr.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OwningOpRef.h"
@@ -35,6 +36,12 @@ namespace stablehlo {
 /// builtin kernels are matched.
 llvm::ErrorOr<SmallVector<InterpreterValue>> evalModule(
     ModuleOp module, ArrayRef<InterpreterValue> inputs,
+    const InterpreterConfiguration &config);
+
+/// This wrapper is intended to be easily used by the StableHLO Python bindings.
+// It wraps the InterpreterValue API.
+llvm::ErrorOr<SmallVector<DenseElementsAttr>> evalModule(
+    ModuleOp module, ArrayRef<DenseElementsAttr> inputs,
     const InterpreterConfiguration &config);
 
 /// Parses a StableHLO MLIR text program into a ModuleOp.

--- a/stablehlo/reference/Api.h
+++ b/stablehlo/reference/Api.h
@@ -45,8 +45,8 @@ FailureOr<SmallVector<DenseElementsAttr>> evalModule(
     const InterpreterConfiguration &config);
 
 /// Parses a StableHLO MLIR text program into a ModuleOp.
-FailureOr<OwningOpRef<ModuleOp>> parseStablehloModule(
-    const std::string &mlir, MLIRContext &context);
+FailureOr<OwningOpRef<ModuleOp>> parseStablehloModule(const std::string &mlir,
+                                                      MLIRContext &context);
 
 }  // namespace stablehlo
 }  // namespace mlir

--- a/stablehlo/reference/Api.h
+++ b/stablehlo/reference/Api.h
@@ -34,18 +34,18 @@ namespace stablehlo {
 /// module input and provided inputs. Returns a list of interpreter outputs.
 /// Can optionally pass a fallback interpreter callback which executes when no
 /// builtin kernels are matched.
-llvm::ErrorOr<SmallVector<InterpreterValue>> evalModule(
+FailureOr<SmallVector<InterpreterValue>> evalModule(
     ModuleOp module, ArrayRef<InterpreterValue> inputs,
     const InterpreterConfiguration &config);
 
 /// This wrapper is intended to be easily used by the StableHLO Python bindings.
 // It wraps the InterpreterValue API.
-llvm::ErrorOr<SmallVector<DenseElementsAttr>> evalModule(
+FailureOr<SmallVector<DenseElementsAttr>> evalModule(
     ModuleOp module, ArrayRef<DenseElementsAttr> inputs,
     const InterpreterConfiguration &config);
 
 /// Parses a StableHLO MLIR text program into a ModuleOp.
-llvm::ErrorOr<OwningOpRef<ModuleOp>> parseStablehloModule(
+FailureOr<OwningOpRef<ModuleOp>> parseStablehloModule(
     const std::string &mlir, MLIRContext &context);
 
 }  // namespace stablehlo

--- a/stablehlo/reference/CMakeLists.txt
+++ b/stablehlo/reference/CMakeLists.txt
@@ -26,6 +26,7 @@ add_mlir_library(StablehloReferenceApi
   StablehloReferenceOps
   StablehloReferenceProcess
   StablehloReferenceScope
+  StablehloReferenceTensor
   StablehloReferenceValue
   StablehloRegister
 )

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -379,12 +379,12 @@ void Tensor::dump() const { print(llvm::errs()); }
 
 Tensor makeTensor(DenseElementsAttr attr) {
   auto type = attr.getType();
-  auto elemType = type.getElementType();
+  auto elementType = type.getElementType();
 
   // Handle floating-point types.
-  if (elemType.isFloat8E4M3B11FNUZ() || elemType.isFloat8E4M3FN() ||
-      elemType.isFloat8E4M3FNUZ() || elemType.isFloat8E5M2() ||
-      elemType.isFloat8E5M2FNUZ()) {
+  if (elementType.isFloat8E4M3B11FNUZ() || elementType.isFloat8E4M3FN() ||
+      elementType.isFloat8E4M3FNUZ() || elementType.isFloat8E5M2() ||
+      elementType.isFloat8E5M2FNUZ()) {
     auto floatValues = llvm::to_vector(llvm::map_range(
         attr.getValues<APFloat>(), [&](APFloat value) -> uint8_t {
           return value.bitcastToAPInt().getZExtValue();
@@ -397,7 +397,7 @@ Tensor makeTensor(DenseElementsAttr attr) {
                             floatValues));
   }
 
-  if (elemType.isF16() || elemType.isBF16()) {
+  if (elementType.isF16() || elementType.isBF16()) {
     auto floatValues = llvm::to_vector(llvm::map_range(
         attr.getValues<APFloat>(), [&](APFloat value) -> uint16_t {
           return value.bitcastToAPInt().getZExtValue();
@@ -410,7 +410,7 @@ Tensor makeTensor(DenseElementsAttr attr) {
         HeapAsmResourceBlob::allocateAndCopyInferAlign<uint16_t>(floatValues));
   }
 
-  if (elemType.isF32()) {
+  if (elementType.isF32()) {
     auto floatValues = llvm::to_vector(llvm::map_range(
         attr.getValues<APFloat>(),
         [&](APFloat value) -> float { return value.convertToFloat(); }));
@@ -418,7 +418,7 @@ Tensor makeTensor(DenseElementsAttr attr) {
                             floatValues));
   }
 
-  if (elemType.isF64()) {
+  if (elementType.isF64()) {
     auto floatValues = llvm::to_vector(llvm::map_range(
         attr.getValues<APFloat>(),
         [&](APFloat value) -> double { return value.convertToDouble(); }));
@@ -427,7 +427,7 @@ Tensor makeTensor(DenseElementsAttr attr) {
   }
 
   // Handle signed integer types.
-  if (elemType.isSignlessInteger(4) || elemType.isSignlessInteger(8)) {
+  if (elementType.isSignlessInteger(4) || elementType.isSignlessInteger(8)) {
     auto intValues = llvm::to_vector(llvm::map_range(
         attr.getValues<APInt>(),
         [&](APInt value) -> int8_t { return value.getSExtValue(); }));
@@ -435,7 +435,7 @@ Tensor makeTensor(DenseElementsAttr attr) {
                             intValues));
   }
 
-  if (elemType.isSignlessInteger(16)) {
+  if (elementType.isSignlessInteger(16)) {
     auto intValues = llvm::to_vector(llvm::map_range(
         attr.getValues<APInt>(),
         [&](APInt value) -> int16_t { return value.getSExtValue(); }));
@@ -443,7 +443,7 @@ Tensor makeTensor(DenseElementsAttr attr) {
                             intValues));
   }
 
-  if (elemType.isSignlessInteger(32)) {
+  if (elementType.isSignlessInteger(32)) {
     auto intValues = llvm::to_vector(llvm::map_range(
         attr.getValues<APInt>(),
         [&](APInt value) -> int32_t { return value.getSExtValue(); }));
@@ -451,7 +451,7 @@ Tensor makeTensor(DenseElementsAttr attr) {
                             intValues));
   }
 
-  if (elemType.isSignlessInteger(64)) {
+  if (elementType.isSignlessInteger(64)) {
     auto intValues = llvm::to_vector(llvm::map_range(
         attr.getValues<APInt>(),
         [&](APInt value) -> int64_t { return value.getSExtValue(); }));
@@ -460,7 +460,7 @@ Tensor makeTensor(DenseElementsAttr attr) {
   }
 
   // Handle unsigned integer types.
-  if (elemType.isUnsignedInteger(4) || elemType.isUnsignedInteger(8)) {
+  if (elementType.isUnsignedInteger(4) || elementType.isUnsignedInteger(8)) {
     auto intValues = llvm::to_vector(llvm::map_range(
         attr.getValues<APInt>(),
         [&](APInt value) -> uint8_t { return value.getZExtValue(); }));
@@ -468,7 +468,7 @@ Tensor makeTensor(DenseElementsAttr attr) {
                             intValues));
   }
 
-  if (elemType.isUnsignedInteger(16)) {
+  if (elementType.isUnsignedInteger(16)) {
     auto intValues = llvm::to_vector(llvm::map_range(
         attr.getValues<APInt>(),
         [&](APInt value) -> uint16_t { return value.getZExtValue(); }));
@@ -477,7 +477,7 @@ Tensor makeTensor(DenseElementsAttr attr) {
         HeapAsmResourceBlob::allocateAndCopyInferAlign<uint16_t>(intValues));
   }
 
-  if (elemType.isUnsignedInteger(32)) {
+  if (elementType.isUnsignedInteger(32)) {
     auto intValues = llvm::to_vector(llvm::map_range(
         attr.getValues<APInt>(),
         [&](APInt value) -> uint32_t { return value.getZExtValue(); }));
@@ -486,7 +486,7 @@ Tensor makeTensor(DenseElementsAttr attr) {
         HeapAsmResourceBlob::allocateAndCopyInferAlign<uint32_t>(intValues));
   }
 
-  if (elemType.isUnsignedInteger(64)) {
+  if (elementType.isUnsignedInteger(64)) {
     auto intValues = llvm::to_vector(llvm::map_range(
         attr.getValues<APInt>(),
         [&](APInt value) -> uint64_t { return value.getZExtValue(); }));
@@ -496,7 +496,7 @@ Tensor makeTensor(DenseElementsAttr attr) {
   }
 
   // Handle boolean type.
-  if (isSupportedBooleanType(elemType)) {
+  if (isSupportedBooleanType(elementType)) {
     auto boolValues = llvm::to_vector(
         llvm::map_range(attr.getValues<bool>(),
                         [&](bool value) -> uint8_t { return value ? 1 : 0; }));
@@ -505,8 +505,8 @@ Tensor makeTensor(DenseElementsAttr attr) {
   }
 
   // Handle complex types.
-  if (elemType.isa<ComplexType>()) {
-    auto complexElemTy = elemType.cast<ComplexType>().getElementType();
+  if (elementType.isa<ComplexType>()) {
+    auto complexElemTy = elementType.cast<ComplexType>().getElementType();
     if (complexElemTy.isF32()) {
       auto complexValues = llvm::to_vector(llvm::map_range(
           attr.getValues<std::complex<APFloat>>(),
@@ -539,21 +539,21 @@ Tensor makeTensor(DenseElementsAttr attr) {
 
 DenseElementsAttr makeDenseElementsAttr(Tensor tensor) {
   auto type = tensor.getType();
-  auto elemType = type.getElementType();
+  auto elementType = type.getElementType();
 
-  if (elemType.isa<FloatType>()) {
+  if (elementType.isa<FloatType>()) {
     std::vector<llvm::APFloat> values;
     for (auto it = tensor.index_begin(); it != tensor.index_end(); ++it) {
-      Element ele = tensor.get(*it);
-      values.push_back(ele.getFloatValue());
+      Element element = tensor.get(*it);
+      values.push_back(element.getFloatValue());
     }
     return DenseFPElementsAttr::get(tensor.getType(), values);
   }
-  if (elemType.isa<IntegerType>()) {
+  if (elementType.isa<IntegerType>()) {
     std::vector<llvm::APInt> values;
     for (auto it = tensor.index_begin(); it != tensor.index_end(); ++it) {
-      Element ele = tensor.get(*it);
-      values.push_back(ele.getIntegerValue());
+      Element element = tensor.get(*it);
+      values.push_back(element.getIntegerValue());
     }
     return DenseIntElementsAttr::get(tensor.getType(), values);
   }

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -138,10 +138,10 @@ inline raw_ostream &operator<<(raw_ostream &os, Tensor tensor) {
   return os;
 }
 
-/// Creates a Tensor using 'DenseElementsAttr' object 'attr'.
+/// Creates a Tensor from a DenseElementsAttr.
 Tensor makeTensor(DenseElementsAttr attr);
 
-/// Creates a DenseElementsAttr from a Tensor
+/// Creates a DenseElementsAttr from a Tensor.
 DenseElementsAttr makeDenseElementsAttr(Tensor tensor);
 
 }  // namespace stablehlo

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -141,6 +141,9 @@ inline raw_ostream &operator<<(raw_ostream &os, Tensor tensor) {
 /// Creates a Tensor using 'DenseElementsAttr' object 'attr'.
 Tensor makeTensor(DenseElementsAttr attr);
 
+/// Creates a DenseElementsAttr from a Tensor
+DenseElementsAttr makeDenseElementsAttr(Tensor tensor);
+
 }  // namespace stablehlo
 }  // namespace mlir
 

--- a/stablehlo/tools/StablehloTranslateMain.cpp
+++ b/stablehlo/tools/StablehloTranslateMain.cpp
@@ -175,7 +175,7 @@ TranslateFromMLIRRegistration interpretRegistration(
           config.probeInstrumentationDir);
 
       llvm::SmallVector<stablehlo::InterpreterValue> inputs;
-      auto results= evalModule(module, inputs, config);
+      auto results = evalModule(module, inputs, config);
       if (failed(results)) return failure();
 
       for (auto &result : *results) result.print(os);

--- a/stablehlo/tools/StablehloTranslateMain.cpp
+++ b/stablehlo/tools/StablehloTranslateMain.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include <memory>
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -173,7 +174,8 @@ TranslateFromMLIRRegistration interpretRegistration(
       config.fallback = std::make_unique<StablehloTranslateInterpreterFallback>(
           config.probeInstrumentationDir);
 
-      auto resultsOrError = evalModule(module, /*inputs=*/{}, config);
+      llvm::SmallVector<stablehlo::InterpreterValue> inputs;
+      auto resultsOrError = evalModule(module, inputs, config);
       if (resultsOrError) {
         return success(resultsOrError);
       }

--- a/stablehlo/tools/StablehloTranslateMain.cpp
+++ b/stablehlo/tools/StablehloTranslateMain.cpp
@@ -175,12 +175,10 @@ TranslateFromMLIRRegistration interpretRegistration(
           config.probeInstrumentationDir);
 
       llvm::SmallVector<stablehlo::InterpreterValue> inputs;
-      auto resultsOrError = evalModule(module, inputs, config);
-      if (resultsOrError) {
-        return success(resultsOrError);
-      }
+      auto results= evalModule(module, inputs, config);
+      if (failed(results)) return failure();
 
-      for (auto &result : *resultsOrError) result.print(os);
+      for (auto &result : *results) result.print(os);
 
       return success();
     },


### PR DESCRIPTION
```py
ASM = """
func.func @test(%arg0: tensor<2x2xf16>) -> tensor<2x2xf16> {
  %0 = stablehlo.add %arg0, %arg0 : (tensor<2x2xf16>, tensor<2x2xf16>) -> tensor<2x2xf16>
  func.return %0 : tensor<2x2xf16>
}
"""

m = ir.Module.parse(ASM)
arg = np.asarray([1, 2, 3, 4], np.float16).reshape(2,2)
args = [ir.DenseIntElementsAttr.get(arg)]
res = stablehlo.eval_module(m, args)
```

- Added python API for reference interpreter, and test cases for int/float datatypes
- Added reference API which takes DenseElementsAttrs to be used by python API
- Added method to convert between `stablehlo::Tensor` and `mlir::DenseElementsAttr` more easily (only supports int/float types)
- Added more error checking at interpreter entry point to improve UX
- Changed error reporting at API boundary from `llvm::Error` to `mlir::LogicalResult` to be more consistent for external users, also improves python error experience


