### PR TITLE
Add support of float type in specialization of ConvertOp

### DIFF
--- a/docs/generated/stablehlo_passes.md
+++ b/docs/generated/stablehlo_passes.md
@@ -16,6 +16,11 @@ compilation pipelines that use StableHLO operations to model dynamism.
 
 _Folds StableHLO operations_
 
+
+#### Options
+```
+-fold-float : Allow for potentially lossy computations using float type.
+```
 ### `-stablehlo-aggressive-simplification`
 
 _Canonicalizes StableHLO operations_

--- a/stablehlo/tests/stablehlo_aggressive_folder.mlir
+++ b/stablehlo/tests/stablehlo_aggressive_folder.mlir
@@ -38,3 +38,75 @@ func.func @eval_iota_zero_dimension() -> (tensor<0xi32>, tensor<5x0x2xi32>) {
   %1 = stablehlo.iota dim = 2 : tensor<5x0x2xi32>
   func.return %0, %1 : tensor<0xi32>, tensor<5x0x2xi32>
 }
+
+// -----
+
+// CHECK-LABEL: func @eval_convert_f32_to_i64
+func.func @eval_convert_f32_to_i64() -> tensor<2xi64> {
+  // CHECK-NOT: stablehlo.convert
+  // CHECK: [[RESULT:%.*]] = stablehlo.constant dense<[1, 2]> : tensor<2xi64>
+  // CHECK: return [[RESULT]]
+  %0 = stablehlo.constant dense<[1.0, 2.0]> : tensor<2xf32>
+  %1 = stablehlo.convert %0 : (tensor<2xf32>) -> tensor<2xi64>
+  func.return %1 : tensor<2xi64>
+}
+
+// -----
+
+// CHECK-LABEL: func @eval_convert_f32_non_convertable
+func.func @eval_convert_f32_non_convertable() -> (tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) {
+  // CHECK: [[RESULT0:%.*]] = stablehlo.convert
+  // CHECK: [[RESULT1:%.*]] = stablehlo.convert
+  // CHECK: [[RESULT2:%.*]] = stablehlo.convert
+  // CHECK: return [[RESULT0]], [[RESULT1]], [[RESULT2]]
+  %pinf = stablehlo.constant dense<[1.0, 0x7F800000]> : tensor<2xf32>
+  %ninf = stablehlo.constant dense<[2.0, 0xFF800000]> : tensor<2xf32>
+  %nzero = stablehlo.constant dense<[3.0, 0x80000000]> : tensor<2xf32>
+  %0 = stablehlo.convert %pinf : (tensor<2xf32>) -> tensor<2xi64>
+  %1 = stablehlo.convert %ninf : (tensor<2xf32>) -> tensor<2xi64>
+  %2 = stablehlo.convert %nzero : (tensor<2xf32>) -> tensor<2xi64>
+  func.return %0, %1, %2 : tensor<2xi64>, tensor<2xi64>, tensor<2xi64>
+}
+
+// -----
+
+// CHECK-LABEL: func @eval_convert_f32_non_fittable
+func.func @eval_convert_f32_non_fittable() -> (tensor<1xi32>, tensor<1xi32>) {
+  // CHECK: [[RESULT0:%.*]] = stablehlo.constant dense<2.14748365E+9> : tensor<1xf32>
+  // CHECK: [[RESULT1:%.*]] = stablehlo.constant dense<2147483520> : tensor<1xi32>
+  // CHECK: [[RESULT2:%.*]] = stablehlo.convert [[RESULT0]]
+  // CHECK: return [[RESULT1]], [[RESULT2]]
+  %twopow30 = stablehlo.constant dense<[2147483583.0]> : tensor<1xf32>
+  %twopow31 = stablehlo.constant dense<[2147483584.0]> : tensor<1xf32>
+  %1 = stablehlo.convert %twopow30 : (tensor<1xf32>) -> tensor<1xi32>
+  %2 = stablehlo.convert %twopow31 : (tensor<1xf32>) -> tensor<1xi32>
+  func.return %1, %2 : tensor<1xi32>, tensor<1xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func @eval_convert_i32_non_exact
+func.func @eval_convert_i32_non_exact() -> (tensor<1xf32>, tensor<1xf32>) {
+  // CHECK: [[RESULT0:%.*]] = stablehlo.constant dense<0x4B7FFFFF> : tensor<1xf32>
+  // 0x4B800000 = 16777216, error due to conversion -1
+  // CHECK: [[RESULT1:%.*]] = stablehlo.constant dense<0x4B800000> : tensor<1xf32>
+  // CHECK: return [[RESULT0]], [[RESULT1]]
+  %pow23 = stablehlo.constant dense<[16777215]> : tensor<1xi32>
+  %pow24 = stablehlo.constant dense<[16777217]> : tensor<1xi32>
+  %1 = stablehlo.convert %pow23 : (tensor<1xi32>) -> tensor<1xf32>
+  %2 = stablehlo.convert %pow24 : (tensor<1xi32>) -> tensor<1xf32>
+  func.return %1, %2 : tensor<1xf32>, tensor<1xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func @eval_convert_f64_precision_loss
+func.func @eval_convert_f64_precision_loss() -> (tensor<1xf32>, tensor<f32>) {
+  // CHECK: [[RESULT0:%.*]] = stablehlo.constant dense<9.99999996E-13> : tensor<1xf32>
+  // CHECK: return [[RESULT0]]
+  %0 = arith.constant dense<9.9999999999999998E-13> : tensor<1xf64>
+  %1 = stablehlo.constant dense<8.000000e+00> : tensor<f64>
+  %2 = stablehlo.convert %0 : (tensor<1xf64>) -> tensor<1xf32>
+  %3 = stablehlo.convert %1 : (tensor<f64>) -> tensor<f32>
+  func.return %2, %3 : tensor<1xf32>, tensor<f32>
+}

--- a/stablehlo/tests/stablehlo_refine_shapes.mlir
+++ b/stablehlo/tests/stablehlo_refine_shapes.mlir
@@ -293,6 +293,18 @@ func.func @eval_convert_infer_before_fold() -> tensor<?xi32> {
 
 // -----
 
+// shape refinement do not perform potentially lossy computations
+// CHECK-LABEL: func @eval_convert_f32_to_i64
+func.func @eval_convert_f32_to_i64() -> tensor<2xi64> {
+  // CHECK: [[RESULT:%.*]] = stablehlo.convert
+  // CHECK: return [[RESULT]]
+  %0 = stablehlo.constant dense<[1.0, 2.0]> : tensor<2xf32>
+  %1 = stablehlo.convert %0 : (tensor<2xf32>) -> tensor<2xi64>
+  return %1 : tensor<2xi64>
+}
+
+// -----
+
 // CHECK-LABEL: func @eval_divide
 func.func @eval_divide() -> tensor<i64> {
   // CHECK-NOT: stablehlo.divide

--- a/stablehlo/transforms/Passes.h
+++ b/stablehlo/transforms/Passes.h
@@ -63,12 +63,14 @@ void populateChloToStablehloPatterns(MLIRContext *context,
 
 /// Collection of folding patterns for StableHLO.
 void populateStablehloAggressiveFolderPatterns(RewritePatternSet *patterns,
-                                               MLIRContext *context);
+                                               MLIRContext *context,
+                                               bool foldFloat);
 
 /// A subset of folding patterns for StableHLO that is necessary for shape
 /// refinement.
 void populateStablehloShapeFolderPatterns(RewritePatternSet *patterns,
-                                          MLIRContext *context);
+                                          MLIRContext *context,
+                                          bool foldFloat = false);
 
 /// Collection of canonicalization patterns for StableHLO.
 void populateStablehloCanonicalizationPatterns(MLIRContext *context,

--- a/stablehlo/transforms/Passes.td
+++ b/stablehlo/transforms/Passes.td
@@ -131,6 +131,10 @@ def StablehloAggressiveFolderPass
   let dependentDialects = [
     "mlir::tensor::TensorDialect",
   ];
+  let options = [
+    Option<"foldFloat", "fold-float", "bool", /*default=*/"true",
+           "Allow for potentially lossy computations using float type.">,
+  ];
 }
 
 def StablehloAggressiveSimplificationPass

--- a/stablehlo/transforms/StablehloAggressiveFolder.cpp
+++ b/stablehlo/transforms/StablehloAggressiveFolder.cpp
@@ -24,6 +24,7 @@ limitations under the License.
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FormatVariadic.h"
+#include "mlir/Dialect/CommonFolders.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
@@ -83,6 +84,95 @@ LogicalResult validateResultTypeForEval(PatternRewriter& rewriter,
     return rewriter.notifyMatchFailure(
         op, "unable to fold dynamically shaped result type to constant");
   return success();
+}
+
+template <class AttrElementT, class TargetAttrElementT, class CalculationT,
+          typename OpType>
+LogicalResult evalConvertHelper(PatternRewriter& rewriter, OpType op,
+                                DenseIntOrFPElementsAttr elements, Type resType,
+                                CalculationT&& calculate) {
+  auto result = constFoldCastOp<AttrElementT, TargetAttrElementT,
+                                typename AttrElementT::ValueType,
+                                typename TargetAttrElementT::ValueType, void>(
+      elements, resType, calculate);
+
+  if (!result)
+    return rewriter.notifyMatchFailure(op, [&](Diagnostic& diag) {
+      diag << "cast of " << elements.getElementType() << " to " << resType
+           << " failed";
+    });
+
+  rewriter.replaceOpWithNewOp<ConstantOp>(op, result);
+  return success();
+}
+
+template <typename OpType>
+LogicalResult evalConvert(PatternRewriter& rewriter, OpType op,
+                          DenseIntOrFPElementsAttr elements,
+                          RankedTensorType resultType) {
+  auto oldType = getElementTypeOrSelf(elements);
+  auto newType = getElementTypeOrSelf(resultType);
+  size_t newBitWidth = newType.getIntOrFloatBitWidth();
+
+  bool isOldTypeUnsigned = oldType.isInteger(1) || oldType.isUnsignedInteger();
+  bool isNewTypeUnsigned = newType.isInteger(1) || newType.isUnsignedInteger();
+
+  if (oldType.isa<FloatType>()) {
+    if (auto newFloatType = newType.dyn_cast<FloatType>()) {
+      // Float -> Float
+      const auto& targetSemantics = newFloatType.getFloatSemantics();
+      return evalConvertHelper<FloatAttr, FloatAttr>(
+          rewriter, op, elements, resultType,
+          [&targetSemantics](const APFloat& operand, bool& castStatus) {
+            bool losesInfo;
+            APFloat newValue = operand;
+            castStatus = APFloat::opInvalidOp !=
+                         newValue.convert(targetSemantics,
+                                          llvm::RoundingMode::NearestTiesToEven,
+                                          &losesInfo);
+            return newValue;
+          });
+    }
+
+    // Float -> Int
+    return evalConvertHelper<FloatAttr, IntegerAttr>(
+        rewriter, op, elements, resultType,
+        [&newBitWidth, &isNewTypeUnsigned](const APFloat& operand,
+                                           bool& castStatus) {
+          APSInt api(newBitWidth, isNewTypeUnsigned);
+          if (operand.isInfinity() || operand.isNegZero()) {
+            castStatus = false;
+            return api;
+          }
+          bool ignored;
+          castStatus =
+              APFloat::opInvalidOp !=
+              operand.convertToInteger(api, APFloat::rmTowardZero, &ignored);
+          return api;
+        });
+  }
+
+  if (auto newFloatType = newType.dyn_cast<FloatType>()) {
+    // Int -> Float
+    return evalConvertHelper<IntegerAttr, FloatAttr>(
+        rewriter, op, elements, resultType,
+        [&newFloatType, &isOldTypeUnsigned](const APInt& operand,
+                                            bool& /*castStatus*/) {
+          APFloat apf(newFloatType.getFloatSemantics(),
+                      APInt::getZero(newFloatType.getWidth()));
+          apf.convertFromAPInt(operand, !isOldTypeUnsigned,
+                               APFloat::rmNearestTiesToEven);
+          return apf;
+        });
+  }
+
+  // Int -> Int
+  return evalConvertHelper<IntegerAttr, IntegerAttr>(
+      rewriter, op, elements, resultType,
+      [&newBitWidth, &isOldTypeUnsigned](const APInt& operand,
+                                         bool& /*castStatus*/) {
+        return APSInt(operand, isOldTypeUnsigned).extOrTrunc(newBitWidth);
+      });
 }
 
 // The patterns below implement partial evaluation of shape computations which
@@ -255,17 +345,26 @@ struct EvalConvertOpPattern : public OpRewritePattern<ConvertOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(ConvertOp op,
                                 PatternRewriter& rewriter) const override {
-    auto resultType = op.getType();
+    auto operandType = op.getOperand().getType();
+    RankedTensorType resultType = op.getType();
+
     if (failed(validateResultTypeForEval(rewriter, op, resultType)))
       return failure();
 
-    if (!isa<IntegerType>(resultType.getElementType()))
+    if (!resultType.getElementType().isIntOrFloat())
       return rewriter.notifyMatchFailure(
-          op, "expected integer result tensor type with static shapes");
-    auto resultBitWidth = resultType.getElementType().getIntOrFloatBitWidth();
-    return evalElementwise(rewriter, op, [&](APSInt operand) {
-      return operand.extOrTrunc(resultBitWidth);
-    });
+          op, "expected integer or float result tensor type");
+
+    if (!operandType.getElementType().isIntOrFloat())
+      return rewriter.notifyMatchFailure(
+          op, "expected integer or float operand tensor type");
+
+    DenseIntOrFPElementsAttr elements;
+    if (!matchPattern(op.getOperand(), m_Constant(&elements)))
+      return rewriter.notifyMatchFailure(
+          op, "expected constant integer or float operand");
+
+    return evalConvert(rewriter, op, elements, resultType);
   }
 };
 

--- a/stablehlo/transforms/StablehloAggressiveFolder.cpp
+++ b/stablehlo/transforms/StablehloAggressiveFolder.cpp
@@ -117,8 +117,8 @@ LogicalResult evalConvert(PatternRewriter& rewriter, OpType op,
   bool isOldTypeUnsigned = oldType.isInteger(1) || oldType.isUnsignedInteger();
   bool isNewTypeUnsigned = newType.isInteger(1) || newType.isUnsignedInteger();
 
-  if (oldType.isa<FloatType>()) {
-    if (auto newFloatType = newType.dyn_cast<FloatType>()) {
+  if (isa<FloatType>(oldType)) {
+    if (auto newFloatType = dyn_cast<FloatType>(newType)) {
       // Float -> Float
       const auto& targetSemantics = newFloatType.getFloatSemantics();
       return evalConvertHelper<FloatAttr, FloatAttr>(
@@ -152,7 +152,7 @@ LogicalResult evalConvert(PatternRewriter& rewriter, OpType op,
         });
   }
 
-  if (auto newFloatType = newType.dyn_cast<FloatType>()) {
+  if (auto newFloatType = dyn_cast<FloatType>(newType)) {
     // Int -> Float
     return evalConvertHelper<IntegerAttr, FloatAttr>(
         rewriter, op, elements, resultType,


### PR DESCRIPTION
This adds support of following specializations in ConvertOp:

Integer -> Integer (old)
Integer -> FloatType (new)
FloatType -> FloatType (new)
FloatType -> Integer (new)

I have considered approach used in `convertElementsAttr` from `mlir-hlo/utils/convert_op_folder.cc`, but `DenseIntOrFPElementsAttr::mapValues` doesn't give an option to stop conversion in case of failure.

This implementation works for my case:

```
%cst = arith.constant dense<1.000000e+00> : tensor<1xf64>
%cst_0 = arith.constant dense<128> : tensor<1xi64>
%cst_1 = arith.constant dense<9.9999999999999998E-13> : tensor<1xf64>
%61 = stablehlo.constant dense<8.000000e+00> : tensor<f64>
%73 = stablehlo.constant dense<-3.4028234663852886E+38> : tensor<f64>
%76 = stablehlo.constant dense<1> : tensor<2x128xi32> 
...
%86 = stablehlo.convert %76 : (tensor<2x128xi32>) -> tensor<2x128xf32>
...
%90 = stablehlo.convert %cst : (tensor<1xf64>) -> tensor<1xf32>
...
%94 = stablehlo.convert %73 : (tensor<f64>) -> tensor<f32>
...
%106 = stablehlo.convert %cst_0 : (tensor<1xi64>) -> tensor<1xf32>
...
%117 = stablehlo.convert %cst_1 : (tensor<1xf64>) -> tensor<1xf32>
...
%151 = stablehlo.convert %61 : (tensor<f64>) -> tensor<f32>
```

```
// other constants are equivalent/folded completely
%73 => stablehlo.constant dense<-3.40282347E+38> : tensor<2x1x1x128xf32>
%cst_1 => stablehlo.constant dense<9.99999996E-13> : tensor<2x128x1xf32>
```

but i am not sure how sound it is with [operator specification](https://github.com/tensorflow/mlir-hlo/blob/master/stablehlo/docs/spec.md#convert), mainly how conversion should be performed.