### PR TITLE
Fix asan build issue

### DIFF
--- a/.github/workflows/buildAndTestCMake.yml
+++ b/.github/workflows/buildAndTestCMake.yml
@@ -74,6 +74,13 @@ jobs:
           CMAKE_BUILD_TYPE: Release
           MLIR_ENABLE_BINDINGS_PYTHON: ON
 
+    - name: Fix kernel mmap rnd bits
+      # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
+      # high-entropy ASLR in much newer kernels that GitHub runners are
+      # using leading to random crashes: https://reviews.llvm.org/D148280
+      # TODO: remove this once https://github.com/actions/runner-images/issues/9491 is fixed
+      run: sudo sysctl vm.mmap_rnd_bits=28
+
     - name: Build and Test StableHLO (with AddressSanitizer)
       shell: bash
       run: |


### PR DESCRIPTION
Seems the image itself has a bug: https://github.com/actions/runner-images/issues/9491.

Apply this patch from https://github.com/actions/runner-images/issues/9491\#issuecomment-1989718917 to fix the issue while we wait for a new version of the image to roll out.

Fixes https://github.com/openxla/stablehlo/issues/2106