### PR TITLE
Add SameOperandsAndResultElementType Trait for type(operand) = type (result) ops 

### DIFF
--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2013,7 +2013,8 @@ def StableHLO_ConcatenateOp : StableHLO_ShapedInterfaceOp<"concatenate",
 
 
 def StableHLO_CollectiveBroadcastOp: StableHLO_Op<"collective_broadcast",
-    [HLO_CompatibleOperandsAndResultType /*collective_broadcast_c3*/]> {
+    [HLO_CompatibleOperandsAndResultType,
+     SameOperandsAndResultElementType /*collective_broadcast_c3*/]> {
   let summary = "CollectiveBroadcast operation";
   let description = [{
     Within each process group in the process grid, send the value of the
@@ -2048,7 +2049,8 @@ def StableHLO_CollectiveBroadcastOp: StableHLO_Op<"collective_broadcast",
 }
 
 def StableHLO_CollectivePermuteOp: StableHLO_Op<"collective_permute",
-    [HLO_CompatibleOperandsAndResultType /*collective_permute_c5*/]> {
+    [HLO_CompatibleOperandsAndResultType,
+     SameOperandsAndResultElementType /*collective_permute_c5*/]> {
   let summary = "CollectivePermute operation";
   let description = [{
     Within each process group in the process grid, sends the value of the
@@ -2731,7 +2733,8 @@ def StableHLO_SortOp : StableHLO_Op<"sort",
 }
 
 def StableHLO_ReverseOp: StableHLO_ShapedInterfaceOp<"reverse",
-      [Pure, HLO_CompatibleOperandsAndResultType /*reverse_c1*/]> {
+      [Pure, HLO_CompatibleOperandsAndResultType,
+       SameOperandsAndResultElementType /*reverse_c1*/]> {
   let summary = "Reverse operation";
   let description = [{
     Reverses the order of elements in the `operand` along the specified


### PR DESCRIPTION
~~New trait for StableHLO ops. Trait tries to match `scale` and `zero_point` of per-tensor quantized `operands` and `result`.~~

~~Initially I added checks at custom verifiers for few ops but there are ops without verifier. Adding a Trait is less code/custom verifier changes.~~

This PR adds SameOperandsAndResultElementType  Trait for applicable ops with `type(operand...) = type(result..) ` constraint. 
Total Three OPs  : `collective_broadcast` , `collective_permute`, `reverse`
Testing: positive tests already exist for these ops. Negative tests: since this is a  native mlir Trait and not custom verifier, skipped negative testing. 

There is a overlap of verifications  done by SameOperandsAndResultElementType and HLO_comp.. For now we will keep both the Traits. I will create a follow up tracker to see if we can remove HLO_com.. .  Tracker : #2145