### PR TITLE
Clean up hasRank checks

### DIFF
--- a/stablehlo/conversions/linalg/transforms/LegalizeToLinalgUtils.cpp
+++ b/stablehlo/conversions/linalg/transforms/LegalizeToLinalgUtils.cpp
@@ -73,7 +73,7 @@ Value getEmptyTensorFor(OpBuilder &b, Location loc, ShapedType resultType,
   // new tensor initialization operation. This operation only needs the
   // dynamic sizes.
   SmallVector<Value> sizes;
-  if (resultType.hasRank() && !resultType.hasStaticShape()) {
+  if (!resultType.hasStaticShape()) {
     // Ask the op for its output shape.
     auto shapeSource = cast<InferShapedTypeOpInterface>(op);
     SmallVector<Value, 1> reifiedShapes;

--- a/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
@@ -966,11 +966,7 @@ struct RealDynamicSliceConverter final
       mlir::stablehlo::RealDynamicSliceOp realDynamicSliceOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     Location loc = realDynamicSliceOp.getLoc();
-    auto argType = llvm::dyn_cast<ShapedType>(adaptor.getOperand().getType());
-    if (!argType || !argType.hasRank()) {
-      return rewriter.notifyMatchFailure(realDynamicSliceOp,
-                                         "require known-rank args");
-    }
+    auto argType = llvm::cast<RankedTensorType>(adaptor.getOperand().getType());
 
     Type dimElementType = getElementTypeOrSelf(adaptor.getStartIndices());
     if (getElementTypeOrSelf(adaptor.getLimitIndices()) != dimElementType ||
@@ -1405,10 +1401,7 @@ struct SliceConverter final : OpConversionPattern<mlir::stablehlo::SliceOp> {
       mlir::stablehlo::SliceOp sliceOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     auto argType =
-        llvm::dyn_cast<ShapedType>(adaptor.getOperands()[0].getType());
-    if (!argType || !argType.hasRank()) {
-      return rewriter.notifyMatchFailure(sliceOp, "expects known-rank args");
-    }
+        llvm::cast<RankedTensorType>(adaptor.getOperands()[0].getType());
 
     SmallVector<OpFoldResult, 3> offsets, sizes, strides;
     auto startIndices = sliceOp.getStartIndices();
@@ -1442,11 +1435,7 @@ struct DynamicSliceConverter final
       mlir::stablehlo::DynamicSliceOp dynamicSliceOp, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     Location loc = dynamicSliceOp.getLoc();
-    auto argType = llvm::dyn_cast<ShapedType>(adaptor.getOperand().getType());
-    if (!argType || !argType.hasRank()) {
-      return rewriter.notifyMatchFailure(dynamicSliceOp,
-                                         "require known-rank args");
-    }
+    auto argType = llvm::cast<RankedTensorType>(adaptor.getOperand().getType());
 
     auto resultType = getTypeConverter()->convertType<RankedTensorType>(
         dynamicSliceOp.getType());

--- a/stablehlo/conversions/linalg/transforms/StablehloToLinalgPointwise.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloToLinalgPointwise.cpp
@@ -80,11 +80,11 @@ FailureOr<PointwiseConversionInfo> checkOperandsAndResults(
   }
 
   // Find result type, if on tensors.
-  auto resultTy = dyn_cast_or_null<ShapedType>(
+  auto resultTy = cast_or_null<RankedTensorType>(
       typeConverter.convertType(op->getResultTypes().front()));
 
   // Check result type compatibility.
-  if (!resultTy || !resultTy.hasRank() || resultTy.getRank() != maxRank ||
+  if (!resultTy || resultTy.getRank() != maxRank ||
       !(resultTy.getElementType().isSignlessIntOrFloat() ||
         isa<ComplexType>(resultTy.getElementType()))) {
     return rewriter.notifyMatchFailure(

--- a/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.pdll
+++ b/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.pdll
@@ -48,12 +48,8 @@ Rewrite positiveFloatInfinityLike(op: Op, type: Type) -> Op [{
 }];
 
 Rewrite changeElementTypeToI1(type: Type) -> Type [{
-  auto tensorType = type.cast<mlir::TensorType>();
-  if (tensorType.hasRank()) {
-    return RankedTensorType::get(tensorType.getShape(), rewriter.getI1Type());
-  } else {
-    return UnrankedTensorType::get(rewriter.getI1Type());
-  }
+  auto tensorType = type.cast<mlir::RankedTensorType>();
+  return RankedTensorType::get(tensorType.getShape(), rewriter.getI1Type());
 }];
 
 // Nullary ops.

--- a/stablehlo/dialect/Base.cpp
+++ b/stablehlo/dialect/Base.cpp
@@ -594,11 +594,9 @@ LogicalResult unflattenTupleTypes(TypeRange prototype, TypeRange types,
 
 ShapedType createShapedType(ShapedTypeComponents components) {
   if (!components.getElementType()) return ShapedType();
-  if (components.hasRank())
-    return RankedTensorType::get(components.getDims(),
-                                 components.getElementType(),
-                                 components.getAttribute());
-  return UnrankedTensorType::get(components.getElementType());
+  return RankedTensorType::get(components.getDims(),
+                               components.getElementType(),
+                               components.getAttribute());
 }
 
 bool isSplatArray(ArrayRef<int64_t> arr, int64_t val) {

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -550,7 +550,6 @@ LogicalResult DotGeneralOp::reifyReturnTypeShapes(
     SmallVectorImpl<Value>& reifiedReturnShapes) {
   auto lhsType = getLhs().getType();
   auto rhsType = getRhs().getType();
-  if (!lhsType.hasRank() || !rhsType.hasRank()) return failure();
 
   Adaptor adaptor(operands);
   auto dimNumbers = getDotDimensionNumbers();
@@ -1520,14 +1519,8 @@ void ReduceOp::build(OpBuilder&, OperationState& odsState, ValueRange inputs,
   SmallVector<Type> inferredReturnTypes;
   for (auto [inputTy, elementTy] :
        llvm::zip(inputArgTensorTypes, elementTypes)) {
-    if (inputTy.hasRank()) {
-      inferredReturnTypes.push_back(
-          RankedTensorType::get(newDimensions, elementTy, encoding));
-    } else {
-      if (encoding != nullptr)
-        llvm::report_fatal_error("attribute not supported.");
-      inferredReturnTypes.push_back(UnrankedTensorType::get(elementTy));
-    }
+    inferredReturnTypes.push_back(
+        RankedTensorType::get(newDimensions, elementTy, encoding));
   }
   odsState.addTypes(inferredReturnTypes);
 }

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -4214,7 +4214,7 @@ LogicalResult verifySelectAndScatterOp(
         location, "expects select-region to return single value, but got: ",
         selectResult.size());
 
-  auto selectResultType = selectResult[0].getType().cast<RankedTensorType>();
+  auto selectResultType = selectResult[0].getType().dyn_cast<RankedTensorType>();
   // select_and_scatter_c9
   if (!selectResultType || !selectResultType.getElementType().isInteger(1) ||
       selectResultType.getRank() != 0)

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -4214,7 +4214,8 @@ LogicalResult verifySelectAndScatterOp(
         location, "expects select-region to return single value, but got: ",
         selectResult.size());
 
-  auto selectResultType = selectResult[0].getType().dyn_cast<RankedTensorType>();
+  auto selectResultType =
+      selectResult[0].getType().dyn_cast<RankedTensorType>();
   // select_and_scatter_c9
   if (!selectResultType || !selectResultType.getElementType().isInteger(1) ||
       selectResultType.getRank() != 0)

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -534,8 +534,9 @@ LogicalResult verifyReduceOpInputsAndInferShape(
   for (size_t i = 1; i < inputTypes.size(); i++)
     if (failed(mlir::verifyCompatibleShape(witnessType, inputTypes[i])))
       return emitOptionalError(
-          location, "expects all inputs to have compatible shapes. Shape at",
-          " input-index ", i, " is not compatible with shape at input-index 0");
+          location,
+          "expects all inputs to have compatible shapes. Shape at input-index ",
+          i, " is not compatible with shape at input-index 0");
 
   DenseSet<int64_t> dimensionsToReduceSet;
   for (int64_t dimension : dimensions) {
@@ -732,8 +733,9 @@ LogicalResult verifyReduceWindowOpInputsAndInferWindow(
   for (size_t i = 1; i < inputTypes.size(); i++)
     if (failed(mlir::verifyCompatibleShape(witnessType, inputTypes[i])))
       return emitOptionalError(
-          location, "expects all inputs to have compatible shapes. Shape at",
-          " input-index ", i, " is not compatible with shape at input-index 0");
+          location,
+          "expects all inputs to have compatible shapes. Shape at input-index ",
+          i, " is not compatible with shape at input-index 0");
 
   // reduce_window_c12, reduce_window_i7
   auto paddingOrErr = convertPaddingAttribute(padding, location);
@@ -1649,9 +1651,7 @@ LogicalResult inferConcatenateOp(std::optional<Location> location,
       if (d != dimension && !verifyCompatibleDims(witnessShape[d], shape[d]))
         return emitOptionalError(
             location, "shapes of operand (", 0, ") and (", i,
-            ") are not compatible at non-concat "
-            "index ",
-            d, ": (",
+            ") are not compatible at non-concat index ", d, ": (",
             llvm::make_range(witnessShape.begin(), witnessShape.end()),
             ") != (", llvm::make_range(shape.begin(), shape.end()), ")");
     }
@@ -2394,8 +2394,8 @@ LogicalResult inferMapOp(
     if (dimensions.size() != operandType.getShape().size())
       return emitOptionalError(
           location,
-          "applied to a subset of dimensions currently not supported: "
-          "operand dimensions = ",
+          "applied to a subset of dimensions currently not supported: operand "
+          "dimensions = ",
           operandType.getShape().size(),
           ", requested map dimensions size = ", dimensions.size());
     resultShape = operandType.getShape();
@@ -3088,10 +3088,10 @@ LogicalResult verifyAllReduceOp(std::optional<Location> location, Value operand,
 
   // all_reduce_c4
   if (useGlobalDeviceIds && channelId <= 0)
-    return emitOptionalError(location,
-                             "channel_id must be positive when "
-                             "useGlobalDeviceIds is set but got: ",
-                             channelId);
+    return emitOptionalError(
+        location,
+        "channel_id must be positive when useGlobalDeviceIds is set but got: ",
+        channelId);
 
   auto operandType = operand.getType().cast<ShapedType>();
   // all_reduce_c5
@@ -3661,17 +3661,17 @@ LogicalResult verifyInfeedOp(HloDialectInterface* dialect,
   // infeed_c2
   for (auto resultType : results.drop_back().getTypes())
     if (!resultType.isa<TensorType>())
-      return emitOptionalError(location,
-                               "all elements of result types, except the "
-                               "last element, are expected "
-                               "to be of tensor type, but got ",
-                               resultType);
+      return emitOptionalError(
+          location,
+          "all elements of result types, except the last element, are expected "
+          "to be of tensor type, but got ",
+          resultType);
 
   // infeed_c3
   if (!dialect->isTokenType(results.back().getType()))
     return emitOptionalError(location,
-                             "last element of result types is expected to "
-                             "be of token type, but got ",
+                             "last element of result types is expected to be "
+                             "of token type, but got ",
                              results.back().getType());
 
   if (!layout.has_value()) return success();
@@ -3680,19 +3680,18 @@ LogicalResult verifyInfeedOp(HloDialectInterface* dialect,
                              "layout-attribute expected to be of array-type.");
 
   if (layout.value().size() != resultTypes.size() - 1)
-    return emitOptionalError(location, "layout-attribute size must be ",
-                             resultTypes.size() - 1,
-                             " (which is the number of "
-                             "op-results - 1 (for token result)), but got ",
-                             layout.value().size());
+    return emitOptionalError(
+        location, "layout-attribute size must be ", resultTypes.size() - 1,
+        " (which is the number of op-results - 1 (for token result)), but got ",
+        layout.value().size());
 
   for (auto childLayout : layout.value()) {
     mlir::ArrayAttr childLayoutArr = childLayout.dyn_cast<mlir::ArrayAttr>();
     if (!childLayoutArr)
-      return emitOptionalError(location,
-                               "layout-attribute expected to have "
-                               "elements of type array, but got ",
-                               childLayout);
+      return emitOptionalError(
+          location,
+          "layout-attribute expected to have elements of type array, but got ",
+          childLayout);
 
     for (auto i : childLayoutArr) {
       mlir::IntegerAttr attr = i.dyn_cast<mlir::IntegerAttr>();
@@ -3993,10 +3992,10 @@ LogicalResult verifyRngBitGeneratorOp(std::optional<Location> location,
   auto outputShape = outputState.getType().dyn_cast<RankedTensorType>();
   if (failed(verifyCompatibleShape(initialShape.getShape(),
                                    outputShape.getShape())))
-    return emitOptionalError(location,
-                             "output state shape must be compatible with "
-                             "initial state shape. Got: ",
-                             initialShape, " and ", outputShape);
+    return emitOptionalError(
+        location,
+        "output state shape must be compatible with initial state shape. Got: ",
+        initialShape, " and ", outputShape);
   return success();
 }
 
@@ -4219,11 +4218,10 @@ LogicalResult verifySelectAndScatterOp(
   // select_and_scatter_c9
   if (!selectResultType || !selectResultType.getElementType().isInteger(1) ||
       selectResultType.getRank() != 0)
-    return emitOptionalError(location,
-                             "expects the return-type of select-region to be "
-                             "tensor<i1>, but got: ",
-                             selectResult[0].getType());
-
+    return emitOptionalError(
+        location,
+        "expects the return-type of select-region to be tensor<i1>, but got: ",
+        selectResult[0].getType());
   // select_and_scatter_c10
   if (failed(verifyReducerShape(
           location, scatter.front(),
@@ -4235,12 +4233,12 @@ LogicalResult verifySelectAndScatterOp(
   auto windowDims = windowDimensionsOpt.value_or(SmallVector<int64_t>{});
   // select_and_scatter_c4
   if (operandType.getRank() != static_cast<int64_t>(windowDims.size()))
-    return emitOptionalError(
-        location,
-        "expects window-dimensions size == operand rank, but got "
-        "window-dimensions size: ",
-        windowDims.size(), " and operand-type: ", operandType,
-        " with rank = ", operandType.getRank(), ".");
+    return emitOptionalError(location,
+                             "expects window-dimensions size == operand rank, "
+                             "but got window-dimensions size: ",
+                             windowDims.size(),
+                             " and operand-type: ", operandType,
+                             " with rank = ", operandType.getRank(), ".");
 
   auto windowStrides = windowStridesOpt.value_or(SmallVector<int64_t>{});
 

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1501,7 +1501,7 @@ func.func @concatenate_c4(%arg0: tensor<1xi32>, %arg1: tensor<2xi32>)  -> tensor
 
 func.func @concatenate_c6(%arg0: tensor<1x3xi32>, %arg1: tensor<2x2xi32>)  -> tensor<3x3xi32> {
   // expected-error@+2 {{failed to infer returned types}}
-  // expected-error@+1 {{shapes of operand (0) and (1) do not match at non-concat index: (1, 3) != (2, 2) at non-concat index 1}}
+  // expected-error@+1 {{shapes of operand (0) and (1) are not compatible at non-concat index 1: (1, 3) != (2, 2)}}
   %0 = "stablehlo.concatenate"(%arg0, %arg1) { dimension = 0 : i64 } : (tensor<1x3xi32>, tensor<2x2xi32>) -> tensor<3x3xi32>
   func.return %0 : tensor<3x3xi32>
 }

--- a/stablehlo/tests/verify_reduce.mlir
+++ b/stablehlo/tests/verify_reduce.mlir
@@ -166,7 +166,7 @@ func.func @reduce_c2(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xi32>,
 func.func @reduce_c4(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
     -> (tensor<?xf32>) {
 
-  // expected-error@+1 {{Out-of-bounds dimension -1, expected to be less than the input-tensor rank 2}}
+  // expected-error@+1 {{Out-of-bounds dimension -1, expected to be in range [0, 2)}}
   %0 = "stablehlo.reduce"(%arg0, %arg1) ({
 
   ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32> ):
@@ -182,7 +182,7 @@ func.func @reduce_c4(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
 func.func @reduce_c4(%arg0: tensor<?x?xf32>, %arg1 : tensor<f32>)
     -> (tensor<?xf32>) {
 
-  // expected-error@+1 {{Out-of-bounds dimension 2, expected to be less than the input-tensor rank 2}}
+  // expected-error@+1 {{Out-of-bounds dimension 2, expected to be in range [0, 2)}}
   %0 = "stablehlo.reduce"(%arg0, %arg1) ({
 
   ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32> ):

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -276,8 +276,7 @@ template <typename OpType, typename FuncType>
 LogicalResult evalElementwise(PatternRewriter& rewriter, OpType op,
                               FuncType fn) {
   auto resultType = op.getType();
-  if (!resultType.hasRank() ||
-      !resultType.getElementType().template isa<IntegerType>())
+  if (!resultType.getElementType().template isa<IntegerType>())
     return rewriter.notifyMatchFailure(op,
                                        "expected integer result tensor type");
 
@@ -345,7 +344,7 @@ struct EvalBroadcastInDimOpPattern : public OpRewritePattern<BroadcastInDimOp> {
   LogicalResult matchAndRewrite(BroadcastInDimOp op,
                                 PatternRewriter& rewriter) const override {
     auto operandType = op.getOperand().getType();
-    if (!operandType.hasRank() || operandType.getRank() != 0)
+    if (operandType.getRank() != 0)
       return rewriter.notifyMatchFailure(op, "expected 0-dimensional type");
 
     SmallVector<APSInt> operand;
@@ -409,7 +408,7 @@ struct EvalConcatenateOpPattern : public OpRewritePattern<ConcatenateOp> {
   LogicalResult matchAndRewrite(ConcatenateOp op,
                                 PatternRewriter& rewriter) const override {
     auto resultType = op.getType();
-    if (!resultType.hasRank() || op.getDimension() != 0)
+    if (op.getDimension() != 0)
       return rewriter.notifyMatchFailure(op, "expected dimension = 0");
 
     SmallVector<APSInt> result;
@@ -454,8 +453,6 @@ struct EvalGetDimensionSizeOpPattern
   LogicalResult matchAndRewrite(GetDimensionSizeOp op,
                                 PatternRewriter& rewriter) const override {
     auto operandType = op.getOperand().getType();
-    if (!operandType.hasRank())
-      return rewriter.notifyMatchFailure(op, "expected ranked operand");
     if (operandType.isDynamicDim(op.getDimension()))
       return rewriter.notifyMatchFailure(op, "expected static dimension");
 
@@ -640,8 +637,6 @@ struct RefineAllGatherOpPattern : public OpRewritePattern<AllGatherOp> {
   LogicalResult matchAndRewrite(AllGatherOp op,
                                 PatternRewriter& rewriter) const override {
     auto operandType = op.getOperand().getType();
-    if (!operandType.hasRank())
-      return rewriter.notifyMatchFailure(op, "expected ranked operand type");
 
     // This represents the cross_replica_and_partition process grouping strategy
     // that requires num_partitions to compute shardCount. Since we don't know
@@ -664,8 +659,6 @@ struct RefineBitcastConvertOpPattern
   LogicalResult matchAndRewrite(BitcastConvertOp op,
                                 PatternRewriter& rewriter) const override {
     auto operandType = op.getOperand().getType();
-    if (!operandType.hasRank())
-      return rewriter.notifyMatchFailure(op, "expected ranked operand type");
 
     // If bit widths of the operand and the result are different, then
     // operand and result shapes have different ranks.
@@ -962,8 +955,6 @@ struct RefineReduceScatterOpPattern : public OpRewritePattern<ReduceScatterOp> {
   LogicalResult matchAndRewrite(ReduceScatterOp op,
                                 PatternRewriter& rewriter) const override {
     auto operandType = op.getOperand().getType();
-    if (!operandType.hasRank())
-      return rewriter.notifyMatchFailure(op, "expected ranked operand type");
 
     // This represents the cross_replica_and_partition process grouping strategy
     // that requires num_partitions to compute shardCount. Since we don't know


### PR DESCRIPTION
These checks are no longer necessary in most cases (they are still necessary in some cases, e.g. when dealing with custom call args/results or CHLO op args/results).

I plan to make further cleanups in future PRs, e.g. in ShapeRefinement.cpp (in this PR I did only the obvious ones). Also I plan to clean up casts, especially casting to `ShapedType` instead of `RankedTensorType`.

#1991