### PR TITLE
[RFC] Standardize TanOp, CustomCallOp with typed FFI, and Tuple-collectives ops

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -700,8 +700,7 @@ it only exists to establish data dependencies from `result` to `inputs`.
 
 Within each process group in the StableHLO process grid, concatenates the values
 of the `operands` tensors from each process along `all_gather_dim` and produces
-`results` tensors. When multiple `operands` are specified, the `all_gather` is
-performed on each operand.
+`results` tensors.
 
 The operation splits the StableHLO process grid into `process_groups` which is
 defined as follows:
@@ -722,13 +721,13 @@ Afterwards, within each `process_group`:
 
 #### Inputs
 
-| Label | Name                    | Type                                                               | Constraints |
-|-------|-------------------------|--------------------------------------------------------------------|-------------|
-| (I1)  | `operands`               | variadic number of tensors or per-tensor quantized tensors        | (C1), (C6)  |
-| (I2)  | `all_gather_dim`        | constant of type `si64`                                            | (C1), (C6)  |
-| (I3)  | `replica_groups`        | 2-dimensional tensor constant of type `si64`                       | (C2-C4)     |
-| (I4)  | `channel_id`            | constant of type `si64`                                            | (C5)        |
-| (I5)  | `use_global_device_ids` | constant of type `i1`                                              | (C5)        |
+| Label | Name                    | Type                                                        | Constraints |
+|-------|-------------------------|-------------------------------------------------------------|-------------|
+| (I1)  | `operands`               | variadic number of tensors or per-tensor quantized tensors | (C1), (C6)  |
+| (I2)  | `all_gather_dim`        | constant of type `si64`                                     | (C1), (C6)  |
+| (I3)  | `replica_groups`        | 2-dimensional tensor constant of type `si64`                | (C2-C4)     |
+| (I4)  | `channel_id`            | constant of type `si64`                                     | (C5)        |
+| (I5)  | `use_global_device_ids` | constant of type `i1`                                       | (C5)        |
 
 #### Outputs
 
@@ -776,8 +775,7 @@ Afterwards, within each `process_group`:
 
 Within each process group in the StableHLO process grid, applies a reduction
 function `computation` to the values of the `operands` tensors from each process
-and produces `results` tensors. When multiple `operands` are specified, the
-`all_reduce` is performed on each operand.
+and produces `results` tensors.
 
 The operation splits the StableHLO process grid into `process_groups` which is
 defined as follows:
@@ -801,13 +799,13 @@ Afterwards, within each `process_group`:
 
 #### Inputs
 
-| Label | Name                    | Type                                                                                   | Constraints |
-|-------|-------------------------|----------------------------------------------------------------------------------------|-------------|
-| (I1)  | `operands`               | variadic number of tensors or per-tensor quantized tensors                            | (C5), (C6)  |
-| (I2)  | `replica_groups`        | variadic number of 1-dimensional tensor constants of type `si64`                       | (C1-C3)     |
-| (I3)  | `channel_id`            | constant of type `si64`                                                                | (C4)        |
-| (I4)  | `use_global_device_ids` | constant of type `i1`                                                                  | (C4)        |
-| (I5)  | `computation`           | function                                                                               | (C5)        |
+| Label | Name                    | Type                                                             | Constraints |
+|-------|-------------------------|------------------------------------------------------------------|-------------|
+| (I1)  | `operands`               | variadic number of tensors or per-tensor quantized tensors      | (C5), (C6)  |
+| (I2)  | `replica_groups`        | variadic number of 1-dimensional tensor constants of type `si64` | (C1-C3)     |
+| (I3)  | `channel_id`            | constant of type `si64`                                          | (C4)        |
+| (I4)  | `use_global_device_ids` | constant of type `i1`                                            | (C4)        |
+| (I5)  | `computation`           | function                                                         | (C5)        |
 
 #### Outputs
 
@@ -859,9 +857,7 @@ Afterwards, within each `process_group`:
 Within each process group in the StableHLO process grid, splits the values of
 the `operands` tensors along `split_dimension` into parts, scatters the split
 parts between the processes, concatenates the scattered parts along
-`concat_dimension` and produces `results` tensors. When multiple `operands`
-are specified, the `all_to_all` is performed on each operand.
-
+`concat_dimension` and produces `results` tensors.
 The operation splits the StableHLO process grid into `process_groups` which is
 defined as follows:
 
@@ -879,14 +875,14 @@ Afterwards, within each `process_group`:
 
 #### Inputs
 
-| Label | Name               | Type                                                               | Constraints            |
-|-------|--------------------|--------------------------------------------------------------------|------------------------|
-| (I1)  | `operands`          | variadic number of tensors or per-tensor quantized tensors        | (C1-C3), (C9)          |
-| (I2)  | `split_dimension`  | constant of type `si64`                                            | (C1), (C2), (C9)       |
-| (I3)  | `concat_dimension` | constant of type `si64`                                            | (C3), (C9)             |
-| (I4)  | `split_count`      | constant of type `si64`                                            | (C2), (C4), (C8), (C9) |
-| (I5)  | `replica_groups`   | 2-dimensional tensor constant of type `si64`                       | (C5-C8)                |
-| (I6)  | `channel_id`       | constant of type `si64`                                            |                        |
+| Label | Name               | Type                                                         | Constraints            |
+|-------|--------------------|--------------------------------------------------------------|------------------------|
+| (I1)  | `operands`          | variadic number of tensors or per-tensor quantized tensors  | (C1-C3), (C9)          |
+| (I2)  | `split_dimension`  | constant of type `si64`                                      | (C1), (C2), (C9)       |
+| (I3)  | `concat_dimension` | constant of type `si64`                                      | (C3), (C9)             |
+| (I4)  | `split_count`      | constant of type `si64`                                      | (C2), (C4), (C8), (C9) |
+| (I5)  | `replica_groups`   | 2-dimensional tensor constant of type `si64`                 | (C5-C8)                |
+| (I6)  | `channel_id`       | constant of type `si64`                                      |                        |
 
 #### Outputs
 
@@ -2419,14 +2415,14 @@ the XLA compiler. In the future, we are planning to unify this metadata
 
 #### Inputs
 
-| Label | Name                  | Type                                                                                                        |
-|-------|-----------------------|-------------------------------------------------------------------------------------------------------------|
-| (I1)  | `inputs`              | variadic number of values                                                                                   |
-| (I2)  | `call_target_name`    | constant of type `string`                                                                                   |
-| (I3)  | `has_side_effect`     | constant of type `i1`                                                                                       |
+| Label | Name                  | Type                                              |
+|-------|-----------------------|---------------------------------------------------|
+| (I1)  | `inputs`              | variadic number of values                         |
+| (I2)  | `call_target_name`    | constant of type `string`                         |
+| (I3)  | `has_side_effect`     | constant of type `i1`                             |
 | (I4)  | `backend_config`      | constant of type `string` or attribute dictionary |
-| (I5)  | `api_version`         | constant of type `si32`                                                                                     |
-| (I6)  | `called_computations` | variadic number of constants of type `string`                                                               |
+| (I5)  | `api_version`         | constant of type `si32`                           |
+| (I6)  | `called_computations` | variadic number of constants of type `string`     |
 
 #### Outputs
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -699,7 +699,7 @@ it only exists to establish data dependencies from `result` to `inputs`.
 #### Semantics
 
 Within each process group in the StableHLO process grid, concatenates the values
-of the `operands` tensors from each process along `all_gather_dim` and produces a
+of the `operands` tensors from each process along `all_gather_dim` and produces
 `results` tensors. When multiple `operands` are specified, the `all_gather` is
 performed on each operand.
 
@@ -722,18 +722,18 @@ Afterwards, within each `process_group`:
 
 #### Inputs
 
-| Label | Name                    | Type                                         | Constraints |
-|-------|-------------------------|----------------------------------------------|-------------|
+| Label | Name                    | Type                                                               | Constraints |
+|-------|-------------------------|--------------------------------------------------------------------|-------------|
 | (I1)  | `operands`               | variadic number of tensors or per-tensor quantized tensors        | (C1), (C6)  |
-| (I2)  | `all_gather_dim`        | constant of type `si64`                      | (C1), (C6)  |
-| (I3)  | `replica_groups`        | 2-dimensional tensor constant of type `si64` | (C2-C4)     |
-| (I4)  | `channel_id`            | constant of type `si64`                      | (C5)        |
-| (I5)  | `use_global_device_ids` | constant of type `i1`                        | (C5)        |
+| (I2)  | `all_gather_dim`        | constant of type `si64`                                            | (C1), (C6)  |
+| (I3)  | `replica_groups`        | 2-dimensional tensor constant of type `si64`                       | (C2-C4)     |
+| (I4)  | `channel_id`            | constant of type `si64`                                            | (C5)        |
+| (I5)  | `use_global_device_ids` | constant of type `i1`                                              | (C5)        |
 
 #### Outputs
 
-| Name     | Type                                  | Constraints |
-|----------|---------------------------------------|-------------|
+| Name     | Type                                                        | Constraints |
+|----------|-------------------------------------------------------------|-------------|
 | `results` | variadic number of tensors or per-tensor quantized tensors | (C6)        |
 
 #### Constraints
@@ -776,7 +776,7 @@ Afterwards, within each `process_group`:
 
 Within each process group in the StableHLO process grid, applies a reduction
 function `computation` to the values of the `operands` tensors from each process
-and produces a `results` tensors. When multiple `operands` are specified, the
+and produces `results` tensors. When multiple `operands` are specified, the
 `all_reduce` is performed on each operand.
 
 The operation splits the StableHLO process grid into `process_groups` which is
@@ -801,19 +801,19 @@ Afterwards, within each `process_group`:
 
 #### Inputs
 
-| Label | Name                    | Type                                                             | Constraints |
-|-------|-------------------------|------------------------------------------------------------------|-------------|
+| Label | Name                    | Type                                                                                   | Constraints |
+|-------|-------------------------|----------------------------------------------------------------------------------------|-------------|
 | (I1)  | `operands`               | variadic number of tensors or per-tensor quantized tensors                            | (C5), (C6)  |
-| (I2)  | `replica_groups`        | variadic number of 1-dimensional tensor constants of type `si64` | (C1-C3)     |
-| (I3)  | `channel_id`            | constant of type `si64`                                          | (C4)        |
-| (I4)  | `use_global_device_ids` | constant of type `i1`                                            | (C4)        |
-| (I5)  | `computation`           | function                                                         | (C5)        |
+| (I2)  | `replica_groups`        | variadic number of 1-dimensional tensor constants of type `si64`                       | (C1-C3)     |
+| (I3)  | `channel_id`            | constant of type `si64`                                                                | (C4)        |
+| (I4)  | `use_global_device_ids` | constant of type `i1`                                                                  | (C4)        |
+| (I5)  | `computation`           | function                                                                               | (C5)        |
 
 #### Outputs
 
-| Name     | Type                                  | Constraints |
-|----------|---------------------------------------|-------------|
-| `results` | variadic number of tensors or per-tensor quantized tensors | (C6-C7)     |
+| Name      | Type                                                        | Constraints |
+|-----------|-------------------------------------------------------------|-------------|
+| `results` | variadic number of tensors or per-tensor quantized tensors  | (C6-C7)     |
 
 #### Constraints
 
@@ -859,7 +859,7 @@ Afterwards, within each `process_group`:
 Within each process group in the StableHLO process grid, splits the values of
 the `operands` tensors along `split_dimension` into parts, scatters the split
 parts between the processes, concatenates the scattered parts along
-`concat_dimension` and produces a `results` tensors. When multiple `operands`
+`concat_dimension` and produces `results` tensors. When multiple `operands`
 are specified, the `all_to_all` is performed on each operand.
 
 The operation splits the StableHLO process grid into `process_groups` which is
@@ -879,20 +879,20 @@ Afterwards, within each `process_group`:
 
 #### Inputs
 
-| Label | Name               | Type                                         | Constraints            |
-|-------|--------------------|----------------------------------------------|------------------------|
+| Label | Name               | Type                                                               | Constraints            |
+|-------|--------------------|--------------------------------------------------------------------|------------------------|
 | (I1)  | `operands`          | variadic number of tensors or per-tensor quantized tensors        | (C1-C3), (C9)          |
-| (I2)  | `split_dimension`  | constant of type `si64`                      | (C1), (C2), (C9)       |
-| (I3)  | `concat_dimension` | constant of type `si64`                      | (C3), (C9)             |
-| (I4)  | `split_count`      | constant of type `si64`                      | (C2), (C4), (C8), (C9) |
-| (I5)  | `replica_groups`   | 2-dimensional tensor constant of type `si64` | (C5-C8)                |
-| (I6)  | `channel_id`       | constant of type `si64`                      |                        |
+| (I2)  | `split_dimension`  | constant of type `si64`                                            | (C1), (C2), (C9)       |
+| (I3)  | `concat_dimension` | constant of type `si64`                                            | (C3), (C9)             |
+| (I4)  | `split_count`      | constant of type `si64`                                            | (C2), (C4), (C8), (C9) |
+| (I5)  | `replica_groups`   | 2-dimensional tensor constant of type `si64`                       | (C5-C8)                |
+| (I6)  | `channel_id`       | constant of type `si64`                                            |                        |
 
 #### Outputs
 
-| Name     | Type                                  | Constraints |
-|----------|---------------------------------------|-------------|
-| `results` | variadic number of tensors or per-tensor quantized tensors | (C9)        |
+| Name      | Type                                                        | Constraints |
+|-----------|-------------------------------------------------------------|-------------|
+| `results` | variadic number of tensors or per-tensor quantized tensors  | (C9)        |
 
 #### Constraints
 
@@ -2419,14 +2419,14 @@ the XLA compiler. In the future, we are planning to unify this metadata
 
 #### Inputs
 
-| Label | Name                  | Type                                          |
-|-------|-----------------------|-----------------------------------------------|
-| (I1)  | `inputs`              | variadic number of values                     |
-| (I2)  | `call_target_name`    | constant of type `string`                     |
-| (I3)  | `has_side_effect`     | constant of type `i1`                         |
-| (I4)  | `backend_config`      | constant of type `string` dictionary with key of type `string` and values of type `Value`                   |
-| (I5)  | `api_version`         | constant of type `si32`                       |
-| (I6)  | `called_computations` | variadic number of constants of type `string` |
+| Label | Name                  | Type                                                                                                        |
+|-------|-----------------------|-------------------------------------------------------------------------------------------------------------|
+| (I1)  | `inputs`              | variadic number of values                                                                                   |
+| (I2)  | `call_target_name`    | constant of type `string`                                                                                   |
+| (I3)  | `has_side_effect`     | constant of type `i1`                                                                                       |
+| (I4)  | `backend_config`      | constant of type `string` or attribute dictionary |
+| (I5)  | `api_version`         | constant of type `si32`                                                                                     |
+| (I6)  | `called_computations` | variadic number of constants of type `string`                                                               |
 
 #### Outputs
 
@@ -2441,6 +2441,7 @@ the XLA compiler. In the future, we are planning to unify this metadata
   call_target_name = "foo",
   has_side_effect = false,
   backend_config = {bar = 42 : i32},
+  // api_version 4 is to express backend_config as a dictionary attribute 
   api_version = 4 : i32,
   called_computations = [@foo]
 } : (tensor<f64>) -> tensor<f64>

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -699,8 +699,9 @@ it only exists to establish data dependencies from `result` to `inputs`.
 #### Semantics
 
 Within each process group in the StableHLO process grid, concatenates the values
-of the `operand` tensor from each process along `all_gather_dim` and produces a
-`result` tensor.
+of the `operands` tensors from each process along `all_gather_dim` and produces a
+`results` tensors. When multiple `operands` are specified, the `all_gather` is
+performed on each operand.
 
 The operation splits the StableHLO process grid into `process_groups` which is
 defined as follows:
@@ -714,16 +715,16 @@ defined as follows:
 
 Afterwards, within each `process_group`:
 
-* `operands@receiver = [operand@sender for sender in process_group]` for all
+* `operands...@receiver = [operand@sender for sender in process_group]` for all
   `receiver` in `process_group`.
-* `result@process = concatenate(operands@process, all_gather_dim)` for all
+* `results...@process = concatenate(operands...@process, all_gather_dim)` for all
   `process` in `process_group`.
 
 #### Inputs
 
 | Label | Name                    | Type                                         | Constraints |
 |-------|-------------------------|----------------------------------------------|-------------|
-| (I1)  | `operand`               | tensor or per-tensor quantized tensor        | (C1), (C6)  |
+| (I1)  | `operands`               | variadic number of tensors or per-tensor quantized tensors        | (C1), (C6)  |
 | (I2)  | `all_gather_dim`        | constant of type `si64`                      | (C1), (C6)  |
 | (I3)  | `replica_groups`        | 2-dimensional tensor constant of type `si64` | (C2-C4)     |
 | (I4)  | `channel_id`            | constant of type `si64`                      | (C5)        |
@@ -733,11 +734,11 @@ Afterwards, within each `process_group`:
 
 | Name     | Type                                  | Constraints |
 |----------|---------------------------------------|-------------|
-| `result` | tensor or per-tensor quantized tensor | (C6)        |
+| `results` | variadic number of tensors or per-tensor quantized tensors | (C6)        |
 
 #### Constraints
 
-* (C1) `0 <= all_gather_dim < rank(operand)`.
+* (C1) `0 <= all_gather_dim < rank(operands...)`.
 * (C2) `is_unique(replica_groups)`.
 * (C3) `size(replica_groups)` is defined as:
   * `num_replicas` if `cross_replica` is used.
@@ -745,9 +746,9 @@ Afterwards, within each `process_group`:
   * `num_processes` if `flattened_ids` is used.
 * (C4) `0 <= replica_groups < size(replica_groups)`.
 * (C5) If `use_global_device_ids = true`, then `channel_id > 0`.
-* (C6) `type(result) = type(operand)` except:
-  * `dim(result, all_gather_dim) =
-    dim(operand, all_gather_dim) * dim(process_groups, 1)`.
+* (C6) `type(results...) = type(operands...)` except:
+  * `dim(results..., all_gather_dim) =
+    dim(operands..., all_gather_dim) * dim(process_groups, 1)`.
 
 #### Examples
 
@@ -774,8 +775,9 @@ Afterwards, within each `process_group`:
 #### Semantics
 
 Within each process group in the StableHLO process grid, applies a reduction
-function `computation` to the values of the `operand` tensor from each process
-and produces a `result` tensor.
+function `computation` to the values of the `operands` tensors from each process
+and produces a `results` tensors. When multiple `operands` are specified, the
+`all_reduce` is performed on each operand.
 
 The operation splits the StableHLO process grid into `process_groups` which is
 defined as follows:
@@ -789,19 +791,19 @@ defined as follows:
 
 Afterwards, within each `process_group`:
 
-* `result@process[result_index] = exec(schedule)` for some binary tree
+* `results...@process[result_index] = exec(schedule)` for some binary tree
   `schedule` where:
   * `exec(node)` = `computation(exec(node.left), exec(node.right))`.
   * `exec(leaf)` = `leaf.value`.
 * `schedule` is an implementation-defined binary tree whose in-order
-  traversal is `to_destination_type(operands@process_group...[result_index],
+  traversal is `to_destination_type(operands...@process_group...[result_index],
   type(func_inputs(computation)[0]))`.
 
 #### Inputs
 
 | Label | Name                    | Type                                                             | Constraints |
 |-------|-------------------------|------------------------------------------------------------------|-------------|
-| (I1)  | `operand`               | tensor or per-tensor quantized tensor                            | (C5), (C6)  |
+| (I1)  | `operands`               | variadic number of tensors or per-tensor quantized tensors                            | (C5), (C6)  |
 | (I2)  | `replica_groups`        | variadic number of 1-dimensional tensor constants of type `si64` | (C1-C3)     |
 | (I3)  | `channel_id`            | constant of type `si64`                                          | (C4)        |
 | (I4)  | `use_global_device_ids` | constant of type `i1`                                            | (C4)        |
@@ -811,7 +813,7 @@ Afterwards, within each `process_group`:
 
 | Name     | Type                                  | Constraints |
 |----------|---------------------------------------|-------------|
-| `result` | tensor or per-tensor quantized tensor | (C6-C7)     |
+| `results` | variadic number of tensors or per-tensor quantized tensors | (C6-C7)     |
 
 #### Constraints
 
@@ -824,8 +826,8 @@ Afterwards, within each `process_group`:
 * (C4) If `use_global_device_ids = true`, then `channel_id > 0`.
 * (C5) `computation` has type `(tensor<E>, tensor<E>) -> (tensor<E>)` where
        `is_promotable(element_type(operand), E)`.
-* (C6) `shape(result) = shape(operand)`.
-* (C7) `element_type(result) = E`.
+* (C6) `shape(results...) = shape(operands...)`.
+* (C7) `element_type(results...) = E`.
 
 #### Examples
 
@@ -855,9 +857,10 @@ Afterwards, within each `process_group`:
 ![all_to_all](images/spec/all_to_all.svg)
 
 Within each process group in the StableHLO process grid, splits the values of
-the `operand` tensor along `split_dimension` into parts, scatters the split
+the `operands` tensors along `split_dimension` into parts, scatters the split
 parts between the processes, concatenates the scattered parts along
-`concat_dimension` and produces a `result` tensor.
+`concat_dimension` and produces a `results` tensors. When multiple `operands`
+are specified, the `all_to_all` is performed on each operand.
 
 The operation splits the StableHLO process grid into `process_groups` which is
 defined as follows:
@@ -867,18 +870,18 @@ defined as follows:
 
 Afterwards, within each `process_group`:
 
-* `split_parts@sender = split(operand@sender, split_count, split_dimension)`
+* `split_parts...@sender = split(operands...@sender, split_count, split_dimension)`
   for all `sender` in `process_group`.
-* `scattered_parts@receiver = [split_parts@sender[receiver_index] for
+* `scattered_parts...@receiver = [split_parts...@sender[receiver_index] for
   sender in process_group]` where
   `receiver_index = process_group.index(receiver)`.
-* `result@process = concatenate(scattered_parts@process, concat_dimension)`.
+* `results...@process = concatenate(scattered_parts...@process, concat_dimension)`.
 
 #### Inputs
 
 | Label | Name               | Type                                         | Constraints            |
 |-------|--------------------|----------------------------------------------|------------------------|
-| (I1)  | `operand`          | tensor or per-tensor quantized tensor        | (C1-C3), (C9)          |
+| (I1)  | `operands`          | variadic number of tensors or per-tensor quantized tensors        | (C1-C3), (C9)          |
 | (I2)  | `split_dimension`  | constant of type `si64`                      | (C1), (C2), (C9)       |
 | (I3)  | `concat_dimension` | constant of type `si64`                      | (C3), (C9)             |
 | (I4)  | `split_count`      | constant of type `si64`                      | (C2), (C4), (C8), (C9) |
@@ -889,13 +892,13 @@ Afterwards, within each `process_group`:
 
 | Name     | Type                                  | Constraints |
 |----------|---------------------------------------|-------------|
-| `result` | tensor or per-tensor quantized tensor | (C9)        |
+| `results` | variadic number of tensors or per-tensor quantized tensors | (C9)        |
 
 #### Constraints
 
-* (C1) `0 <= split_dimension < rank(operand)`.
-* (C2) `dim(operand, split_dimension) % split_count = 0`.
-* (C3) `0 <= concat_dimension < rank(operand)`.
+* (C1) `0 <= split_dimension < rank(operands...)`.
+* (C2) `dim(operands..., split_dimension) % split_count = 0`.
+* (C3) `0 <= concat_dimension < rank(operands...)`.
 * (C4) `0 < split_count`.
 * (C5) `is_unique(replica_groups)`.
 * (C6) `size(replica_groups)` is defined as:
@@ -903,11 +906,11 @@ Afterwards, within each `process_group`:
   * `num_partitions` if `cross_partition` is used.
 * (C7) `0 <= replica_groups < size(replica_groups)`.
 * (C8) `dim(replica_groups, 1) = split_count`.
-* (C9) `type(result) = type(operand)` except:
-  * `dim(result, split_dimension) =
-    dim(operand, split_dimension) / split_count`.
-  * `dim(result, concat_dimension) =
-    dim(operand, concat_dimension) * split_count`.
+* (C9) `type(results...) = type(operands...)` except:
+  * `dim(results..., split_dimension) =
+    dim(operands..., split_dimension) / split_count`.
+  * `dim(results..., concat_dimension) =
+    dim(operands..., concat_dimension) * split_count`.
 
 #### Examples
 
@@ -2421,7 +2424,7 @@ the XLA compiler. In the future, we are planning to unify this metadata
 | (I1)  | `inputs`              | variadic number of values                     |
 | (I2)  | `call_target_name`    | constant of type `string`                     |
 | (I3)  | `has_side_effect`     | constant of type `i1`                         |
-| (I4)  | `backend_config`      | constant of type `string`                     |
+| (I4)  | `backend_config`      | constant of type `string` dictionary with key of type `string` and values of type `Value`                   |
 | (I5)  | `api_version`         | constant of type `si32`                       |
 | (I6)  | `called_computations` | variadic number of constants of type `string` |
 
@@ -2437,8 +2440,8 @@ the XLA compiler. In the future, we are planning to unify this metadata
 %results = "stablehlo.custom_call"(%input0) {
   call_target_name = "foo",
   has_side_effect = false,
-  backend_config = "bar",
-  api_version = 1 : i32,
+  backend_config = {bar = 42 : i32},
+  api_version = 4 : i32,
   called_computations = [@foo]
 } : (tensor<f64>) -> tensor<f64>
 ```
@@ -5621,6 +5624,42 @@ Performs element-wise subtraction of two tensors `lhs` and `rhs` and produces a
 ```
 
 &nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/subtract.mlir)
+
+### tan
+
+#### Semantics
+
+Performs element-wise tangent operation on `operand` tensor and
+produces a `result` tensor. Depending on the element type, does the following:
+
+* For floats: `tan` from IEEE-754.
+* For complex numbers: complex tangent.
+* For quantized types:
+  * `dequantize_op_quantize(tan, operand, type(result))`.
+
+#### Inputs
+
+| Label | Name      | Type                                                                    | Constraints |
+|-------|-----------|-------------------------------------------------------------------------|-------------|
+| (I1)  | `operand` | tensor of floating-point or complex type or per-tensor quantized tensor | (C1)        |
+
+#### Outputs
+
+| Name     | Type                                                                    | Constraints |
+|----------|-------------------------------------------------------------------------|-------------|
+| `result` | tensor of floating-point or complex type or per-tensor quantized tensor | (C1)        |
+
+#### Constraints
+
+* (C1) `baseline_type(operand) = baseline_type(result)`.
+
+#### Examples
+
+```mlir
+// %operand: [-1.0, 0.0, 1.0]
+%result = "stablehlo.tan"(%operand) : (tensor<3xf32>) -> tensor<3xf32>
+// %result: [-1.55740772465, 0.0, 1.55740772465]
+```
 
 ### tanh
 

--- a/rfcs/20240312-standardize-tan-customcall-tuplecollective-ops.md
+++ b/rfcs/20240312-standardize-tan-customcall-tuplecollective-ops.md
@@ -62,8 +62,8 @@ gap.
 View spec.md changes in this PR to view the diff vs original spec.
 
 To view rich text of the spec, see:
-[TanOp](https://github.com/abhigunj/stablehlo/blob/a3b4c1b69aff41e3175c1b4ccb6352bcadf1f79a/docs/spec.md#tan)
-[CustomCallOp](https://github.com/abhigunj/stablehlo/blob/a3b4c1b69aff41e3175c1b4ccb6352bcadf1f79a/docs/spec.md#custom_call)
-[AllGatherOp](https://github.com/abhigunj/stablehlo/blob/a3b4c1b69aff41e3175c1b4ccb6352bcadf1f79a/docs/spec.md#all_gather)
-[AllReduceOp](https://github.com/abhigunj/stablehlo/blob/a3b4c1b69aff41e3175c1b4ccb6352bcadf1f79a/docs/spec.md#all_reduce)
-[AllToAllOp](https://github.com/abhigunj/stablehlo/blob/a3b4c1b69aff41e3175c1b4ccb6352bcadf1f79a/docs/spec.md#all_to_all)
+[TanOp](https://github.com/openxla/stablehlo/blob/f8d6756c70dc5301d5be88d1ca378d1429943e0c/docs/spec.md#tan)
+[CustomCallOp](https://github.com/openxla/stablehlo/blob/f8d6756c70dc5301d5be88d1ca378d1429943e0c/docs/spec.md#custom_call)
+[AllGatherOp](https://github.com/openxla/stablehlo/blob/f8d6756c70dc5301d5be88d1ca378d1429943e0c/docs/spec.md#all_gather)
+[AllReduceOp](https://github.com/openxla/stablehlo/blob/f8d6756c70dc5301d5be88d1ca378d1429943e0c/docs/spec.md#all_reduce)
+[AllToAllOp](https://github.com/openxla/stablehlo/blob/f8d6756c70dc5301d5be88d1ca378d1429943e0c/docs/spec.md#all_to_all)

--- a/rfcs/20240312-standardize-tan-customcall-tuplecollective-ops.md
+++ b/rfcs/20240312-standardize-tan-customcall-tuplecollective-ops.md
@@ -1,0 +1,69 @@
+# [RFC] Standardize TanOp, CustomCallOp with typed FFI, and tuple-collectives ops
+
+Status: Draft<br/>
+Initial version: 03/12/2024<br/>
+Last updated: 03/12/2024<br/>
+Discussion thread: [GitHub](add PR Link)
+
+## Motivation
+
+Several features have been added to MHLO in the past year, which frameworks want
+to leverage and members of the community have made requests for them as well.
+This includes: `TanOp`, `CustomCallOp` with typed FFI (dictionary), and
+tuple-collective ops (`AllGatherOp`, `AllReduceOp`, `AllToAllOp` with variadic
+operands/results). Some of these features are being used today with various
+workarounds -- unregistered attributes, serializing dictionary as string,
+custom_calls. None of these approaches are stable, so we propose adding these
+ops/features to the StableHLO spec so they can be used safely by the community.
+
+### TanOp
+
+Frameworks and Compilers both want `tan` op.
+Jax has [`jnp.tan`](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.tan.html),
+PyTorch has [`torch.tan`](https://pytorch.org/docs/stable/generated/torch.tan.html).
+On Compilers side, XLA has [`mhlo.tan`](https://github.com/tensorflow/mlir-hlo/blob/master/mhlo/IR/hlo_ops.td#L633).
+StableHLO doesn't support `tan` op, but there is an open ticket which requests
+adding this feature in
+[#1358](https://github.com/openxla/stablehlo/issues/1358)
+
+### CustomCallOp with typed FFI
+
+StableHLO `custom_call` op supporting `backend_config` dictionary will help to
+unify metadata under single `mlir::DictionaryAttr`. This provides more stable
+serialization of `custom_call` metadata, a feature that is desired by frameworks
+and compilers. There are several occurrences of users working around this gap in
+`custom_call` today, either as an unregistered attribute
+([example](https://github.com/google/jax/blob/1ed27ecebb92e916b45601e3a107971170a4592b/jaxlib/hlo_helpers.py#L191)),
+or a serialized dictionary string. Standardizing this feature to StableHLO will
+benefit the entire ecosystem. We propose to support the same as what
+[MHLO custom_call op](https://github.com/tensorflow/mlir-hlo/blob/master/mhlo/IR/hlo_ops.td#L2483)
+already supporting. Open tickets for this request: [#637](https://github.com/openxla/stablehlo/issues/637),
+[#741](https://github.com/openxla/stablehlo/issues/741)
+
+### Tuple-collectives (AllGatherOp, AllReduceOp, AllToAllOp)
+
+StableHLO tuple-collective ops support is limited to **single-operand** and **single-result**.
+[MHLO ops](https://github.com/tensorflow/mlir-hlo/blob/master/mhlo/IR/hlo_ops.td)
+supports
+**multi-operand** and **multi-result** which is in sync with XLA semantics and
+horizontal scaling
+[`all_reduce`](https://openxla.org/xla/operation_semantics#allreduce)
+[`all_gather`](https://openxla.org/xla/operation_semantics#allgather) and
+[`all_to_all`](https://openxla.org/xla/operation_semantics#alltoall) which
+supports multi-operand and multi-result. `all_reduce` support is requested
+in [#1370](https://github.com/openxla/stablehlo/issues/1370) is relied on by
+PyTorch/XLA today via XlaBuilder ([ref](https://github.com/pytorch/xla/blob/1bbe333ad137ace6b8134db640c0b24c8c428db6/torch_xla/csrc/cross_replica_reduces.cpp#L156)).
+`all_to_all` support is requested in
+[#574](https://github.com/openxla/stablehlo/issues/574) and identified as a feature
+gap.
+
+## Proposed Specification Changes
+
+View spec.md changes in this PR to view the diff vs original spec.
+
+To view rich text of the spec, see:
+[TanOp](https://github.com/abhigunj/stablehlo/blob/a3b4c1b69aff41e3175c1b4ccb6352bcadf1f79a/docs/spec.md#tan)
+[CustomCallOp](https://github.com/abhigunj/stablehlo/blob/a3b4c1b69aff41e3175c1b4ccb6352bcadf1f79a/docs/spec.md#custom_call)
+[AllGatherOp](https://github.com/abhigunj/stablehlo/blob/a3b4c1b69aff41e3175c1b4ccb6352bcadf1f79a/docs/spec.md#all_gather)
+[AllReduceOp](https://github.com/abhigunj/stablehlo/blob/a3b4c1b69aff41e3175c1b4ccb6352bcadf1f79a/docs/spec.md#all_reduce)
+[AllToAllOp](https://github.com/abhigunj/stablehlo/blob/a3b4c1b69aff41e3175c1b4ccb6352bcadf1f79a/docs/spec.md#all_to_all)


### PR DESCRIPTION
This RFC proposes standardizing  `TanOp` , `CustomCallOp` with typed FFI, and Tuple-collectives (`AllGatherOp`, `AllReduceOp`, `AllToAllOp`) for  HLO-StableHLO parity. 
Please review and provide you feedback.