### PR TITLE
AddOp: Remove HLO_CompatibleOperandsAndResultType Trait, add custom verifier

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -146,7 +146,6 @@ LogicalResult ReduceScatterOp::verify() {
         inferredReturnShapes);                                        \
   }
 
-INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(AddOp)
 INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(AndOp)
 INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(Atan2Op)
 INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(CbrtOp)
@@ -185,6 +184,32 @@ INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(SqrtOp)
 INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(SubtractOp)
 INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(TanhOp)
 INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(XorOp)
+
+//===----------------------------------------------------------------------===//
+// AddOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult AddOp::inferReturnTypeComponents(
+    MLIRContext* context, std::optional<Location> location,
+    ValueShapeRange operands, DictionaryAttr attributes,
+    OpaqueProperties properties, RegionRange regions,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+  SmallVector<Type> inferredReturnTypes;
+  if (failed(inferReturnTypes(context, location, operands.getValues(),
+                              attributes, properties, regions,
+                              inferredReturnTypes)))
+    return failure();
+  if (inferredReturnTypes.size() != 1) return failure();
+  auto inferredReturnType = inferredReturnTypes[0].dyn_cast<ShapedType>();
+  if (!inferredReturnType) return failure();
+  inferredReturnShapes.push_back(inferredReturnType);
+  return success();
+}
+
+LogicalResult AddOp::verify() {
+  return hlo::verifyAddOp(getLoc(), getLhs().getType(), getRhs().getType(),
+                          getResult().getType());
+}
 
 //===----------------------------------------------------------------------===//
 // AfterAllOp

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -207,8 +207,8 @@ LogicalResult AddOp::inferReturnTypeComponents(
 }
 
 LogicalResult AddOp::verify() {
-  return hlo::verifyAddOp(getLoc(), getLhs().getType(), getRhs().getType(),
-                          getResult().getType());
+  return hlo::verifyAddOp(getLoc(), getOperation(), getLhs().getType(),
+                          getRhs().getType(), getResult().getType());
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -660,7 +660,7 @@ class StableHLO_BinaryElementwiseOp<string mnemonic, list<Trait> traits,
     OperandType:$rhs
   );
 
-  let extraClassDeclaration = commonClassDeclaration # [{
+  string binElementwiseOpCommonClassDeclaration = commonClassDeclaration # [{
     LogicalResult reifyReturnTypeShapes(
         OpBuilder& builder, ValueRange operands,
         SmallVectorImpl<Value>& reifiedReturnShapes) {
@@ -670,6 +670,8 @@ class StableHLO_BinaryElementwiseOp<string mnemonic, list<Trait> traits,
     }
   }];
 
+  let extraClassDeclaration = binElementwiseOpCommonClassDeclaration;
+
   let results = (outs ResultType:$result);
 
   let assemblyFormat = [{
@@ -678,8 +680,9 @@ class StableHLO_BinaryElementwiseOp<string mnemonic, list<Trait> traits,
   }];
 }
 
-def StableHLO_AddOp : StableHLO_BinaryElementwiseOp<"add",
-      [HLO_Commutative, Pure, HLO_CompatibleOperandsAndResultType],
+def StableHLO_AddOp : StableHLO_BinaryElementwiseOp<"add", [HLO_Commutative, Pure,
+      InferTypeOpInterface,
+      DeclareOpInterfaceMethods<InferShapedTypeOpInterface, ["inferReturnTypeComponents"]>],
       HLO_TensorOrPerAxisQuantizedTensor> {
   let summary = "Add operation";
   let description = [{
@@ -694,6 +697,28 @@ def StableHLO_AddOp : StableHLO_BinaryElementwiseOp<"add",
     %result = stablehlo.add %lhs, %rhs : tensor<2x2xi32>
     ```
   }];
+
+  let extraClassDeclaration = binElementwiseOpCommonClassDeclaration # [{
+    static LogicalResult inferReturnTypes(
+        MLIRContext * /*context*/, std::optional<Location> location,
+        ValueRange operands, DictionaryAttr /*attributes*/,
+        OpaqueProperties /*properties*/, RegionRange /*regions*/,
+        SmallVectorImpl<Type> &inferredReturnTypes) {
+      if (operands.empty())
+        return emitOptionalError(
+            location,
+            "Expected non-empty operands for [CompatibleOperandsAndResultType]");
+
+      auto inferredTypeOrErr =
+          mlir::hlo::inferMostSpecificType(location, operands.getTypes());
+      if (failed(inferredTypeOrErr)) return failure();
+      inferredReturnTypes.emplace_back(*inferredTypeOrErr);
+      return success();
+    }
+  }];
+
+  let hasVerifier = 1;
+
 }
 
 def StableHLO_Atan2Op : StableHLO_BinaryElementwiseOp<"atan2",

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -660,7 +660,7 @@ class StableHLO_BinaryElementwiseOp<string mnemonic, list<Trait> traits,
     OperandType:$rhs
   );
 
-  string binElementwiseOpCommonClassDeclaration = commonClassDeclaration # [{
+  string binaryElementwiseOpCommonClassDeclaration = commonClassDeclaration # [{
     LogicalResult reifyReturnTypeShapes(
         OpBuilder& builder, ValueRange operands,
         SmallVectorImpl<Value>& reifiedReturnShapes) {
@@ -670,7 +670,7 @@ class StableHLO_BinaryElementwiseOp<string mnemonic, list<Trait> traits,
     }
   }];
 
-  let extraClassDeclaration = binElementwiseOpCommonClassDeclaration;
+  let extraClassDeclaration = binaryElementwiseOpCommonClassDeclaration;
 
   let results = (outs ResultType:$result);
 
@@ -698,7 +698,7 @@ def StableHLO_AddOp : StableHLO_BinaryElementwiseOp<"add", [HLO_Commutative, Pur
     ```
   }];
 
-  let extraClassDeclaration = binElementwiseOpCommonClassDeclaration # [{
+  let extraClassDeclaration = binaryElementwiseOpCommonClassDeclaration # [{
     static LogicalResult inferReturnTypes(
         MLIRContext * /*context*/, std::optional<Location> location,
         ValueRange operands, DictionaryAttr /*attributes*/,
@@ -707,7 +707,7 @@ def StableHLO_AddOp : StableHLO_BinaryElementwiseOp<"add", [HLO_Commutative, Pur
       if (operands.empty())
         return emitOptionalError(
             location,
-            "Expected non-empty operands for [CompatibleOperandsAndResultType]");
+            "Expected non-empty operands for AddOp::inferReturnTypes");
 
       auto inferredTypeOrErr =
           mlir::hlo::inferMostSpecificType(location, operands.getTypes());

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -322,10 +322,11 @@ LogicalResult verifyAddOp(std::optional<Location> location, Type lhsType,
   auto resultQPAType =
       resultType.dyn_cast<quant::UniformQuantizedPerAxisType>();
   if (lhsQPAType || rhsQPAType) {
+    // add_c5
     if (!resultQPAType)
       return emitOptionalError(
           location, "result is not per_axis quantized but lhs or rhs are");
-
+    // add_c6
     if (lhsQPAType)
       if (resultQPAType.getQuantizedDimension() !=
           lhsQPAType.getQuantizedDimension())

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -62,6 +62,7 @@ limitations under the License.
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "stablehlo/dialect/AssemblyFormat.h"
+#include "stablehlo/dialect/StablehloOps.h"
 
 namespace mlir {
 namespace hlo {
@@ -94,13 +95,7 @@ LogicalResult verifyBinaryOpQuantizationConstraints(
   rhsType = getElementTypeOrSelf(rhsType);
   resultType = getElementTypeOrSelf(resultType);
   llvm::SmallVector<Type, 3> typeEntries{lhsType, rhsType, resultType};
-  // add_c1
-  if (noneQuantized<quant::QuantizedType>(typeEntries)) {
-    if (lhsType != rhsType || lhsType != resultType)
-      return emitOptionalError(
-          location, "op requires same types for all operands and results");
-    return success();
-  }
+
   // add_c2
   if (!allQuantized<quant::QuantizedType>(typeEntries)) {
     return emitOptionalError(location,

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -62,7 +62,6 @@ limitations under the License.
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "stablehlo/dialect/AssemblyFormat.h"
-#include "stablehlo/dialect/StablehloOps.h"
 
 namespace mlir {
 namespace hlo {
@@ -360,8 +359,13 @@ LogicalResult verifyAddOp(std::optional<Location> location, Operation* op,
     return verifyBinaryOpQuantizationConstraints(location, lhsType, rhsType,
                                                  resultType);
 
-  return mlir::OpTrait::SameOperandsAndResultElementType<
-      ::mlir::stablehlo::AddOp>::verifyTrait(op);
+  if (getElementTypeOrSelf(lhsType) != getElementTypeOrSelf(rhsType) ||
+      getElementTypeOrSelf(lhsType) != getElementTypeOrSelf(resultType))
+    return emitOptionalError(
+        location,
+        "op requires the same element type for all operands and results");
+
+  return success();
 }
 
 LogicalResult verifyBatchNorm(std::optional<Location> location,

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -333,7 +333,6 @@ LogicalResult verifyAddOp(std::optional<Location> location, Type lhsType,
         return emitOptionalError(
             location, "quantization_dimension of lhs and result are not same ",
             lhsType, " vs ", resultType);
-
     // add_c7
     if (rhsQPAType)
       if (resultQPAType.getQuantizedDimension() !=

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -65,6 +65,23 @@ limitations under the License.
 
 namespace mlir {
 namespace hlo {
+namespace {
+//===----------------------------------------------------------------------===//
+// Utils for quantization specific verifications
+//===----------------------------------------------------------------------===//
+template <typename T>
+bool allQuantized(ArrayRef<Type> typeRange) {
+  return llvm::all_of(
+      typeRange, [&](Type val) { return getElementTypeOrSelf(val).isa<T>(); });
+}
+
+template <typename T>
+bool noneQuantized(ArrayRef<Type> typeRange) {
+  return llvm::all_of(
+      typeRange, [&](Type val) { return !getElementTypeOrSelf(val).isa<T>(); });
+}
+
+} // namespace
 
 //===----------------------------------------------------------------------===//
 // Utils for shape functions.
@@ -261,6 +278,71 @@ LogicalResult verifyPairwiseCompatibleShapes(TypeRange values) {
   for (auto type1 : values)
     for (auto type2 : values)
       if (failed(verifyCompatibleShape(type1, type2))) return failure();
+  return success();
+}
+
+LogicalResult verifyAddOp(std::optional<Location> location, Type lhsType,
+                               Type rhsType, Type resultType){
+
+  lhsType = getElementTypeOrSelf(lhsType);
+  rhsType = getElementTypeOrSelf(rhsType);
+  resultType = getElementTypeOrSelf(resultType);
+  llvm::SmallVector<Type, 3> typeEntries{lhsType, rhsType, resultType};
+  // add_c1
+  if (noneQuantized<quant::QuantizedType>(typeEntries)) {
+    if (lhsType != rhsType || lhsType != resultType)
+      return emitOptionalError(
+          location,
+          "op requires compatible types for all operands and results");
+    return success();
+  }
+  // add_c2
+  if (!allQuantized<quant::QuantizedType>(typeEntries)) {
+    return emitOptionalError(location,
+                             "not all of operands and result are quantized");
+  }
+  auto lhsQType = lhsType.dyn_cast<quant::QuantizedType>();
+  auto rhsQType = rhsType.dyn_cast<quant::QuantizedType>();
+  auto resultQType = resultType.dyn_cast<quant::QuantizedType>();
+  // add_c3
+  auto storageType = lhsQType.getStorageType();
+  if (storageType != rhsQType.getStorageType() ||
+      storageType != resultQType.getStorageType())
+    return emitOptionalError(location,
+                             "mismatched operands and result storage_type");
+  // add_c4
+  auto expressedType = lhsQType.getExpressedType();
+  if (expressedType != rhsQType.getExpressedType() ||
+      expressedType != resultQType.getExpressedType())
+    return emitOptionalError(location,
+                             "mismatched operands and result expressed_type");
+
+  auto lhsQPAType = lhsType.dyn_cast<quant::UniformQuantizedPerAxisType>();
+  auto rhsQPAType = rhsType.dyn_cast<quant::UniformQuantizedPerAxisType>();
+  auto resultQPAType =
+      resultType.dyn_cast<quant::UniformQuantizedPerAxisType>();
+  if (resultQPAType) {
+    // add_c5
+    if (!lhsQPAType && !rhsQPAType)
+      return emitOptionalError(location,
+                               "result per_axis quantized but none from rhs "
+                               "and lhs are per_axis quantized");
+    // add_c6
+    if (lhsQPAType)
+      if (resultQPAType.getQuantizedDimension() !=
+          lhsQPAType.getQuantizedDimension())
+        return emitOptionalError(
+            location, "quantization_dimension of lhs and result are not same ",
+            lhsType, " vs ", resultType);
+    // add_c7
+    if (rhsQPAType)
+      if (resultQPAType.getQuantizedDimension() !=
+          rhsQPAType.getQuantizedDimension())
+        return emitOptionalError(
+            location, "quantization_dimension of rhs and result are not same ",
+            rhsType, " vs ", resultType);
+  }
+
   return success();
 }
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -128,28 +128,29 @@ LogicalResult verifyBinaryOpQuantizationConstraints(
       return emitOptionalError(
           location, "result is not per_axis quantized but lhs or rhs are");
     // add_c6
-    if (lhsQPAType)
+    if (lhsQPAType) {
       if (resultQPAType.getQuantizedDimension() !=
           lhsQPAType.getQuantizedDimension())
         return emitOptionalError(
             location, "quantization_dimension of lhs and result are not same ",
             lhsType, " vs ", resultType);
+    }
     // add_c7
-    if (rhsQPAType)
+    if (rhsQPAType) {
       if (resultQPAType.getQuantizedDimension() !=
           rhsQPAType.getQuantizedDimension())
         return emitOptionalError(
             location, "quantization_dimension of rhs and result are not same ",
             rhsType, " vs ", resultType);
-
+    }
     return success();
   }
 
-  return !resultQPAType
-             ? success()
-             : emitOptionalError(location,
-                                 "result per_axis quantized but none from rhs "
-                                 "and lhs are per_axis quantized");
+  if (resultQPAType)
+    return emitOptionalError(location,
+                             "result per_axis quantized but none from rhs "
+                             "and lhs are per_axis quantized");
+  return success();
 }
 
 }  // namespace

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -291,8 +291,7 @@ LogicalResult verifyAddOp(std::optional<Location> location, Type lhsType,
   if (noneQuantized<quant::QuantizedType>(typeEntries)) {
     if (lhsType != rhsType || lhsType != resultType)
       return emitOptionalError(
-          location,
-          "op requires compatible types for all operands and results");
+          location, "op requires same types for all operands and results");
     return success();
   }
   // add_c2
@@ -308,14 +307,15 @@ LogicalResult verifyAddOp(std::optional<Location> location, Type lhsType,
   auto storageType = lhsQType.getStorageType();
   if (storageType != rhsQType.getStorageType() ||
       storageType != resultQType.getStorageType())
-    return emitOptionalError(location,
-                             "mismatched operands and result storage_type");
+    return emitOptionalError(
+        location, "mismatched operands and result quantization storage types");
   // add_c4
   auto expressedType = lhsQType.getExpressedType();
   if (expressedType != rhsQType.getExpressedType() ||
       expressedType != resultQType.getExpressedType())
-    return emitOptionalError(location,
-                             "mismatched operands and result expressed_type");
+    return emitOptionalError(
+        location,
+        "mismatched operands and result quantization expressed types");
 
   auto lhsQPAType = lhsType.dyn_cast<quant::UniformQuantizedPerAxisType>();
   auto rhsQPAType = rhsType.dyn_cast<quant::UniformQuantizedPerAxisType>();

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -81,7 +81,7 @@ bool noneQuantized(ArrayRef<Type> typeRange) {
       typeRange, [&](Type val) { return !getElementTypeOrSelf(val).isa<T>(); });
 }
 
-} // namespace
+}  // namespace
 
 //===----------------------------------------------------------------------===//
 // Utils for shape functions.
@@ -282,8 +282,7 @@ LogicalResult verifyPairwiseCompatibleShapes(TypeRange values) {
 }
 
 LogicalResult verifyAddOp(std::optional<Location> location, Type lhsType,
-                               Type rhsType, Type resultType){
-
+                          Type rhsType, Type resultType) {
   lhsType = getElementTypeOrSelf(lhsType);
   rhsType = getElementTypeOrSelf(rhsType);
   resultType = getElementTypeOrSelf(resultType);

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -341,6 +341,10 @@ LogicalResult verifyAddOp(std::optional<Location> location, Type lhsType,
             location, "quantization_dimension of rhs and result are not same ",
             rhsType, " vs ", resultType);
   }
+  // add_c5
+  if (!resultQPAType && (lhsQPAType || rhsQPAType))
+    return emitOptionalError(
+        location, "result is not per_axis quantized but lhs or rhs is");
 
   return success();
 }

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -375,7 +375,7 @@ LogicalResult inferWhileOp(std::optional<Location> location, ValueRange operand,
 //===----------------------------------------------------------------------===//
 
 LogicalResult verifyAddOp(std::optional<Location> location, Type lhsType,
-                               Type rhsType, Type resultType);
+                          Type rhsType, Type resultType);
 
 LogicalResult verifyAllGatherOp(std::optional<Location> location, Value operand,
                                 int64_t allGatherDim,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -28,7 +28,6 @@ limitations under the License.
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Support/LogicalResult.h"
 #include "stablehlo/dialect/Base.h"
-#include "stablehlo/dialect/StablehloOps.h"
 
 namespace mlir {
 namespace hlo {

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -28,6 +28,7 @@ limitations under the License.
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Support/LogicalResult.h"
 #include "stablehlo/dialect/Base.h"
+#include "stablehlo/dialect/StablehloOps.h"
 
 namespace mlir {
 namespace hlo {
@@ -374,8 +375,8 @@ LogicalResult inferWhileOp(std::optional<Location> location, ValueRange operand,
 // Verifiers for ops.
 //===----------------------------------------------------------------------===//
 
-LogicalResult verifyAddOp(std::optional<Location> location, Type lhsType,
-                          Type rhsType, Type resultType);
+LogicalResult verifyAddOp(std::optional<Location> location, Operation* op,
+                          Type lhsType, Type rhsType, Type resultType);
 
 LogicalResult verifyAllGatherOp(std::optional<Location> location, Value operand,
                                 int64_t allGatherDim,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -374,6 +374,9 @@ LogicalResult inferWhileOp(std::optional<Location> location, ValueRange operand,
 // Verifiers for ops.
 //===----------------------------------------------------------------------===//
 
+LogicalResult verifyAddOp(std::optional<Location> location, Type lhsType,
+                               Type rhsType, Type resultType);
+
 LogicalResult verifyAllGatherOp(std::optional<Location> location, Value operand,
                                 int64_t allGatherDim,
                                 DenseIntElementsAttr replicaGroups,

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -1204,7 +1204,8 @@ func.func @add_bounds(
 func.func @add_bounds_mismatch(
   %arg0: tensor<3xf32, #stablehlo.bounds<?>>,
   %arg1: tensor<?xf32, #stablehlo.bounds<2>>) -> tensor<?xindex> {
-  // expected-error@+1 {{requires compatible types for all operands and results}}
+  // expected-error@+2 {{op failed to infer returned types}}
+  // expected-error@+1 {{Mismatched dimension size 3 and bound 2 in dimension 0}}
   %result = "stablehlo.add"(%arg0, %arg1) : (
     tensor<3xf32, #stablehlo.bounds<?>>,
     tensor<?xf32, #stablehlo.bounds<2>>) -> tensor<?xf32>

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -5087,7 +5087,7 @@ func.func @is_compatible_quant_mix_non_quant(%arg0: tensor<1xf32>, %arg1: tensor
 // -----
 
 func.func @add_c4(%arg0: tensor<1x!quant.uniform<i8:f32, 1.0:17>>) {
-  // expected-error@+1 {{mismatched operands and result expressed_type}}
+  // expected-error@+1 {{mismatched operands and result quantization expressed types}}
   %0 = "stablehlo.add"(%arg0, %arg0) : (tensor<1x!quant.uniform<i8:f32, 1.0:17>>, tensor<1x!quant.uniform<i8:f32, 1.0:17>>) -> tensor<1x!quant.uniform<i8:bf16, 1.0:17>>
   func.return
 }
@@ -5095,7 +5095,7 @@ func.func @add_c4(%arg0: tensor<1x!quant.uniform<i8:f32, 1.0:17>>) {
 // -----
 
 func.func @add_c3(%arg0: tensor<1x!quant.uniform<i8:f32, 1.0:17>>) {
-  // expected-error@+1 {{mismatched operands and result storage_type}}
+  // expected-error@+1 {{mismatched operands and result quantization storage types}}
   %0 = "stablehlo.add"(%arg0, %arg0) : (tensor<1x!quant.uniform<i8:f32, 1.0:17>>, tensor<1x!quant.uniform<i8:f32, 1.0:17>>) -> tensor<1x!quant.uniform<i4:f32, 1.0:17>>
   func.return
 }

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -5073,7 +5073,7 @@ func.func @is_compatible_dynamism_dim_mismatch(%arg0: tensor<1x?xf32>) {
 
 // -----
 
-func.func @add_positive_tests(%arg0: tensor<1xf32>, %arg1: tensor<1x!quant.uniform<i8:f32, 1.0:17>>) {
+func.func @is_compatible_quant_mix_non_quant(%arg0: tensor<1xf32>, %arg1: tensor<1x!quant.uniform<i8:f32, 1.0:17>>) {
   %0 = "stablehlo.add"(%arg0, %arg0) : (tensor<1xf32>, tensor<1xf32>) -> tensor<1xf32>
   %1 = "stablehlo.add"(%arg1, %arg1) : (tensor<1x!quant.uniform<i8:f32, 1.0:17>>, tensor<1x!quant.uniform<i8:f32, 1.0:17>>) -> tensor<1x!quant.uniform<i8:f32, 1.0:17>>
   %2 = "stablehlo.add"(%arg1, %arg1) : (tensor<1x!quant.uniform<i8:f32, 1.0:17>>, tensor<1x!quant.uniform<i8:f32, 1.0:17>>) -> tensor<1x!quant.uniform<i8:f32, 1.0:17>>
@@ -5103,7 +5103,7 @@ func.func @add_c3(%arg0: tensor<1x!quant.uniform<i8:f32, 1.0:17>>) {
 // -----
 
 func.func @add_c2(%arg0: tensor<1x!quant.uniform<i8:f32, 1.0:17>>) {
-  // expected-error@+1 {{not all of operands and result are quantized}}
+  // expected-error@+1 {{all operands and results to be either quantized or non-quantized}}
   %0 = "stablehlo.add"(%arg0, %arg0) : (tensor<1x!quant.uniform<i8:f32, 1.0:17>>, tensor<1x!quant.uniform<i8:f32, 1.0:17>>) -> tensor<1xf32>
   func.return
 }
@@ -5111,7 +5111,7 @@ func.func @add_c2(%arg0: tensor<1x!quant.uniform<i8:f32, 1.0:17>>) {
 // -----
 
 func.func @add_c5(%arg0: tensor<1x!quant.uniform<i8:f32:0, {1.0:17}>>) {
-  // expected-error@+1 {{result is not per_axis quantized but lhs or rhs is}}
+  // expected-error@+1 {{result is not per_axis quantized but lhs or rhs are}}
   %0 = "stablehlo.add"(%arg0, %arg0) : (tensor<1x!quant.uniform<i8:f32:0, {1.0:17}>>, tensor<1x!quant.uniform<i8:f32:0, {1.0:17}>>) -> tensor<1x!quant.uniform<i8:f32, 1.0:17>>
   func.return
 }
@@ -5135,8 +5135,8 @@ func.func @add_c7(%arg0: tensor<1x2x!quant.uniform<i8:f32:0, {1.0:17}>>, %arg1: 
 // -----
 
 func.func @is_compatible_quant_signedness_mismatch(%arg0: tensor<1x!quant.uniform<i8:f32, 1.0:17>>) {
-  // expected-error@+2 {{'stablehlo.add' op failed to infer returned types}}
-  // expected-error@+1 {{'stablehlo.add' op inferred type(s) 'tensor<1x!quant.uniform<i8:f32, 1.000000e+00:17>>' are incompatible with return type(s) of operation 'tensor<1x!quant.uniform<u8:f32, 1.000000e+00:17>>'}}
+  // expected-error@+2 {{op failed to infer returned types}}
+  // expected-error@+1 {{op inferred type(s) 'tensor<1x!quant.uniform<i8:f32, 1.000000e+00:17>>' are incompatible with return type(s) of operation 'tensor<1x!quant.uniform<u8:f32, 1.000000e+00:17>>'}}
   %0 = "stablehlo.add"(%arg0, %arg0) : (tensor<1x!quant.uniform<i8:f32, 1.0:17>>, tensor<1x!quant.uniform<i8:f32, 1.0:17>>) -> tensor<1x!quant.uniform<u8:f32, 1.0:17>>
   func.return
 }

--- a/stablehlo/tests/print_types_invalid.mlir
+++ b/stablehlo/tests/print_types_invalid.mlir
@@ -11,10 +11,9 @@ func.func @unary_eltwise_two_types(%arg0: tensor<?x?xf64>,
 
 // -----
 
-// TODO(ajcbik): error message is a bit too strict, should be "compatible" type?
 func.func @binary_eltwise_type_mismatch(%arg0: tensor<?x?xf64>,
                                         %arg1: tensor<?x?xf32>) -> tensor<?x?xf64> {
-  // expected-error @+1 {{op requires same types for all operands and results}}
+  // expected-error @+1 {{op requires the same element type for all operands and results}}
   %0 = stablehlo.add %arg0, %arg1 : (tensor<?x?xf64>, tensor<?x?xf32>) -> tensor<?x?xf64>
   func.return %0 : tensor<?x?xf64>
 }

--- a/stablehlo/tests/print_types_invalid.mlir
+++ b/stablehlo/tests/print_types_invalid.mlir
@@ -14,7 +14,7 @@ func.func @unary_eltwise_two_types(%arg0: tensor<?x?xf64>,
 // TODO(ajcbik): error message is a bit too strict, should be "compatible" type?
 func.func @binary_eltwise_type_mismatch(%arg0: tensor<?x?xf64>,
                                         %arg1: tensor<?x?xf32>) -> tensor<?x?xf64> {
-  // expected-error @+1 {{op requires compatible types for all operands and results}}
+  // expected-error @+1 {{op requires same types for all operands and results}}
   %0 = stablehlo.add %arg0, %arg1 : (tensor<?x?xf64>, tensor<?x?xf32>) -> tensor<?x?xf64>
   func.return %0 : tensor<?x?xf64>
 }

--- a/stablehlo/tests/print_types_invalid.mlir
+++ b/stablehlo/tests/print_types_invalid.mlir
@@ -14,7 +14,7 @@ func.func @unary_eltwise_two_types(%arg0: tensor<?x?xf64>,
 // TODO(ajcbik): error message is a bit too strict, should be "compatible" type?
 func.func @binary_eltwise_type_mismatch(%arg0: tensor<?x?xf64>,
                                         %arg1: tensor<?x?xf32>) -> tensor<?x?xf64> {
-  // expected-error @+1 {{'stablehlo.add' op requires compatible types for all operands and results}}
+  // expected-error @+1 {{op requires compatible types for all operands and results}}
   %0 = stablehlo.add %arg0, %arg1 : (tensor<?x?xf64>, tensor<?x?xf32>) -> tensor<?x?xf64>
   func.return %0 : tensor<?x?xf64>
 }

--- a/stablehlo/tests/stablehlo_refine_shapes.mlir
+++ b/stablehlo/tests/stablehlo_refine_shapes.mlir
@@ -3,7 +3,7 @@
 func.func @error_illformed(%arg0: tensor<3xf32>, %arg1: tensor<4xf32>) -> tensor<?xf32> {
   %0 = stablehlo.abs %arg0 : (tensor<3xf32>) -> tensor<?xf32>
   %1 = stablehlo.abs %arg1 : (tensor<4xf32>) -> tensor<?xf32>
-  // expected-error@+1{{requires compatible types for all operands and results}}
+  // expected-error@+1{{requires the same shape for all operands and results}}
   %2 = stablehlo.add %0, %1 : (tensor<?xf32>, tensor<?xf32>) -> tensor<?xf32>
   func.return %2 : tensor<?xf32>
 }


### PR DESCRIPTION
AddOP allows mix of `per-tensor` and `per-axis` inputs. Existing StableHLO AddOp def uses `HLO_CompatibleOperandsAndResultType` Trait which does not allow mix of `per-tensor` and `per-axis` inputs. 
This PR:
removed HLO_CompatibleOperandsAndResultType Trait for AddOP
Added custom Verifier to implement OP constraints



Thank you @sdasgup3  for the help with debugging builder issues after removal of `HLO_CompatibleOperandsAndResultType` suggestion for  `inferReturnTypes` placement. 