### PR TITLE
Add shape refinement pass for DotOp

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -481,8 +481,8 @@ LogicalResult CholeskyOp::inferReturnTypeComponents(
 //===----------------------------------------------------------------------===//
 
 LogicalResult DotOp::verify() {
-  return hlo::verifyDotOp(getLoc(), getLhs(), getRhs(), getPrecisionConfig(),
-                          getResult());
+  return hlo::verifyDotOp(getLoc(), getLhs().getType(), getRhs().getType(),
+                          getPrecisionConfig(), getResult());
 }
 
 // PrecisionConfig - std::optional attribute, print the array as raw enums

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1884,39 +1884,40 @@ LogicalResult inferCreateTokenOp(HloDialectInterface* dialect,
 }
 
 LogicalResult inferDotOp(
-    std::optional<Location> location, Value lhs, Value rhs,
+    std::optional<Location> location, Type lhsType, Type rhsType,
     std::optional<ArrayAttr> precisionConfig,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   if (failed(verifyPrecisionConfig(location, precisionConfig)))
     return failure();
 
-  auto lhsType = lhs.getType().dyn_cast<RankedTensorType>();
-  auto rhsType = rhs.getType().dyn_cast<RankedTensorType>();
-  if (!lhsType || !rhsType) {
+  auto lhsRankedType = lhsType.dyn_cast<RankedTensorType>();
+  auto rhsRankedType = rhsType.dyn_cast<RankedTensorType>();
+  if (!lhsRankedType || !rhsRankedType) {
     inferredReturnShapes.push_back({});
     return success();
   }
 
   SmallVector<int64_t> dimensions;
-  if (1 == lhsType.getRank() && 1 == rhsType.getRank() &&
+  if (1 == lhsRankedType.getRank() && 1 == rhsRankedType.getRank() &&
       // vector dot vector
-      verifyCompatibleDims(lhsType.getDimSize(0), rhsType.getDimSize(0))) {
-  } else if (2 == lhsType.getRank() && 1 == rhsType.getRank() &&
-             verifyCompatibleDims(lhsType.getDimSize(1),
-                                  rhsType.getDimSize(0))) {
+      verifyCompatibleDims(lhsRankedType.getDimSize(0),
+                           rhsRankedType.getDimSize(0))) {
+  } else if (2 == lhsRankedType.getRank() && 1 == rhsRankedType.getRank() &&
+             verifyCompatibleDims(lhsRankedType.getDimSize(1),
+                                  rhsRankedType.getDimSize(0))) {
     // matrix dot vector
-    dimensions.push_back(lhsType.getDimSize(0));
-  } else if (1 == lhsType.getRank() && 2 == rhsType.getRank() &&
-             verifyCompatibleDims(lhsType.getDimSize(0),
-                                  rhsType.getDimSize(0))) {
+    dimensions.push_back(lhsRankedType.getDimSize(0));
+  } else if (1 == lhsRankedType.getRank() && 2 == rhsRankedType.getRank() &&
+             verifyCompatibleDims(lhsRankedType.getDimSize(0),
+                                  rhsRankedType.getDimSize(0))) {
     // vector dot matrix
-    dimensions.push_back(rhsType.getDimSize(1));
-  } else if (2 == lhsType.getRank() && 2 == rhsType.getRank() &&
-             verifyCompatibleDims(lhsType.getDimSize(1),
-                                  rhsType.getDimSize(0))) {
+    dimensions.push_back(rhsRankedType.getDimSize(1));
+  } else if (2 == lhsRankedType.getRank() && 2 == rhsRankedType.getRank() &&
+             verifyCompatibleDims(lhsRankedType.getDimSize(1),
+                                  rhsRankedType.getDimSize(0))) {
     // matrix dot matrix
-    dimensions.push_back(lhsType.getDimSize(0));
-    dimensions.push_back(rhsType.getDimSize(1));
+    dimensions.push_back(lhsRankedType.getDimSize(0));
+    dimensions.push_back(rhsRankedType.getDimSize(1));
   } else {
     return emitOptionalError(location,
                              "expected both lhs/rhs ranks to be "
@@ -3407,7 +3408,7 @@ LogicalResult verifyDotOp(std::optional<Location> location, Value lhs,
                           Value rhs, std::optional<ArrayAttr> precisionConfig,
                           Value result) {
   SmallVector<ShapedTypeComponents> inferredReturnShapes;
-  if (failed(inferDotOp(location, lhs, rhs, precisionConfig,
+  if (failed(inferDotOp(location, lhs.getType(), rhs.getType(), precisionConfig,
                         inferredReturnShapes)))
     return failure();
 

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -194,8 +194,8 @@ LogicalResult inferCreateTokenOp(HloDialectInterface* dialect,
                                  SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferDotOp(
-    std::optional<Location> location, Type lhsType, Type rhsType,
-    std::optional<ArrayAttr> precisionConfig,
+    std::optional<Location> location, RankedTensorType lhsType,
+    RankedTensorType rhsType, std::optional<ArrayAttr> precisionConfig,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
 LogicalResult inferDotGeneralOp(
@@ -412,8 +412,9 @@ LogicalResult verifyConvolutionOp(
     int64_t featureGroupCount, int64_t batchGroupCount,
     std::optional<ArrayAttr> precisionConfig, Type resultType);
 
-LogicalResult verifyDotOp(std::optional<Location> location, Value lhs,
-                          Value rhs, std::optional<ArrayAttr> precisionConfig,
+LogicalResult verifyDotOp(std::optional<Location> location,
+                          RankedTensorType lhsType, RankedTensorType rhsType,
+                          std::optional<ArrayAttr> precisionConfig,
                           Value result);
 
 LogicalResult verifyDotGeneralOp(std::optional<Location> location, Value lhs,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -194,7 +194,7 @@ LogicalResult inferCreateTokenOp(HloDialectInterface* dialect,
                                  SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferDotOp(
-    std::optional<Location> location, Value lhs, Value rhs,
+    std::optional<Location> location, Type lhsType, Type rhsType,
     std::optional<ArrayAttr> precisionConfig,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 

--- a/stablehlo/tests/stablehlo_refine_shapes.mlir
+++ b/stablehlo/tests/stablehlo_refine_shapes.mlir
@@ -562,6 +562,15 @@ func.func @refine_dot_general(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5xf32>
 
 // -----
 
+// CHECK-LABEL: @refine_dot
+func.func @refine_dot(%arg0: tensor<3x4xf32>, %arg1: tensor<4x5xf32>) -> tensor<?x?xf32> {
+  // CHECK: stablehlo.dot{{.*}} -> tensor<3x5xf32>
+  %0 = stablehlo.dot %arg0, %arg1 : (tensor<3x4xf32>, tensor<4x5xf32>) -> tensor<?x?xf32>
+  func.return %0 : tensor<?x?xf32>
+}
+
+// -----
+
 // CHECK-LABEL: @refine_dynamic_broadcast_in_dim
 func.func @refine_dynamic_broadcast_in_dim(%arg0: tensor<4xf32>) -> tensor<?x?xf32> {
   // CHECK: stablehlo.dynamic_broadcast_in_dim{{.*}} -> tensor<3x4xf32>


### PR DESCRIPTION
`DotOp` currently doesn't have shape refinement, so if downstream exports stablehlo with dot, and it contains unbounded dynamic shapes with `stablehlo.dot`, it fails to refine shape.

This change enables refinement, and prevents users from having to transform `dot` back to `dot_general` whenever canonicalization pass (for `dot_general` to `dot`) is run implicitly.