### PR TITLE
Skip conversion of shape.shapeof with 0-ranked tensor operand

### DIFF
--- a/stablehlo/tests/shape_legalize_to_stablehlo.mlir
+++ b/stablehlo/tests/shape_legalize_to_stablehlo.mlir
@@ -387,3 +387,12 @@ func.func @tensor_extract_dynamic(%arg0: tensor<?x3xindex>) -> index {
   %0 = tensor.extract %arg0[%c1, %c2] : tensor<?x3xindex>
   return %0 : index
 }
+
+// -----
+
+func.func @shape_of_zero_ranked_tensor(%arg0: tensor<?x3xindex>) -> tensor<0xindex> {
+  %0 = arith.constant dense<0> : tensor<i32>
+  // expected-error@+1 {{failed to legalize operation 'shape.shape_of' that was explicitly marked illegal}}
+  %1 = shape.shape_of %0 : tensor<i32> -> tensor<0xindex>
+  func.return %1 : tensor<0xindex>
+}

--- a/stablehlo/transforms/ShapeLegalizeToStablehlo.cpp
+++ b/stablehlo/transforms/ShapeLegalizeToStablehlo.cpp
@@ -253,6 +253,9 @@ struct ConvertShapeOfOpPattern : public OpRewritePattern<shape::ShapeOfOp> {
     if (!operandType)
       return rewriter.notifyMatchFailure(op, "expected ranked operand");
 
+    if (operandType.getRank() == 0)
+      return rewriter.notifyMatchFailure(op, "expected non-0 ranked operand");
+
     // Produce a StableHLO equivalent of this shape::ShapeOfOp.
     // This is a very laborious representation because StableHLO is currently
     // lacking convenient tools to express this.


### PR DESCRIPTION
Currently `--shape-legalize-to-stablehlo` fails on the following code:

```
func.func @test1() -> tensor<0xindex> {
  %0 = arith.constant dense<0> : tensor<i32>
  %1 = shape.shape_of %0 : tensor<i32> -> tensor<0xindex>
  func.return %1 : tensor<0xindex>
}
```
at `stablehlo/dialect/TypeInference.cpp:1700`:
```
// concatenate_c5
auto elementType = inputTypes[0].cast<ShapedType>().getElementType();
```
as `inputTypes.size()` is zero.

I have checked how it works on non-0 ranked tensor type:
```
func.func @test2() -> tensor<2xindex> {
  %1 = arith.constant dense<0> : tensor<2x128xi32>
  %3 = shape.shape_of %1 : tensor<2x128xi32> -> tensor<2xindex>
  func.return %3 : tensor<2xindex>
}
```
produces:
```
func.func @test2() -> tensor<2xindex> {
  %cst = arith.constant dense<0> : tensor<2x128xi32>
  %0 = stablehlo.get_dimension_size %cst, dim = 0 : (tensor<2x128xi32>) -> tensor<i32>
  %1 = stablehlo.reshape %0 : (tensor<i32>) -> tensor<1xi32>
  %2 = stablehlo.get_dimension_size %cst, dim = 1 : (tensor<2x128xi32>) -> tensor<i32>
  %3 = stablehlo.reshape %2 : (tensor<i32>) -> tensor<1xi32>
  %4 = stablehlo.concatenate %1, %3, dim = 0 : (tensor<1xi32>, tensor<1xi32>) -> tensor<2xi32>
  %5 = builtin.unrealized_conversion_cast %4 : tensor<2xi32> to tensor<2xindex>
    return %5 : tensor<2xindex>
}
```

I suggest considering an alternative approach instead of simply bailing out; one option could be generating a constant tensor with zero dimension:
```
func.func @test1() -> tensor<0xindex> {
  %cst = arith.constant dense<0> : tensor<i32>
  %0 = stablehlo.constant dense<> : tensor<0xi32>
  %1 = builtin.unrealized_conversion_cast %0 : tensor<0xi32> to tensor<0xindex>
  return %1 : tensor<0xindex>
}
```
but i am not entirely certain in semantic equivalence.