### PR TITLE
Use long form volume flag for docker run

### DIFF
--- a/build_tools/github_actions/lint_markdown.sh
+++ b/build_tools/github_actions/lint_markdown.sh
@@ -47,6 +47,6 @@ then
 fi
 
 # Run markdownlint-cli in Docker to avoid node versioning issues
-docker run -v "$STABLEHLO_ROOT_DIR:/workdir" \
+docker run --volume "$STABLEHLO_ROOT_DIR:/workdir" \
     ghcr.io/igorshubovych/markdownlint-cli:v0.32.2 \
     --config $CONFIG "$@"


### PR DESCRIPTION
I haven't used docker in a while, so I forgot what -v meant. In general, it is a good idea to use long form flag names in shell scripts for readability.