### PR TITLE
Add patterns in ShapeLegalizeToStablehlo for tensor::ExtractOp

### DIFF
--- a/stablehlo/tests/shape_legalize_to_stablehlo.mlir
+++ b/stablehlo/tests/shape_legalize_to_stablehlo.mlir
@@ -279,6 +279,16 @@ func.func @index_cast_scalar_index_to_i64(%arg0: index) -> i64 {
 
 // -----
 
+func.func @index_cast_scalar_i32_to_index(%arg0: i32) -> index {
+  //      CHECK: %[[CAST_I32:.*]] = builtin.unrealized_conversion_cast %arg0 : i32 to tensor<i32>
+  // CHECK-NEXT: %[[CAST_INDEX:.*]] = builtin.unrealized_conversion_cast %[[CAST_I32]] : tensor<i32> to index
+  // CHECK-NEXT: return %[[CAST_INDEX]] : index
+  %0 = arith.index_cast %arg0 : i32 to index
+  return %0 : index
+}
+
+// -----
+
 func.func @index_cast_index_to_i8(%arg0: tensor<2xindex>) -> tensor<2xi8> {
   // expected-error@+1 {{failed to legalize operation 'arith.index_cast' that was explicitly marked illegal}}
   %0 = arith.index_cast %arg0 : tensor<2xindex> to tensor<2xi8>
@@ -291,14 +301,6 @@ func.func @index_cast_i8_to_index(%arg0: tensor<2xi8>) -> tensor<2xindex> {
   // expected-error@+1 {{failed to legalize operation 'arith.index_cast' that was explicitly marked illegal}}
   %0 = arith.index_cast %arg0 : tensor<2xi8> to tensor<2xindex>
   return %0 : tensor<2xindex>
-}
-
-// -----
-
-func.func @index_cast_scalar_i32_to_index(%arg0: i32) -> index {
-  // expected-error@+1 {{failed to legalize operation 'arith.index_cast' that was explicitly marked illegal}}
-  %0 = arith.index_cast %arg0 : i32 to index
-  return %0 : index
 }
 
 // -----
@@ -335,4 +337,53 @@ func.func @muli_i32(%arg0: i32, %arg1: i32) -> i32 {
   // expected-error@+1 {{failed to legalize operation 'arith.muli' that was explicitly marked illegal}}
   %0 = arith.muli %arg0, %arg1 : i32
   return %0 : i32
+}
+
+// -----
+
+// CHECK-LABEL: func @tensor_extract
+func.func @tensor_extract(%arg0: tensor<3x3xindex>) -> index {
+  %c1 = arith.constant 0 : index
+  %c2 = arith.constant 1 : index
+  %0 = tensor.extract %arg0[%c1, %c2] : tensor<3x3xindex>
+  return %0 : index
+  //      CHECK: %[[CAST:.*]] = builtin.unrealized_conversion_cast %arg0 : tensor<3x3xindex> to tensor<3x3xi32>
+  //      CHECK: %[[SLICE:.*]] = stablehlo.slice %[[CAST]] [0:1, 1:2] : (tensor<3x3xi32>) -> tensor<1x1xi32>
+  // CHECK-NEXT: %[[RESHAPE:.*]] = stablehlo.reshape %[[SLICE]] : (tensor<1x1xi32>) -> tensor<i32>
+  // CHECK-NEXT: %[[RES_INDEX:.*]] = builtin.unrealized_conversion_cast %[[RESHAPE]] : tensor<i32> to index
+  // CHECK-NEXT: return %[[RES_INDEX]] : index
+}
+
+// -----
+
+// CHECK-LABEL: func @tensor_extract_i32
+func.func @tensor_extract_i32(%arg0: tensor<3x3xi32>) -> i32 {
+  %c1 = arith.constant 0 : index
+  %c2 = arith.constant 1 : index
+  %0 = tensor.extract %arg0[%c1, %c2] : tensor<3x3xi32>
+  return %0 : i32
+  //      CHECK: %[[SLICE:.*]] = stablehlo.slice %arg0 [0:1, 1:2] : (tensor<3x3xi32>) -> tensor<1x1xi32>
+  // CHECK-NEXT: %[[RESHAPE:.*]] = stablehlo.reshape %[[SLICE]] : (tensor<1x1xi32>) -> tensor<i32>
+  // CHECK-NEXT: %[[RES_I32:.*]] = builtin.unrealized_conversion_cast %[[RESHAPE]] : tensor<i32> to i32
+  // CHECK-NEXT: return %[[RES_I32]] : i32
+}
+
+// -----
+
+func.func @tensor_extract_out_of_range(%arg0: tensor<3x3xindex>) -> index {
+  %c1 = arith.constant 4 : index
+  %c2 = arith.constant 4 : index
+  // expected-error@+1 {{failed to legalize operation 'tensor.extract' that was explicitly marked illegal}}
+  %0 = tensor.extract %arg0[%c1, %c2] : tensor<3x3xindex>
+  return %0 : index
+}
+
+// -----
+
+func.func @tensor_extract_dynamic(%arg0: tensor<?x3xindex>) -> index {
+  %c1 = arith.constant 0 : index
+  %c2 = arith.constant 2 : index
+  // expected-error@+1 {{failed to legalize operation 'tensor.extract' that was explicitly marked illegal}}
+  %0 = tensor.extract %arg0[%c1, %c2] : tensor<?x3xindex>
+  return %0 : index
 }


### PR DESCRIPTION
Add patterns in ShapeLegalizeToStablehlo for tensor::ExtractOp

1. Add support for tensor.Extract, which is lowered to mhlo.slice
2. Support a special case from TF graph:
   tensor.extract tensor<?xi32> -> i32
   arith.index_cast i32 -> index
   This is lower to:
   mhlo.slice tensor<?xi32> -> tensor<1xi32>
   mhlo.reshape tensor<ixi32> -> tensor<i32>
   unrealized_conversion_cast tensor<i32> -> i32
   unrealized_conversion_cast i32 -> tensor<i32>
   unrealized_conversion_cast tensor<i32> -> index