### PR TITLE
Fix broken links

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -3,7 +3,7 @@
 StableHLO is a backward compatible ML compute opset inspired by HLO/MHLO.
 This document explains the kind and the extent of the compatibility guarantees
 that StableHLO provides, based on the process established in
-[the compatibility RFC](../rfcs/20220912-compatibility.md).
+[the compatibility RFC](https://github.com/openxla/stablehlo/tree/main/rfcs/20220912-compatibility.md).
 
 ## Versions
 
@@ -126,8 +126,8 @@ for roundtrip examples of using the Python Serialization APIs.
 
 ## Tests
 
-We have a compatibility suite in [stablehlo/tests/vhlo](../stablehlo/tests/vhlo)
-that involves [a comprehensive compendium of StableHLO ops](../stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.mlir)
+We have a compatibility suite in [stablehlo/tests/vhlo](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/vhlo)
+that involves [a comprehensive compendium of StableHLO ops](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.mlir)
 serialized for all supported StableHLO versions. For every pull request, we are
 testing both backward and forward compatibility - i.e. that the suite can be
 deserialized targeting HEAD (backward compatibility), that the compendium

--- a/docs/reference_checklist.md
+++ b/docs/reference_checklist.md
@@ -63,7 +63,7 @@ on those fronts alongside the interpreter implementation.
            an open issue reflecting that discrepancy.
 1. In [interpreter tests](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret):
     1. Add a file called `<op_mnemonic>.mlir`.
-    1. Write tests following the [testing guidelines](https://github.com/openxla/stablehlo/blob/main/docs/reference.md#testing-guidelines).
+    1. Write tests following the [testing guidelines](reference.md#testing-guidelines).
 1. In the [testdata directory](https://github.com/openxla/stablehlo/tree/main/stablehlo/testdata):
     1. Run any disabled tests that are covered by the newly added operation.
     1. If the tests pass, enable them by converting `RUN-DISABLED` to `RUN`.
@@ -94,13 +94,13 @@ on those fronts alongside the interpreter implementation.
        in this file, following the same naming guidelines noted above.
     1. Move any shape inference tests from the [ops_stablehlo.mlir](https://github.com/openxla/stablehlo/blob/main/stablehlo/tests/ops_stablehlo.mlir)
        file into this file.
-1. In [spec.md](link):
+1. In [spec.md](spec.md):
     1. Add a link to `stablehlo/tests/interpret/<op_mnemonic>.mlir`
        to the "Examples" section
-       (e.g. [More Examples](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#add)).
+       (e.g. [More Examples](spec.md#add)).
     1. Make sure the spec only has 1 example.
-    1. Make sure the spec example follows the [testing guidelines](https://github.com/openxla/stablehlo/blob/main/docs/reference.md#testing-guidelines).
+    1. Make sure the spec example follows the [testing guidelines](reference.md#testing-guidelines).
     1. Make sure the spec example test is interpretable.
     1. Make sure the spec example is the same as what is in the ODS.
-1. In [status.md](https://github.com/openxla/stablehlo/blob/main/docs/status.md):
+1. In [status.md](status.md):
     1. Update the "Interpreter" column to `yes`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -610,7 +610,7 @@ tensor. Depending on the element type, does the following:
 // %result: [2, 0, 2]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/abs.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/abs.mlir)
 
 ### add
 
@@ -662,7 +662,7 @@ Performs element-wise addition of two tensors `lhs` and `rhs` and produces a
 // %result: [[6, 8], [10, 12]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/add.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/add.mlir)
 
 ### after_all
 
@@ -692,7 +692,7 @@ it only exists to establish data dependencies from `result` to `inputs`.
 %result = "stablehlo.after_all"(%input0, %input1) : (!stablehlo.token, !stablehlo.token) -> !stablehlo.token
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/after_all.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/after_all.mlir)
 
 ### all_gather
 
@@ -767,7 +767,7 @@ Afterwards, within each `process_group`:
 // %result@(1, 0): [[1, 2, 5, 6], [3, 4, 7, 8]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/all_gather.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/all_gather.mlir)
 
 ### all_reduce
 
@@ -846,13 +846,13 @@ Afterwards, within each `process_group`:
 // %result@(1, 0): [6, 8, 10, 12]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/all_reduce.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/all_reduce.mlir)
 
 ### all_to_all
 
 #### Semantics
 
-![](images/spec/all_to_all.svg)
+![all_to_all example](images/spec/all_to_all.svg)
 
 Within each process group in the StableHLO process grid, splits the values of
 the `operand` tensor along `split_dimension` into parts, scatters the split
@@ -934,7 +934,7 @@ Afterwards, within each `process_group`:
 //                  [15, 16]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/all_to_all.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/all_to_all.mlir)
 
 ### and
 
@@ -972,7 +972,7 @@ tensor. Depending on the element type, does the following:
 // %result: [[1, 2], [3, 0]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/and.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/and.mlir)
 
 ### atan2
 
@@ -1011,7 +1011,7 @@ Performs element-wise atan2 operation on `lhs` and `rhs` tensor and produces a
 // %result: [0.0, 1.57079637, -1.57079637] // [0.0, pi/2, -pi/2]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/atan2.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/atan2.mlir)
 
 ### batch_norm_grad
 
@@ -1375,7 +1375,7 @@ implementation-defined as well.
 // %result: [0xCDEF, 0x89AB, 0x4567, 0x0123] // little-endian representation
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/bitcast_convert.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/bitcast_convert.mlir)
 
 ### broadcast_in_dim
 
@@ -1446,7 +1446,7 @@ in the `operand` tensor and produces a `result` tensor. More formally,
 //          ]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/broadcast_in_dim.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/broadcast_in_dim.mlir)
 
 ### case
 
@@ -1494,7 +1494,7 @@ where:
 // %result1: [1, 1]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/case.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/case.mlir)
 
 ### cbrt
 
@@ -1531,7 +1531,7 @@ Performs element-wise cubic root operation on `operand` tensor and produces a
 // %result: [0.0, 1.0, 2.0, 3.0]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/cbrt.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/cbrt.mlir)
 
 ### ceil
 
@@ -1566,7 +1566,7 @@ specification. For quantized types, performs
 // %result: [-0.0, -0.0, 1.0, 1.0, 2.0]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/ceil.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/ceil.mlir)
 
 ### cholesky
 
@@ -1670,7 +1670,7 @@ for this operation ([#560](https://github.com/openxla/stablehlo/issues/560)).
 // %result: [5, 13, 20]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/clamp.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/clamp.mlir)
 
 ### collective_broadcast
 
@@ -1799,7 +1799,7 @@ Afterwards, `result@process` is given by:
 // %result@(2, 0): [[5, 6], [7, 8]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/collective_permute.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/collective_permute.mlir)
 
 ### compare
 
@@ -1883,7 +1883,7 @@ comparison_direction)`.
 // %result: [true, false]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/compare.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/compare.mlir)
 
 ### complex
 
@@ -1921,7 +1921,7 @@ imaginary values, `lhs` and `rhs`, and produces a `result` tensor.
 // %result: [(1.0, 2.0), (3.0, 4.0)]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/complex.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/complex.mlir)
 
 ### composite
 
@@ -1971,7 +1971,7 @@ semantics change.
 } : (tensor<f32>, tensor<f32>) -> tensor<f32>
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/composite.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/composite.mlir)
 
 ### concatenate
 
@@ -2019,7 +2019,7 @@ arguments and produces a `result` tensor. More formally,
 // %result: [[1, 2], [3, 4], [5, 6], [7, 8]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/concatenate.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/concatenate.mlir)
 
 ### constant
 
@@ -2052,7 +2052,7 @@ Produces an `output` tensor from a constant `value`.
 // %output: [[0.0, 1.0], [2.0, 3.0]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/constant.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/constant.mlir)
 
 ### convert
 
@@ -2118,7 +2118,7 @@ into `convert` ([#1576](https://github.com/openxla/stablehlo/issues/1576)).
 // %result: [(-1.0, 0.0), (0.0, 0.0), (1.0, 0.0)]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/convert.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/convert.mlir)
 
 ### convolution
 
@@ -2128,7 +2128,7 @@ Computes dot products between windows of `lhs` and slices of `rhs` and produces
 `result`. The following diagram shows how elements in `result` are computed from
 `lhs` and `rhs` using a concrete example.
 
-![](images/spec/convolution.svg)
+![convolution example](images/spec/convolution.svg)
 
 More formally, consider the following reframing of the inputs in terms of `lhs`
 in order to be able to express windows of `lhs`:
@@ -2365,7 +2365,7 @@ Performs element-wise cosine operation on `operand` tensor and produces a
 // %result: [[1.0, 0.0], [-1.0, 0.0]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/cosine.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/cosine.mlir)
 
 ### count_leading_zeros
 
@@ -2398,7 +2398,7 @@ tensor and produces a `result` tensor.
 // %result: [[64, 63], [56, 0]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/count_leading_zeros.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/count_leading_zeros.mlir)
 
 ### custom_call
 
@@ -2483,7 +2483,7 @@ produces a `result` tensor. Depending on the element type, does the following:
 // %result: [5.66666651, -5.66666651, -5.66666651, 5.66666651]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/divide.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/divide.mlir)
 
 ### dot_general
 
@@ -2617,7 +2617,7 @@ planning to address this in
 //          ]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/dot_general.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/dot_general.mlir)
 
 ### dynamic_slice
 
@@ -2675,7 +2675,7 @@ contain the sizes of the slice for each dimension. More formally,
 //          ]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/dynamic_slice.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/dynamic_slice.mlir)
 
 ### dynamic_update_slice
 
@@ -2739,7 +2739,7 @@ More formally, `result[result_index]` is defined as:
 //          ]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/dynamic_update_slice.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/dynamic_update_slice.mlir)
 
 ### exponential
 
@@ -2777,7 +2777,7 @@ Performs element-wise exponential operation on `operand` tensor and produces a
 // %result: [[1.0, 2.7182818284590451], [7.3890560989306504, 20.085536923187668]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/exponential.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/exponential.mlir)
 
 ### exponential_minus_one
 
@@ -2815,7 +2815,7 @@ produces a `result` tensor. Depending on the element type, does the following:
 // %result: [0.0, 1.71828187]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/exponential_minus_one.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/exponential_minus_one.mlir)
 
 ### fft
 
@@ -2963,7 +2963,7 @@ specification. For quantized types, performs
 // %result: [-1.0, -1.0, 0.0, 0.0, 2.0]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/floor.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/floor.mlir)
 
 ### gather
 
@@ -2976,7 +2976,7 @@ The following diagram shows how elements in `result` map on elements in
 `operand` using a concrete example. The diagram picks a few example `result`
 indices and explains in detail which `operand` indices they correspond to.
 
-![](images/spec/gather.svg)
+![gather example](images/spec/gather.svg)
 
 More formally, `result[result_index] = operand[operand_index]` where:
 
@@ -3083,7 +3083,7 @@ behavior is undefined. More formally, for all `i1 < i2` from `indices(result)`,
 //          ]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/gather.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/gather.mlir)
 
 ### get_dimension_size
 
@@ -3120,7 +3120,7 @@ component of the type. The element-type could be anything.
 // %result: 3
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/get_dimension_size.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/get_dimension_size.mlir)
 
 ### get_tuple_element
 
@@ -3157,7 +3157,7 @@ Extracts element at `index` position of the `operand` tuple and produces a
 // %result: [1.0, 2.0]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/tuple_and_get_tuple_element.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/tuple_and_get_tuple_element.mlir)
 
 ### if
 
@@ -3201,7 +3201,7 @@ pred ? true_branch() : false_branch()`.
 // %result: 10
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/if.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/if.mlir)
 
 ### imag
 
@@ -3239,7 +3239,7 @@ constant(0, element_type(result))`.
 // %result: [2.0, 4.0]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/imag.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/imag.mlir)
 
 ### infeed
 
@@ -3289,7 +3289,7 @@ separate outputs to improve clarity
 // results1#0: [[5, 6], [7, 8]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/infeed.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/infeed.mlir)
 
 ### iota
 
@@ -3342,7 +3342,7 @@ result_index[iota_dimension], element_type(output))`.
 //          ]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/iota.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/iota.mlir)
 
 ### is_finite
 
@@ -3378,7 +3378,7 @@ always `true`.
 // %y: [false, false, false, true, true, true, true]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/is_finite.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/is_finite.mlir)
 
 ### log
 
@@ -3415,7 +3415,7 @@ Performs element-wise logarithm operation on `operand` tensor and produces a
 // %result: [[0.0, 0.69314718055994529], [1.0986122886681098, 1.3862943611198906]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/log.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/log.mlir)
 
 ### log_plus_one
 
@@ -3453,7 +3453,7 @@ produces a `result` tensor. Depending on the element type, does the following:
 // %result: [0.0, -6.90776825, 2.07944155, 2.0, 2.77258873]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/log_plus_one.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/log_plus_one.mlir)
 
 ### logistic
 
@@ -3491,7 +3491,7 @@ Performs element-wise logistic operation on `operand` tensor and produces a
 // %result: [[0.5, 0.73105858], [0.88079708, 0.95257413]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/logistic.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/logistic.mlir)
 
 ### map
 
@@ -3541,7 +3541,7 @@ the future ([#487](https://github.com/openxla/stablehlo/issues/487)).
 // %result: [[0, 5], [12, 21]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/map.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/map.mlir)
 
 ### maximum
 
@@ -3586,7 +3586,7 @@ Performs element-wise max operation on tensors `lhs` and `rhs` and produces a
 // %result: [[5, 6], [7, 8]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/maximum.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/maximum.mlir)
 
 ### minimum
 
@@ -3631,7 +3631,7 @@ Performs element-wise min operation on tensors `lhs` and `rhs` and produces a
 // %result: [[1, 2], [3, 4]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/minimum.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/minimum.mlir)
 
 ### multiply
 
@@ -3673,7 +3673,7 @@ Performs element-wise product of two tensors `lhs` and `rhs` and produces a
 // %result: [[5, 12], [21, 32]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/multiply.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/multiply.mlir)
 
 ### negate
 
@@ -3720,7 +3720,7 @@ tensor. Depending on the element type, does the following:
 // %result: [-2.5, -0.0]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/negate.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/negate.mlir)
 
 ### not
 
@@ -3762,7 +3762,7 @@ Depending on the element type, does the following:
 // %result: [false, true]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/not.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/not.mlir)
 
 ### optimization_barrier
 
@@ -3799,7 +3799,7 @@ an identity, i.e. `result = operand`.
 // %result1: 1.0
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/optimization_barrier.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/optimization_barrier.mlir)
 
 ### or
 
@@ -3844,7 +3844,7 @@ tensor. Depending on the element type, does the following:
 // %result: [[false, true], [true, true]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/or.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/or.mlir)
 
 ### outfeed
 
@@ -3876,7 +3876,7 @@ Semantics of `outfeed_config` is implementation-defined.
 } : (tensor<2x2x2xi64>, !stablehlo.token) -> !stablehlo.token
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/outfeed.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/outfeed.mlir)
 
 ### pad
 
@@ -3950,7 +3950,7 @@ More formally, `result[result_index]` is defined as:
 //          ]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/pad.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/pad.mlir)
 
 ### partition_id
 
@@ -3970,7 +3970,7 @@ Produces `partition_id` of the current process.
 %result = "stablehlo.partition_id"() : () -> tensor<ui32>
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/partition_id.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/partition_id.mlir)
 
 ### popcnt
 
@@ -4003,7 +4003,7 @@ and produces a `result` tensor.
 // %result: [0, 1, 1, 7]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/popcnt.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/popcnt.mlir)
 
 ### power
 
@@ -4043,7 +4043,7 @@ produces a `result` tensor. Depending on the element type, does the following:
 // %result: [4.0, 0.0, -nan, 25.0, 0.333333343, inf]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/power.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/power.mlir)
 
 ### real
 
@@ -4080,7 +4080,7 @@ tensor. More formally, for each element `x`:
 // %result: [1.0, 3.0]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/real.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/real.mlir)
 
 ### recv
 
@@ -4132,7 +4132,7 @@ separate outputs to improve clarity
 } : (!stablehlo.token) -> (tensor<2x2xi64>, !stablehlo.token)
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/send_recv.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/send_recv.mlir)
 
 ### reduce
 
@@ -4212,7 +4212,7 @@ More formally, `results...[j0, ..., jR-1] = reduce(input_slices_converted)` wher
 // %result = [15]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/reduce.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/reduce.mlir)
 
 ### reduce_precision
 
@@ -4270,13 +4270,13 @@ More formally:
 // %output: [0x7FF0000000000000, 0x7FFFFFFFFFFFFFFF, 0.0, 0.0, 65504.0, 0x7FF0000000000000]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/reduce_precision.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/reduce_precision.mlir)
 
 ### reduce_scatter
 
 #### Semantics
 
-![](images/spec/reduce_scatter.svg)
+![reduce_scatter example](images/spec/reduce_scatter.svg)
 
 Within each process group in the StableHLO process grid, performs reduction,
 using `computations`, over the values of the `operand` tensor from each process,
@@ -4362,7 +4362,7 @@ Afterwards, within each `process_group`:
 //                  [22, 24]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/reduce_scatter.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/reduce_scatter.mlir)
 
 ### reduce_window
 
@@ -4374,7 +4374,7 @@ and produces `results`.
 The following diagram shows how elements in `results...` are computed from
 `inputs...` using a concrete example.
 
-![](images/spec/reduce_window.svg)
+![reduce_window example](images/spec/reduce_window.svg)
 
 More formally,
 `results...[result_index] = reduce(windows, init_values, axes(inputs...), body)`
@@ -4453,7 +4453,7 @@ More formally,
 // %result = [[0, 0], [3, 4]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/reduce_window.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/reduce_window.mlir)
 
 ### remainder
 
@@ -4504,7 +4504,7 @@ nearest to the exact value of `lhs/rhs` with ties to even.
 // %result: [2, -2, 2, -2]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/remainder.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/remainder.mlir)
 
 ### replica_id
 
@@ -4524,7 +4524,7 @@ Produces `replica_id` of the current process.
 %result = "stablehlo.replica_id"() : () -> tensor<ui32>
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/replica_id.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/replica_id.mlir)
 
 ### reshape
 
@@ -4579,7 +4579,7 @@ ordering of `index_space(result)` and `index_space(operand)`.
 // %result: [[1, 2], [3, 4], [5, 6]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/reshape.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/reshape.mlir)
 
 ### reverse
 
@@ -4622,7 +4622,7 @@ and produces a `result` tensor. More formally,
 // %result: [[2, 1], [4, 3], [6, 5]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/reverse.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/reverse.mlir)
 
 ### rng
 
@@ -4773,7 +4773,7 @@ quantized types, performs
 // %result: [-3.0, 0.0, 1.0, 1.0, 3.0]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/round_nearest_afz.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/round_nearest_afz.mlir)
 
 ### round_nearest_even
 
@@ -4809,7 +4809,7 @@ specification. For quantized types, performs
 // %result: [-2.0, 0.0, 0.0, 1.0, 2.0]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/round_nearest_even.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/round_nearest_even.mlir)
 
 ### rsqrt
 
@@ -4846,7 +4846,7 @@ produces a `result` tensor. Depending on the element type, does the following:
 // %result: [[1.0, 0.5], [0.33333343, 0.2]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/rsqrt.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/rsqrt.mlir)
 
 ### scatter
 
@@ -4861,7 +4861,7 @@ The following diagram shows how elements in `updates...` map on elements in
 `updates...` indices and explains in detail which `results...` indices they
 correspond to.
 
-![](images/spec/scatter.svg)
+![scatter example](images/spec/scatter.svg)
 
 More formally, for all `update_index` in `index_space(updates[0])`:
 
@@ -4999,7 +4999,7 @@ undefined.
 //          ]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/scatter.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/scatter.mlir)
 
 ### select
 
@@ -5041,7 +5041,7 @@ pred[result_index]`. For quantized types, performs
 // %result: [[5, 2], [3, 8]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/select.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/select.mlir)
 
 ### select_and_scatter
 
@@ -5054,7 +5054,7 @@ a `result` tensor.
 The following diagram shows how elements in `result` are computed from
 `operand` and `source` using a concrete example.
 
-![](images/spec/select_and_scatter.svg)
+![select_and_scatter](images/spec/select_and_scatter.svg)
 
 More formally:
 
@@ -5149,7 +5149,7 @@ More formally:
 // %result: [[0, 0], [0, 0], [5, 14], [7, 0]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/select_and_scatter.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/select_and_scatter.mlir)
 
 ### send
 
@@ -5194,7 +5194,7 @@ implementation-defined. This flag duplicates the information provided in
 } : (tensor<2x2xi64>, !stablehlo.token) -> !stablehlo.token
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/send_recv.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/send_recv.mlir)
 
 ### shift_left
 
@@ -5229,7 +5229,7 @@ of bits and produces a `result` tensor.
 // %result: [-2, 0, 8]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/shift_left.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/shift_left.mlir)
 
 ### shift_right_arithmetic
 
@@ -5264,7 +5264,7 @@ Performs element-wise arithmetic right-shift operation on the `lhs` tensor by
 // %result: [-1, 0, 1]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/shift_right_arithmetic.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/shift_right_arithmetic.mlir)
 
 ### shift_right_logical
 
@@ -5299,7 +5299,7 @@ number of bits and produces a `result` tensor.
 // %result: [9223372036854775807, 0, 1]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/shift_right_logical.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/shift_right_logical.mlir)
 
 ### sign
 
@@ -5356,7 +5356,7 @@ For quantized types, performs
 // %result: [0x7FFFFFFFFFFFFFFF, -1.0, -0.0, 0.0, 1.0]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/sign.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/sign.mlir)
 
 ### sine
 
@@ -5396,7 +5396,7 @@ tensor. Depending on the element type, does the following:
 // %result: [[0.0, 1.0], [0.0, -1.0]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/sine.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/sine.mlir)
 
 ### slice
 
@@ -5454,7 +5454,7 @@ More formally, `result[result_index] = operand[operand_index]` where
 //           ]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/slice.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/slice.mlir)
 
 ### sort
 
@@ -5542,7 +5542,7 @@ More formally, for all `result_index` in `index_space(results[0])`:
 // %result1 = [[1, 2, 1], [3, 2, 3]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/sort.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/sort.mlir)
 
 ### sqrt
 
@@ -5579,7 +5579,7 @@ Performs element-wise square root operation on `operand` tensor and produces a
 // %result: [[0.0, 1.0], [2.0, 3.0]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/sqrt.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/sqrt.mlir)
 
 ### subtract
 
@@ -5620,7 +5620,7 @@ Performs element-wise subtraction of two tensors `lhs` and `rhs` and produces a
 // %result: [[1, 2], [3, 4]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/subtract.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/subtract.mlir)
 
 ### tanh
 
@@ -5658,7 +5658,7 @@ produces a `result` tensor. Depending on the element type, does the following:
 // %result: [-0.76159416, 0.0, 0.76159416]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/tanh.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/tanh.mlir)
 
 ### transpose
 
@@ -5709,7 +5709,7 @@ where `result_index[d] = operand_index[permutation[d]]`.
 //          ]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/transpose.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/transpose.mlir)
 
 ### triangular_solve
 
@@ -5822,7 +5822,7 @@ Produces a `result` tuple from values `val`.
 // %result: ([1.0, 2.0], (3))
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/tuple_and_get_tuple_element.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/tuple_and_get_tuple_element.mlir)
 
 ### uniform_dequantize
 
@@ -5968,7 +5968,7 @@ The behavior of an infinite loop is TBD
 // %results1: 10
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/while.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/while.mlir)
 
 ### xor
 
@@ -6013,7 +6013,7 @@ tensor. Depending on the element type, does the following:
 // %result: [[false, true], [true, false]]
 ```
 
-&nbsp;[More Examples](../stablehlo/tests/interpret/xor.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/xor.mlir)
 
 ## Execution
 


### PR DESCRIPTION
Most of these links are only broken when rendered out of tree, e.g. on the OpenXLA website: https://openxla.org/stablehlo. For example, the "More Examples" link lead to e.g.
https://openxla.org/stablehlo/tests/interpret/add.mlir, which is 404.

For links under `docs/` it is possible to use relative paths.

Also, add labels to images used in spec. This will materialize as the "alt" text, which is used by screen readers.