### PR TITLE
Add EvalIotaOp pattern to StablehloAggressiveFolder

### DIFF
--- a/stablehlo/tests/stablehlo_aggressive_folder.mlir
+++ b/stablehlo/tests/stablehlo_aggressive_folder.mlir
@@ -1,0 +1,28 @@
+// RUN: stablehlo-opt --stablehlo-aggressive-folder --split-input-file --verify-diagnostics %s | FileCheck %s
+
+
+// CHECK-LABEL: func @eval_iota
+func.func @eval_iota() -> (tensor<3x4x5xi32>, tensor<3x4x5xi32>, tensor<3x4x5xi32>) {
+  // CHECK-NOT: stablehlo.eval_iota
+  // CHECK: [[RESULT0:%.*]] = stablehlo.constant dense<{{\[\[}}[0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]], {{\[}}[1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1]], {{\[}}[2, 2, 2, 2, 2], [2, 2, 2, 2, 2], [2, 2, 2, 2, 2], [2, 2, 2, 2, 2]]]> : tensor<3x4x5xi32>
+  // CHECK: [[RESULT1:%.*]] = stablehlo.constant dense<{{\[\[}}[0, 0, 0, 0, 0], [1, 1, 1, 1, 1], [2, 2, 2, 2, 2], [3, 3, 3, 3, 3]], {{\[}}[0, 0, 0, 0, 0], [1, 1, 1, 1, 1], [2, 2, 2, 2, 2], [3, 3, 3, 3, 3]], {{\[}}[0, 0, 0, 0, 0], [1, 1, 1, 1, 1], [2, 2, 2, 2, 2], [3, 3, 3, 3, 3]]]> : tensor<3x4x5xi32>
+  // CHECK: [[RESULT2:%.*]] = stablehlo.constant dense<{{\[\[}}[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]], {{\[}}[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]], {{\[}}[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]]]> : tensor<3x4x5xi32>
+  // CHECK: return [[RESULT0]], [[RESULT1]], [[RESULT2]]
+  %0 = stablehlo.iota dim = 0 : tensor<3x4x5xi32>
+  %1 = stablehlo.iota dim = 1 : tensor<3x4x5xi32>
+  %2 = stablehlo.iota dim = 2 : tensor<3x4x5xi32>
+  func.return %0, %1, %2 : tensor<3x4x5xi32>, tensor<3x4x5xi32>, tensor<3x4x5xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func @eval_iota_zero_dimension
+func.func @eval_iota_zero_dimension() -> (tensor<0xi32>, tensor<5x0x2xi32>) {
+  // CHECK-NOT: stablehlo.eval_iota
+  // CHECK: [[RESULT0:%.*]] = stablehlo.constant dense<> : tensor<0xi32>
+  // CHECK: [[RESULT1:%.*]] = stablehlo.constant dense<> : tensor<5x0x2xi32>
+  // CHECK: return [[RESULT0]], [[RESULT1]]
+  %0 = stablehlo.iota dim = 0 : tensor<0xi32>
+  %1 = stablehlo.iota dim = 2 : tensor<5x0x2xi32>
+  func.return %0, %1 : tensor<0xi32>, tensor<5x0x2xi32>
+}

--- a/stablehlo/tests/stablehlo_aggressive_folder.mlir
+++ b/stablehlo/tests/stablehlo_aggressive_folder.mlir
@@ -38,17 +38,3 @@ func.func @eval_iota_zero_dimension() -> (tensor<0xi32>, tensor<5x0x2xi32>) {
   %1 = stablehlo.iota dim = 2 : tensor<5x0x2xi32>
   func.return %0, %1 : tensor<0xi32>, tensor<5x0x2xi32>
 }
-
-// -----
-
-// CHECK-LABEL: func @eval_iota
-func.func @eval_iota() -> tensor<3x4x5xi32> {
-  // CHECK-NOT: stablehlo.iota
-  // CHECK: [[RESULT0:%.*]] = stablehlo.constant dense<
-  // CHECK-SAME: {{\[\[}}[0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]],
-  // CHECK-SAME: {{\[}}[1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1]],
-  // CHECK-SAME: {{\[}}[2, 2, 2, 2, 2], [2, 2, 2, 2, 2], [2, 2, 2, 2, 2], [2, 2, 2, 2, 2]]]> : tensor<3x4x5xi32>
-  // CHECK: return [[RESULT0]]
-  %0 = stablehlo.iota dim = 0 : tensor<3x4x5xi32>
-  func.return %0 : tensor<3x4x5xi32>
-}

--- a/stablehlo/tests/stablehlo_aggressive_folder.mlir
+++ b/stablehlo/tests/stablehlo_aggressive_folder.mlir
@@ -3,10 +3,22 @@
 
 // CHECK-LABEL: func @eval_iota
 func.func @eval_iota() -> (tensor<3x4x5xi32>, tensor<3x4x5xi32>, tensor<3x4x5xi32>) {
-  // CHECK-NOT: stablehlo.eval_iota
-  // CHECK: [[RESULT0:%.*]] = stablehlo.constant dense<{{\[\[}}[0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]], {{\[}}[1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1]], {{\[}}[2, 2, 2, 2, 2], [2, 2, 2, 2, 2], [2, 2, 2, 2, 2], [2, 2, 2, 2, 2]]]> : tensor<3x4x5xi32>
-  // CHECK: [[RESULT1:%.*]] = stablehlo.constant dense<{{\[\[}}[0, 0, 0, 0, 0], [1, 1, 1, 1, 1], [2, 2, 2, 2, 2], [3, 3, 3, 3, 3]], {{\[}}[0, 0, 0, 0, 0], [1, 1, 1, 1, 1], [2, 2, 2, 2, 2], [3, 3, 3, 3, 3]], {{\[}}[0, 0, 0, 0, 0], [1, 1, 1, 1, 1], [2, 2, 2, 2, 2], [3, 3, 3, 3, 3]]]> : tensor<3x4x5xi32>
-  // CHECK: [[RESULT2:%.*]] = stablehlo.constant dense<{{\[\[}}[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]], {{\[}}[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]], {{\[}}[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]]]> : tensor<3x4x5xi32>
+  // CHECK-NOT: stablehlo.iota
+  // CHECK: [[RESULT0:%.*]] = stablehlo.constant dense<
+  // CHECK-SAME: {{\[\[}}[0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]],
+  // CHECK-SAME: {{\[}}[1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1]],
+  // CHECK-SAME: {{\[}}[2, 2, 2, 2, 2], [2, 2, 2, 2, 2], [2, 2, 2, 2, 2], [2, 2, 2, 2, 2]]]> : tensor<3x4x5xi32>
+
+  // CHECK: [[RESULT1:%.*]] = stablehlo.constant dense<
+  // CHECK-SAME: {{\[\[}}[0, 0, 0, 0, 0], [1, 1, 1, 1, 1], [2, 2, 2, 2, 2], [3, 3, 3, 3, 3]],
+  // CHECK-SAME: {{\[}}[0, 0, 0, 0, 0], [1, 1, 1, 1, 1], [2, 2, 2, 2, 2], [3, 3, 3, 3, 3]],
+  // CHECK-SAME: {{\[}}[0, 0, 0, 0, 0], [1, 1, 1, 1, 1], [2, 2, 2, 2, 2], [3, 3, 3, 3, 3]]]> : tensor<3x4x5xi32>
+
+  // CHECK: [[RESULT2:%.*]] = stablehlo.constant dense<
+  // CHECK-SAME: {{\[\[}}[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
+  // CHECK-SAME: {{\[}}[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]],
+  // CHECk-SAME: {{\[}}[0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4], [0, 1, 2, 3, 4]]]> : tensor<3x4x5xi32>
+
   // CHECK: return [[RESULT0]], [[RESULT1]], [[RESULT2]]
   %0 = stablehlo.iota dim = 0 : tensor<3x4x5xi32>
   %1 = stablehlo.iota dim = 1 : tensor<3x4x5xi32>
@@ -18,11 +30,25 @@ func.func @eval_iota() -> (tensor<3x4x5xi32>, tensor<3x4x5xi32>, tensor<3x4x5xi3
 
 // CHECK-LABEL: func @eval_iota_zero_dimension
 func.func @eval_iota_zero_dimension() -> (tensor<0xi32>, tensor<5x0x2xi32>) {
-  // CHECK-NOT: stablehlo.eval_iota
+  // CHECK-NOT: stablehlo.iota
   // CHECK: [[RESULT0:%.*]] = stablehlo.constant dense<> : tensor<0xi32>
   // CHECK: [[RESULT1:%.*]] = stablehlo.constant dense<> : tensor<5x0x2xi32>
   // CHECK: return [[RESULT0]], [[RESULT1]]
   %0 = stablehlo.iota dim = 0 : tensor<0xi32>
   %1 = stablehlo.iota dim = 2 : tensor<5x0x2xi32>
   func.return %0, %1 : tensor<0xi32>, tensor<5x0x2xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func @eval_iota
+func.func @eval_iota() -> tensor<3x4x5xi32> {
+  // CHECK-NOT: stablehlo.iota
+  // CHECK: [[RESULT0:%.*]] = stablehlo.constant dense<
+  // CHECK-SAME: {{\[\[}}[0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]],
+  // CHECK-SAME: {{\[}}[1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1], [1, 1, 1, 1, 1]],
+  // CHECK-SAME: {{\[}}[2, 2, 2, 2, 2], [2, 2, 2, 2, 2], [2, 2, 2, 2, 2], [2, 2, 2, 2, 2]]]> : tensor<3x4x5xi32>
+  // CHECK: return [[RESULT0]]
+  %0 = stablehlo.iota dim = 0 : tensor<3x4x5xi32>
+  func.return %0 : tensor<3x4x5xi32>
 }

--- a/stablehlo/transforms/StablehloAggressiveFolder.cpp
+++ b/stablehlo/transforms/StablehloAggressiveFolder.cpp
@@ -490,6 +490,12 @@ struct EvalIotaOpPattern : public OpRewritePattern<IotaOp> {
     llvm::SmallVector<APInt> values;
     values.reserve(outputSize);
 
+    if (outputSize == 0) {
+      rewriter.replaceOpWithNewOp<ConstantOp>(
+          op, DenseIntElementsAttr::get(resultType, values));
+      return success();
+    }
+
     int64_t sequences = 1;
     int64_t sequenceMax = resultType.getDimSize(dimension);
     int64_t elementRepetitions = 1;

--- a/stablehlo/transforms/StablehloAggressiveFolder.cpp
+++ b/stablehlo/transforms/StablehloAggressiveFolder.cpp
@@ -477,15 +477,15 @@ struct EvalIotaOpPattern : public OpRewritePattern<IotaOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(IotaOp op,
                                 PatternRewriter& rewriter) const override {
-    auto resultType = op.getType().cast<RankedTensorType>();
+    auto resultType = cast<RankedTensorType>(op.getType());
     auto elementType = resultType.getElementType();
 
     if (!elementType.isInteger())
       return rewriter.notifyMatchFailure(op, "expected integer result type");
 
     auto outputSize = resultType.getNumElements();
-    auto dimension = op.getIotaDimension();
     auto resultBitWidth = elementType.getIntOrFloatBitWidth();
+    int64_t dimension = op.getIotaDimension();
 
     llvm::SmallVector<APInt> values;
     values.reserve(outputSize);
@@ -493,7 +493,7 @@ struct EvalIotaOpPattern : public OpRewritePattern<IotaOp> {
     int64_t sequences = 1;
     int64_t sequenceMax = resultType.getDimSize(dimension);
     int64_t elementRepetitions = 1;
-    for (uint64_t i = 0; i < resultType.getShape().size(); i++) {
+    for (int64_t i = 0; i < resultType.getRank(); i++) {
       sequences *= i < dimension ? resultType.getDimSize(i) : 1;
       elementRepetitions *= i > dimension ? resultType.getDimSize(i) : 1;
     }


### PR DESCRIPTION
This PR adds support of IotaOp specialization:

```
func.func @eval_iota() -> tensor<3x4x5xi32> {
  %1 = stablehlo.iota dim = 1 : tensor<3x4x5xi32>
  func.return %1 : tensor<3x4x5xi32>
}
```
is transformed into:
```
func.func @eval_iota() -> tensor<3x4x5xi32> {
  %0 = stablehlo.constant dense<
            [[[0, 0, 0, 0, 0], [1, 1, 1, 1, 1], [2, 2, 2, 2, 2], [3, 3, 3, 3, 3]],
             [[0, 0, 0, 0, 0], [1, 1, 1, 1, 1], [2, 2, 2, 2, 2], [3, 3, 3, 3, 3]],
             [[0, 0, 0, 0, 0], [1, 1, 1, 1, 1], [2, 2, 2, 2, 2], [3, 3, 3, 3, 3]]]> : tensor<3x4x5xi32>
  func.return %0 : tensor<3x4x5xi32>
}
```