### PR TITLE
Update `BUILD.bazel` target name

### DIFF
--- a/examples/c++/BUILD.bazel
+++ b/examples/c++/BUILD.bazel
@@ -19,7 +19,7 @@ package(
 )
 
 cc_binary(
-    name = "example-add",
+    name = "example_add",
     srcs = [
         "ExampleAdd.cpp",
     ],
@@ -33,7 +33,7 @@ cc_binary(
 )
 
 cc_test(
-    name = "example-add-test",
+    name = "example_add_test",
     srcs = [
         "ExampleAdd.cpp",
     ],


### PR DESCRIPTION
All of our build target names are snake case. The only exceptions are `stablehlo-opt`, `stablehlo-lsp-server`, and `stablehlo-translate` which were named such to follow MLIR style for passes.