### PR TITLE
fix typo of py args

### DIFF
--- a/stablehlo/integrations/python/StablehloModule.cpp
+++ b/stablehlo/integrations/python/StablehloModule.cpp
@@ -551,5 +551,5 @@ PYBIND11_MODULE(_stablehlo, m) {
 
         return {module.release()};
       },
-      py::arg("module"), py::arg("target"));
+      py::arg("context"), py::arg("artifact"));
 }


### PR DESCRIPTION
because that the lambda's signature is `[](MlirContext context, std::string artifact)`.