### PR TITLE
Fix formatting on spec examples

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -39,7 +39,7 @@ func.func @main(
   %0 = "stablehlo.reshape"(%image) : (tensor<28x28xf32>) -> tensor<1x784xf32>
   %1 = "stablehlo.dot"(%0, %weights) : (tensor<1x784xf32>, tensor<784x10xf32>) -> tensor<1x10xf32>
   %2 = "stablehlo.add"(%1, %bias) : (tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32>
-  %3 = "stablehlo.constant"() { value = dense<0.0> : tensor<1x10xf32> } : () -> tensor<1x10xf32>
+  %3 = "stablehlo.constant"() {value = dense<0.0> : tensor<1x10xf32>} : () -> tensor<1x10xf32>
   %4 = "stablehlo.maximum"(%2, %3) : (tensor<1x10xf32>, tensor<1x10xf32>) -> tensor<1x10xf32>
   "func.return"(%4): (tensor<1x10xf32>) -> ()
 }
@@ -1965,8 +1965,10 @@ semantics change.
 ```mlir
 %results = "stablehlo.composite"(%input0, %input1) {
   name = "my_namespace.my_op",
+  composite_attributes = {
+    my_attribute = "my_value"
+  },
   decomposition = @my_op,
-  composite_attributes = { my_attribute = "my_value" },
   version = 1 : i32
 } : (tensor<f32>, tensor<f32>) -> tensor<f32>
 ```
@@ -3871,7 +3873,7 @@ Semantics of `outfeed_config` is implementation-defined.
 #### Examples
 
 ```mlir
-%result = "stablehlo.outfeed"(%inputs0, %token) {
+%result = "stablehlo.outfeed"(%input0, %token) {
   outfeed_config = ""
 } : (tensor<2x2x2xi64>, !stablehlo.token) -> !stablehlo.token
 ```

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1020,7 +1020,7 @@ def StableHLO_OutfeedOp : StableHLO_Op<"outfeed",
 
     Example:
     ```mlir
-    %result = "stablehlo.outfeed"(%inputs0, %token) :
+    %result = "stablehlo.outfeed"(%input0, %token) :
         (tensor<2x2x2xi64>, !stablehlo.token) -> !stablehlo.token
     ```
   }];
@@ -2100,9 +2100,11 @@ def StableHLO_CompositeOp : StableHLO_Op<"composite", [DeclareOpInterfaceMethods
 
     Example:
     ```mlir
-    %results = stablehlo.composite "my.op" %arg0, %arg1 {
+    %results = stablehlo.composite "my.op" %input0, %input1 {
+      composite_attributes = {
+        my_attribute = "my_value"
+      },
       decomposition = @my_op,
-      composite_attributes = { my_attribute = "my_value" },
       version = 1 : i32
     } : (tensor<f32>, tensor<f32>) -> tensor<f32>
     ```


### PR DESCRIPTION
As pointed out in https://github.com/openxla/stablehlo/pull/2097#discussion_r1534620186, MLIR doesn't insert spaces between the brackets and the content. I've also made minor formatting improvements.