### PR TITLE
Ensure emitting bytecode does not yield warnings

### DIFF
--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1,4 +1,7 @@
 // RUN: stablehlo-opt %s -verify-diagnostics -split-input-file -allow-unregistered-dialect | FileCheck %s
+// RUN: stablehlo-opt %s -verify-diagnostics -split-input-file -allow-unregistered-dialect -emit-bytecode -debug-only=stablehlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s
+
+// CHECK-WARN-NOT: Not Implemented
 
 // Tests for types, ops with custom constraints, verifiers, printer or parser
 // methods.


### PR DESCRIPTION
This mirrors the checks we have for VHLO in
`stablehlo_legalize_to_vhlo.mlir`.

Emitting StableHLO bytecode should not emit such warnings either.