### PR TITLE
Check whitespace in all files except bytecode and image/vector files

### DIFF
--- a/build_tools/github_actions/lint_whitespace_checks.sh
+++ b/build_tools/github_actions/lint_whitespace_checks.sh
@@ -40,7 +40,7 @@ if [[ $# -ne 0 ]] ; then
 fi
 
 echo "Gathering changed files..."
-mapfile -t CHANGED_FILES < <(git diff "$BASE_BRANCH" HEAD --name-only --diff-filter=d | grep -E '.*\.(cpp|h|md|mlir|sh|td|txt|ya?ml|py)$')
+mapfile -t CHANGED_FILES < <(git diff "$BASE_BRANCH" HEAD --name-only --diff-filter=d | grep -Ev '.*\.(bc|png|svg)$')
 if (( ${#CHANGED_FILES[@]} == 0 )); then
   echo "No files to check."
   exit 0

--- a/build_tools/github_actions/lint_whitespace_checks.sh
+++ b/build_tools/github_actions/lint_whitespace_checks.sh
@@ -40,7 +40,7 @@ if [[ $# -ne 0 ]] ; then
 fi
 
 echo "Gathering changed files..."
-mapfile -t CHANGED_FILES < <(git diff "$BASE_BRANCH" HEAD --name-only --diff-filter=d | grep '.*\.cpp$\|.*\.h$\|.*\.md$\|.*\.mlir$\|.*\.sh$\|.*\.td$\|.*\.txt$\|.*\.yml$\|.*\.yaml$')
+mapfile -t CHANGED_FILES < <(git diff "$BASE_BRANCH" HEAD --name-only --diff-filter=d | grep -E '.*\.(cpp|h|md|mlir|sh|td|txt|ya?ml|py)$')
 if (( ${#CHANGED_FILES[@]} == 0 )); then
   echo "No files to check."
   exit 0


### PR DESCRIPTION
The root cause of #2129 is that Python files (ending in `.py`) were excluded from the whitespace check. I originally proposed expanding the list of included files to include Python files, but @ghpvnist pointed out that there are more files that need this check than files that don't and suggested using an exclude list, so I did that instead.

Also, use `-E` and rewrite the pattern to allow the exclude list to be expanded more easily in the future.

Fixes #2129