### PR TITLE
[RFC] Standardize CustomCallOp to extend backend_config to take a DictionaryAttr

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2416,14 +2416,14 @@ the XLA compiler. In the future, we are planning to unify this metadata
 
 #### Inputs
 
-| Label | Name                  | Type                                          |
-|-------|-----------------------|-----------------------------------------------|
-| (I1)  | `inputs`              | variadic number of values                     |
-| (I2)  | `call_target_name`    | constant of type `string`                     |
-| (I3)  | `has_side_effect`     | constant of type `i1`                         |
-| (I4)  | `backend_config`      | constant of type `string`                     |
-| (I5)  | `api_version`         | constant of type `si32`                       |
-| (I6)  | `called_computations` | variadic number of constants of type `string` |
+| Label | Name                  | Type                                              |
+|-------|-----------------------|---------------------------------------------------|
+| (I1)  | `inputs`              | variadic number of values                         |
+| (I2)  | `call_target_name`    | constant of type `string`                         |
+| (I3)  | `has_side_effect`     | constant of type `i1`                             |
+| (I4)  | `backend_config`      | constant of type `string` or attribute dictionary |
+| (I5)  | `api_version`         | constant of type `si32`                           |
+| (I6)  | `called_computations` | variadic number of constants of type `string`     |
 
 #### Outputs
 
@@ -2437,8 +2437,9 @@ the XLA compiler. In the future, we are planning to unify this metadata
 %results = "stablehlo.custom_call"(%input0) {
   call_target_name = "foo",
   has_side_effect = false,
-  backend_config = "bar",
-  api_version = 1 : i32,
+  backend_config = {bar = 42 : i32},
+  // api_version 4 is to express backend_config as a dictionary attribute
+  api_version = 4 : i32,
   called_computations = [@foo]
 } : (tensor<f64>) -> tensor<f64>
 ```

--- a/rfcs/20240312-standardize-customcallop.md
+++ b/rfcs/20240312-standardize-customcallop.md
@@ -13,15 +13,15 @@ This includes: MHLO
 [`custom_call`](https://github.com/tensorflow/mlir-hlo/blob/master/mhlo/IR/hlo_ops.td#L2483)
 `backend_config` to take a `DictionaryAttr`.
 
-StableHLO `custom_call` op does not support this feature. There are several
+The current StableHLO `custom_call` op does not support this feature. There are several
 occurrences of users working around this gap in `custom_call` today, examples -
 JAX uses [unregistered attributes](https://github.com/google/jax/blob/1ed27ecebb92e916b45601e3a107971170a4592b/jaxlib/hlo_helpers.py#L191)
 to hold the `DictionaryAttr` or serializing the dictionary as a string
-to pass around for StableHLO `custom_call` op.
+to pass around for the StableHLO `custom_call` op.
 
-We propose standardizing StableHLO `custom_call` op to extend `backend_config`
-to take a `DictionaryAttr`.  So they can be used safely by the community without
-workarounds. It will help to unify metadata under single `DictionaryAttr` which
+We propose standardizing the StableHLO `custom_call` op to extend `backend_config`
+to take a `DictionaryAttr` so they can be used safely by the community without
+workarounds. This will help to unify metadata under a single `DictionaryAttr` which
 provides more stable serialization of `custom_call` metadata, a feature that is
 desired by frameworks and compilers. Standardizing this feature to StableHLO
 will benefit the entire ecosystem.

--- a/rfcs/20240312-standardize-customcallop.md
+++ b/rfcs/20240312-standardize-customcallop.md
@@ -25,6 +25,7 @@ workarounds. It will help to unify metadata under single `DictionaryAttr` which
 provides more stable serialization of `custom_call` metadata, a feature that is
 desired by frameworks and compilers. Standardizing this feature to StableHLO
 will benefit the entire ecosystem.
+Note: `backend_config` will continue to accept strings as before.
 
 Open tickets for this request: [#637](https://github.com/openxla/stablehlo/issues/637),
 [#741](https://github.com/openxla/stablehlo/issues/741)

--- a/rfcs/20240312-standardize-customcallop.md
+++ b/rfcs/20240312-standardize-customcallop.md
@@ -3,7 +3,7 @@
 Status: Review<br/>
 Initial version: 03/12/2024<br/>
 Last updated: 03/12/2024<br/>
-Discussion thread: [GitHub](add PR Link)
+Discussion thread: [GitHub](https://github.com/openxla/stablehlo/pull/2097)
 
 ## Motivation
 

--- a/rfcs/20240312-standardize-customcallop.md
+++ b/rfcs/20240312-standardize-customcallop.md
@@ -1,0 +1,37 @@
+# [RFC] Standardize CustomCallOp to extend backend_config to take a DictionaryAttr
+
+Status: Review<br/>
+Initial version: 03/12/2024<br/>
+Last updated: 03/12/2024<br/>
+Discussion thread: [GitHub](add PR Link)
+
+## Motivation
+
+Several features have been added to MHLO in the past year, which frameworks want
+to leverage and members of the community have made requests for them as well.
+This includes:  `CustomCallOp` to support backend_config to take a DictionaryAttr.
+This feature is being used today with various workarounds -- unregistered
+attributes, serializing dictionary as string, custom_calls. None of these
+approaches are stable, so we propose adding these ops/features to the StableHLO
+spec so they can be used safely by the community.
+
+### CustomCallOp with typed FFI
+
+StableHLO `custom_call` op supporting `backend_config` dictionary will help to
+unify metadata under single `mlir::DictionaryAttr`. This provides more stable
+serialization of `custom_call` metadata, a feature that is desired by frameworks
+and compilers. There are several occurrences of users working around this gap in
+`custom_call` today, either as an unregistered attribute
+([example](https://github.com/google/jax/blob/1ed27ecebb92e916b45601e3a107971170a4592b/jaxlib/hlo_helpers.py#L191)),
+or a serialized dictionary string. Standardizing this feature to StableHLO will
+benefit the entire ecosystem. We propose to support DictionaryAttr for
+`backend_config`, the same as what [MHLO custom_call op](https://github.com/tensorflow/mlir-hlo/blob/master/mhlo/IR/hlo_ops.td#L2483)
+already supporting. Open tickets for this request: [#637](https://github.com/openxla/stablehlo/issues/637),
+[#741](https://github.com/openxla/stablehlo/issues/741)
+
+## Proposed Specification Changes
+
+View spec.md changes in this PR to view the diff vs original spec.
+
+To view rich text of the spec, see:
+[CustomCallOp](https://github.com/openxla/stablehlo/blob/f8d6756c70dc5301d5be88d1ca378d1429943e0c/docs/spec.md#custom_call)

--- a/rfcs/20240312-standardize-customcallop.md
+++ b/rfcs/20240312-standardize-customcallop.md
@@ -1,4 +1,4 @@
-# [RFC] Standardize CustomCallOp to extend backend_config to take a DictionaryAttr
+# [RFC] Standardize CustomCallOp to extend backend_config to take a DictAttr
 
 Status: Review<br/>
 Initial version: 03/12/2024<br/>
@@ -9,29 +9,29 @@ Discussion thread: [GitHub](add PR Link)
 
 Several features have been added to MHLO in the past year, which frameworks want
 to leverage and members of the community have made requests for them as well.
-This includes:  `CustomCallOp` to support backend_config to take a DictionaryAttr.
-This feature is being used today with various workarounds -- unregistered
-attributes, serializing dictionary as string, custom_calls. None of these
-approaches are stable, so we propose adding these ops/features to the StableHLO
-spec so they can be used safely by the community.
+This includes: MHLO
+[`custom_call`](https://github.com/tensorflow/mlir-hlo/blob/master/mhlo/IR/hlo_ops.td#L2483)
+`backend_config` to take a `DictionaryAttr`.
 
-### CustomCallOp with typed FFI
+StableHLO `custom_call` op does not support this feature. There are several
+occurrences of users working around this gap in `custom_call` today.
+Example - Jax uses [unregistered attributes](https://github.com/google/jax/blob/1ed27ecebb92e916b45601e3a107971170a4592b/jaxlib/hlo_helpers.py#L191)
+to hold the `DictionaryAttr` or serializing the dictionary as a string
+to pass around for StableHLO `custom_call` op.
 
-StableHLO `custom_call` op supporting `backend_config` dictionary will help to
-unify metadata under single `mlir::DictionaryAttr`. This provides more stable
-serialization of `custom_call` metadata, a feature that is desired by frameworks
-and compilers. There are several occurrences of users working around this gap in
-`custom_call` today, either as an unregistered attribute
-([example](https://github.com/google/jax/blob/1ed27ecebb92e916b45601e3a107971170a4592b/jaxlib/hlo_helpers.py#L191)),
-or a serialized dictionary string. Standardizing this feature to StableHLO will
-benefit the entire ecosystem. We propose to support DictionaryAttr for
-`backend_config`, the same as what [MHLO custom_call op](https://github.com/tensorflow/mlir-hlo/blob/master/mhlo/IR/hlo_ops.td#L2483)
-already supporting. Open tickets for this request: [#637](https://github.com/openxla/stablehlo/issues/637),
+We propose standardizing StableHLO `custom_call` op to extend `backend_config`
+to take a `DictionaryAttr`.  So they can be used safely by the community without
+workarounds. It will help to unify metadata under single `DictionaryAttr` which
+provides more stable serialization of `custom_call` metadata, a feature that is
+desired by frameworks and compilers. Standardizing this feature to StableHLO
+will benefit the entire ecosystem.
+
+Open tickets for this request: [#637](https://github.com/openxla/stablehlo/issues/637),
 [#741](https://github.com/openxla/stablehlo/issues/741)
 
 ## Proposed Specification Changes
 
-View spec.md changes in this PR to view the diff vs original spec.
+Please refer spec.md changes in this PR to view the diff vs original spec.
 
 To view rich text of the spec, see:
 [CustomCallOp](https://github.com/openxla/stablehlo/blob/f8d6756c70dc5301d5be88d1ca378d1429943e0c/docs/spec.md#custom_call)

--- a/rfcs/20240312-standardize-customcallop.md
+++ b/rfcs/20240312-standardize-customcallop.md
@@ -33,6 +33,3 @@ Open tickets for this request: [#637](https://github.com/openxla/stablehlo/issue
 ## Proposed Specification Changes
 
 Please refer spec.md changes in this PR to view the diff vs original spec.
-
-To view rich text of the spec, see:
-[CustomCallOp](https://github.com/openxla/stablehlo/blob/f8d6756c70dc5301d5be88d1ca378d1429943e0c/docs/spec.md#custom_call)

--- a/rfcs/20240312-standardize-customcallop.md
+++ b/rfcs/20240312-standardize-customcallop.md
@@ -1,4 +1,4 @@
-# [RFC] Standardize CustomCallOp to extend backend_config to take a DictAttr
+# [RFC] Standardize CustomCallOp to extend backend_config to take a DictionaryAttr
 
 Status: Review<br/>
 Initial version: 03/12/2024<br/>
@@ -14,8 +14,8 @@ This includes: MHLO
 `backend_config` to take a `DictionaryAttr`.
 
 StableHLO `custom_call` op does not support this feature. There are several
-occurrences of users working around this gap in `custom_call` today.
-Example - Jax uses [unregistered attributes](https://github.com/google/jax/blob/1ed27ecebb92e916b45601e3a107971170a4592b/jaxlib/hlo_helpers.py#L191)
+occurrences of users working around this gap in `custom_call` today, examples -
+Jax uses [unregistered attributes](https://github.com/google/jax/blob/1ed27ecebb92e916b45601e3a107971170a4592b/jaxlib/hlo_helpers.py#L191)
 to hold the `DictionaryAttr` or serializing the dictionary as a string
 to pass around for StableHLO `custom_call` op.
 

--- a/rfcs/20240312-standardize-customcallop.md
+++ b/rfcs/20240312-standardize-customcallop.md
@@ -2,7 +2,7 @@
 
 Status: Review<br/>
 Initial version: 03/12/2024<br/>
-Last updated: 03/12/2024<br/>
+Last updated: 03/15/2024<br/>
 Discussion thread: [GitHub](https://github.com/openxla/stablehlo/pull/2097)
 
 ## Motivation

--- a/rfcs/20240312-standardize-customcallop.md
+++ b/rfcs/20240312-standardize-customcallop.md
@@ -15,7 +15,7 @@ This includes: MHLO
 
 StableHLO `custom_call` op does not support this feature. There are several
 occurrences of users working around this gap in `custom_call` today, examples -
-Jax uses [unregistered attributes](https://github.com/google/jax/blob/1ed27ecebb92e916b45601e3a107971170a4592b/jaxlib/hlo_helpers.py#L191)
+JAX uses [unregistered attributes](https://github.com/google/jax/blob/1ed27ecebb92e916b45601e3a107971170a4592b/jaxlib/hlo_helpers.py#L191)
 to hold the `DictionaryAttr` or serializing the dictionary as a string
 to pass around for StableHLO `custom_call` op.
 


### PR DESCRIPTION
This RFC proposes standardizing CustomCallOp to extend backend_config to take a DictionaryAttr.

Please review and provide you feedback.