### PR TITLE
Remove redundant static result shape check on reshape

### DIFF
--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -3858,8 +3858,6 @@ LogicalResult verifyReshapeOp(std::optional<Location> location, Value operand,
   // If the operand type is statically shaped (not required) the number of
   // elements must match that of the result type.
   auto resultTy = result.getType().cast<RankedTensorType>();
-  assert(resultTy && resultTy.hasStaticShape() &&
-         "result type must be statically shaped");
   int64_t numResultElements = resultTy.getNumElements();
   int64_t numOperandElements = operandTy.getNumElements();
   if (numResultElements != numOperandElements)


### PR DESCRIPTION
The check is already enforced by the [tablegen declaration](https://github.com/openxla/stablehlo/blob/f392f5fcae12ef445e18eef921720b3313336c38/stablehlo/dialect/StablehloOps.td#L2514) 