### PR TITLE
Delete rank_specialization_cluster ops

### DIFF
--- a/stablehlo/dialect/ChloOps.td
+++ b/stablehlo/dialect/ChloOps.td
@@ -882,59 +882,6 @@ def CHLO_MinimumBroadcastShapesOp :
   let hasVerifier = 1;
 }
 
-def CHLO_RankSpecializationClusterOp
-    : CHLO_Op<"rank_specialization_cluster", [
-    DeclareOpInterfaceMethods<RegionBranchOpInterface>,
-    SingleBlockImplicitTerminator<"RankSpecializationClusterYieldOp">,
-    RecursiveMemoryEffects]> {
-
-  let summary = "Cluster of operations that will be rank-specialized together.";
-
-  let description = [{
-    Groups compatible element-wise operatons together so that they can be
-    rank-specialized together. The operation takes and yields a variadic number
-    of (unranked) tensor operands. Its body region holds one block with one
-    block argument per input tensor of the same type. All operations in this
-    block must only operate on these block arguments. Results are returned
-    through the `rank_specialization_cluster_yield` operation.
-
-    Example:
-
-    ```
-    %0 = "chlo.rank_specialization_cluster"(%arg0, %arg1, %arg2) ({
-    ^bb0(%arg0_ : tensor<*xf32>, %arg1_ : tensor<*xf32>, %arg2_ : tensor<*xf32>):
-      %1 = chlo.broadcast_multiply %arg0_, %arg1_
-          : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-      %2 = chlo.broadcast_add %1, %arg2_
-          : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-      "chlo.rank_specialization_cluster_yield"(%2) : (tensor<*xf32>) -> ()
-    }) : (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-    ```
-  }];
-
-  let arguments = (ins Variadic<HLO_AnyTensor>);
-  let results = (outs Variadic<HLO_AnyTensor>);
-  let regions = (region SizedRegion<1>:$body);
-
-  let hasVerifier = 1;
-}
-
-def CHLO_RankSpecializationClusterYieldOp
-    : CHLO_Op<"rank_specialization_cluster_yield", [Pure,
-    ReturnLike, Terminator, HasParent<"RankSpecializationClusterOp">]> {
-
-  let summary = "Yield operation for `rank_specialization_cluster`";
-  let description = [{
-    This operation yields the results from within the
-    `chlo.rank_specialization_cluster` operation's region. The operation takes
-    an arbitrary number of operands and produces no results. The operand number
-    and types must match the number and types of the parent
-    `rank_specialization_cluster` operation's results.
-  }];
-
-  let arguments = (ins Variadic<HLO_AnyTensor>:$results);
-}
-
 def CHLO_DynamicReshapeOp: CHLO_Op<"dynamic_reshape", [Pure,
     DeclareOpInterfaceMethods<InferShapedTypeOpInterface>]> {
   let summary = "Reshape a tensor to a given, possibly dynamic, shape.";

--- a/stablehlo/tests/ops_chlo.mlir
+++ b/stablehlo/tests/ops_chlo.mlir
@@ -100,61 +100,6 @@ func.func @minimum_broadcast_shapes_one_operand(%arg: tensor<?xindex>) {
 
 // -----
 
-func.func @rank_specialization_cluster(%arg0 : tensor<*xf32>, %arg1 : tensor<*xf32>,
-    %arg2 : tensor<*xf32>) -> tensor<*xf32> {
-  %0 = "chlo.rank_specialization_cluster"(%arg0, %arg1, %arg2) ({
-  ^bb0(%arg0_ : tensor<*xf32>, %arg1_ : tensor<*xf32>, %arg2_ : tensor<*xf32>):
-    %1 = chlo.broadcast_multiply %arg0_, %arg1_
-        : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-    %2 = chlo.broadcast_add %1, %arg2_
-        : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-    "chlo.rank_specialization_cluster_yield"(%2) : (tensor<*xf32>) -> ()
-  }) : (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return %0 : tensor<*xf32>
-}
-
-// -----
-
-func.func @rank_specialization_cluster(%arg0 : tensor<*xf32>,
-    %arg1 : tensor<*xf32>) -> tensor<*xf32> {
-  // expected-error @+1{{source has 2 operands, but target successor needs 1}}
-  %0 = "chlo.rank_specialization_cluster"(%arg0, %arg1) ({
-  ^bb0(%arg0_ : tensor<*xf32>, %arg1_ : tensor<*xf32>):
-    "chlo.rank_specialization_cluster_yield"(%arg0_, %arg1_)
-        : (tensor<*xf32>, tensor<*xf32>) -> ()
-  }) : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return %0 : tensor<*xf32>
-}
-
-// -----
-
-func.func @rank_specialization_cluster(%arg0 : tensor<*xf32>) -> tensor<*xf32> {
-  // expected-error @+1{{block argument types must match operand types}}
-  %0 = "chlo.rank_specialization_cluster"(%arg0) ({
-  ^bb0(%arg0_ : tensor<*xf32>, %arg1_ : tensor<*xf32>):
-    "chlo.rank_specialization_cluster_yield"(%arg0_) : (tensor<*xf32>) -> ()
-  }) : (tensor<*xf32>) -> tensor<*xf32>
-  func.return %0 : tensor<*xf32>
-}
-
-// -----
-
-func.func @rank_specialization_cluster(%arg0 : tensor<*xf32>, %arg1 : tensor<*xf32>,
-    %arg2 : tensor<*xf32>) -> tensor<*xf32> {
-  // expected-error @+1{{nested ops must not depend on implicit operands}}
-  %0 = "chlo.rank_specialization_cluster"(%arg0, %arg1, %arg2) ({
-  ^bb0(%arg0_ : tensor<*xf32>, %arg1_ : tensor<*xf32>, %arg2_ : tensor<*xf32>):
-    %1 = chlo.broadcast_multiply %arg0_, %arg1_
-        : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-    %2 = chlo.broadcast_add %1, %arg2
-        : (tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-    "chlo.rank_specialization_cluster_yield"(%2) : (tensor<*xf32>) -> ()
-  }) : (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return %0 : tensor<*xf32>
-}
-
-// -----
-
 func.func @top_k(%arg0 : tensor<f32>) {
   // expected-error @+2 {{failed to infer returned types}}
   // @expected-error @+1{{operand's rank must be at least 1}}

--- a/stablehlo/tests/ops_chlo_roundtrip.mlir
+++ b/stablehlo/tests/ops_chlo_roundtrip.mlir
@@ -417,24 +417,6 @@ func.func @chlo_reshape_dynamic(%arg0: tensor<?xf32>, %arg1: tensor<2xi32>) -> t
   func.return %0 : tensor<?x?xf32>
 }
 
-// CHECK-LABEL:  func @chlo_rank_specialization_cluster
-// CHECK-SAME:   %[[A0:.*0]]: tensor<*xf32>,
-// CHECK-SAME:   %[[A1:.*1]]: tensor<*xf32>,
-// CHECK-SAME:   %[[A2:.*2]]: tensor<*xf32>)
-// CHECK-NEXT:   %[[T:.*]] = "chlo.rank_specialization_cluster"(%[[A0]], %[[A1]], %[[A2]])
-// CHECK:        ^bb0(%[[A3:.*]]: tensor<*xf32>, %[[A4:.*]]: tensor<*xf32>, %[[A5:.*]]: tensor<*xf32>):
-// CHECK:          "chlo.rank_specialization_cluster_yield"(%[[A3]]) : (tensor<*xf32>) -> ()
-// CHECK:        }) : (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-// CHECK:        return %[[T]] : tensor<*xf32>
-func.func @chlo_rank_specialization_cluster(%arg0 : tensor<*xf32>, %arg1 : tensor<*xf32>,
-    %arg2 : tensor<*xf32>) -> tensor<*xf32> {
-  %0 = "chlo.rank_specialization_cluster"(%arg0, %arg1, %arg2) ({
-  ^bb0(%arg0_ : tensor<*xf32>, %arg1_ : tensor<*xf32>, %arg2_ : tensor<*xf32>):
-    "chlo.rank_specialization_cluster_yield"(%arg0_) : (tensor<*xf32>) -> ()
-  }) : (tensor<*xf32>, tensor<*xf32>, tensor<*xf32>) -> tensor<*xf32>
-  func.return %0 : tensor<*xf32>
-}
-
 // CHECK-LABEL:  func @chlo_erf_inv
 // CHECK-SAME:   %[[A0:.*0]]: tensor<16x16xf32>)
 // CHECK:          chlo.erf_inv %[[A0]] : tensor<16x16xf32> -> tensor<16x16xf32>


### PR DESCRIPTION
(P1) of the Dynamism RFC.

These ops are no longer used by KernelGen and can safely be deleted.