### PR TITLE
Add spec warning about shape mismatches

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -6263,13 +6263,13 @@ future ([#1157](https://github.com/openxla/stablehlo/issues/1157)).
 #### Shape mismatches
 
 StableHLO supports dynamically-shaped tensors. However, shapes have to agree at
-runtime, otherwise the behavior is implementation-defined. StableHLO does not
-explicitly provide an op that can assert that a tensor has a given shape at
-runtime. Generating correct code is the responsibility of the producer.
+runtime, otherwise the behavior is undefined. StableHLO does not explicitly
+provide an op that can assert that a tensor has a given shape at runtime.
+Generating correct code is the responsibility of the producer.
 
 As a specific example, the below program is valid. However, at runtime, the
 exact shapes of `%arg0` and `%arg1` will have to be the same, otherwise the
-result is unspecified:
+behavior of the program is undefined:
 
 ```
 func.func @foo(%arg0: tensor<?xi32>, %arg1: tensor<?xi32>) -> tensor<?xi32> {

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -6271,7 +6271,7 @@ As a specific example, the below program is valid. However, at runtime, the
 exact shapes of `%arg0` and `%arg1` will have to be the same, otherwise the
 behavior of the program is undefined:
 
-```
+```mlir
 func.func @foo(%arg0: tensor<?xi32>, %arg1: tensor<?xi32>) -> tensor<?xi32> {
     %0 = stablehlo.add %arg0, %arg1 : tensor<?xi32>
     return %0 : tensor<?xi32>

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -6276,7 +6276,7 @@ func.func @foo(%arg0: tensor<?xi32>, %arg1: tensor<?xi32>) -> tensor<?xi32> {
     %0 = stablehlo.add %arg0, %arg1 : tensor<?xi32>
     return %0 : tensor<?xi32>
 }
-``
+```
 
 #### Floating-point exceptions
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -6260,6 +6260,26 @@ out-of-bounds accesses, etc. Unless explicitly called out, all these errors
 result in implementation-defined behavior, but this may change in the
 future ([#1157](https://github.com/openxla/stablehlo/issues/1157)).
 
+#### Shape mismatches
+
+StableHLO supports dynamically-shaped tensors. However, shapes have to agree at
+runtime, otherwise the behavior is implementation-defined. StableHLO does not
+explicitly provide an op that can assert that a tensor has a given shape at
+runtime. Generating correct code is the responsibility of the producer.
+
+As a specific example, the below program is valid. However, at runtime, the
+exact shapes of `%arg0` and `%arg1` will have to be the same, otherwise the
+result is unspecified:
+
+```
+func.func @foo(%arg0: tensor<?xi32>, %arg1: tensor<?xi32>) -> tensor<?xi32> {
+    %0 = stablehlo.add %arg0, %arg1 : tensor<?xi32>
+    return %0 : tensor<?xi32>
+}
+``
+
+#### Floating-point exceptions
+
 As an exception to this rule, floating-point exceptions in StableHLO programs
 have well-defined behavior. Operations which result in exceptions defined by the
 IEEE-754 standard (invalid operation, division-by-zero, overflow, underflow, or

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -6260,6 +6260,17 @@ out-of-bounds accesses, etc. Unless explicitly called out, all these errors
 result in implementation-defined behavior, but this may change in the
 future ([#1157](https://github.com/openxla/stablehlo/issues/1157)).
 
+#### Floating-point exceptions
+
+As an exception to this rule, floating-point exceptions in StableHLO programs
+have well-defined behavior. Operations which result in exceptions defined by the
+IEEE-754 standard (invalid operation, division-by-zero, overflow, underflow, or
+inexact exceptions) produce default results (as defined in the standard) and
+continue execution without raising the corresponding status flag; similar to
+`raiseNoFlag` exception handling from the standard. Exceptions for nonstandard
+operations (e.g. complex arithmetic and certain transcendental functions) are
+implementation-defined.
+
 #### Shape mismatches
 
 StableHLO supports dynamically-shaped tensors. However, shapes have to agree at
@@ -6277,17 +6288,6 @@ func.func @foo(%arg0: tensor<?xi32>, %arg1: tensor<?xi32>) -> tensor<?xi32> {
     return %0 : tensor<?xi32>
 }
 ```
-
-#### Floating-point exceptions
-
-As an exception to this rule, floating-point exceptions in StableHLO programs
-have well-defined behavior. Operations which result in exceptions defined by the
-IEEE-754 standard (invalid operation, division-by-zero, overflow, underflow, or
-inexact exceptions) produce default results (as defined in the standard) and
-continue execution without raising the corresponding status flag; similar to
-`raiseNoFlag` exception handling from the standard. Exceptions for nonstandard
-operations (e.g. complex arithmetic and certain transcendental functions) are
-implementation-defined.
 
 ## Notation
 


### PR DESCRIPTION
This implements part 1 of (P2) from the Dynamism 101 RFC: https://github.com/openxla/stablehlo/blob/main/rfcs/20230704-dynamism-101.md#-p2-ratify-the-existing-convention-for-shape-mismatches-constituting-undefined-behavior

In a future change, I will implement `ConditionallySpeculatable` where relevant. Many ops have the `Pure` trait but they are not actually `Pure` in all cases because shape mismatches are undefined behavior.

#1991 