### PR TITLE
Implement ConditionallySpeculatable for all UnaryElementwise ops

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -51,6 +51,7 @@ cc_library(
         "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:QuantOps",
         "@llvm-project//mlir:ShapeDialect",
+        "@llvm-project//mlir:SideEffectInterfaces",
         "@llvm-project//mlir:Support",
     ],
 )

--- a/stablehlo/dialect/Base.td
+++ b/stablehlo/dialect/Base.td
@@ -18,6 +18,7 @@ limitations under the License.
 #define STABLEHLO_DIALECT_BASE
 
 include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/OpBase.td"
 
@@ -319,5 +320,11 @@ def HLO_BoundedAttrInterface : AttrInterface<"BoundedAttrInterface"> {
     "::llvm::ArrayRef<int64_t>", "getBounds"
   >];
 }
+
+def HLO_UnaryElementwiseSpeculatableImplTrait
+  : HLO_NativeOpTrait<"UnaryElementwiseSpeculatableImplTrait">;
+
+def HLO_UnaryElementwiseSpeculatable : TraitList<[
+    ConditionallySpeculatable, HLO_UnaryElementwiseSpeculatableImplTrait]>;
 
 #endif // STABLEHLO_DIALECT_BASE

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -179,7 +179,7 @@ def StableHLO_CreateTokenOp : StableHLO_Op<"create_token", [Pure,
 
 class StableHLO_UnaryElementwiseOp<string mnemonic, list<Trait> traits,
     Type OperandType, Type ResultType = OperandType> : StableHLO_Op<mnemonic, traits # [Elementwise,
-    InferShapedTypeOpInterface, SameOperandsAndResultShape]> {
+    InferShapedTypeOpInterface, SameOperandsAndResultShape, HLO_UnaryElementwiseSpeculatable, NoMemoryEffect]> {
   let arguments = (ins OperandType:$operand);
   let results = (outs ResultType:$result);
   let extraClassDeclaration = commonClassDeclaration # [{
@@ -199,7 +199,7 @@ class StableHLO_UnaryElementwiseOp<string mnemonic, list<Trait> traits,
 
 // Abs supports complex to real, so element type is not guaranteed to match.
 def StableHLO_AbsOp: StableHLO_UnaryElementwiseOp<"abs",
-    [Pure, DeclareOpInterfaceMethods<InferTypeOpInterface>],
+    [DeclareOpInterfaceMethods<InferTypeOpInterface>],
      RankedTensorOf<[HLO_SInt, HLO_Float, HLO_Complex, HLO_QuantizedInt] /* abs_i1 */>,
      RankedTensorOf<[HLO_SInt, HLO_Float, HLO_QuantizedInt]>> {
   let summary = "Abs operation";
@@ -218,7 +218,7 @@ def StableHLO_AbsOp: StableHLO_UnaryElementwiseOp<"abs",
 }
 
 def StableHLO_CbrtOp: StableHLO_UnaryElementwiseOp<"cbrt",
-    [Pure, HLO_CompatibleOperandsAndResultType /*cbrt_c1*/],
+    [HLO_CompatibleOperandsAndResultType /*cbrt_c1*/],
     HLO_FpComplexOrQuantizedIntTensor /*cbrt_i1*/> { /*cbrt_c1*/
   let summary = "Cbrt operation";
   let description = [{
@@ -236,7 +236,7 @@ def StableHLO_CbrtOp: StableHLO_UnaryElementwiseOp<"cbrt",
 }
 
 def StableHLO_CeilOp: StableHLO_UnaryElementwiseOp<"ceil",
-    [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpOrQuantizedIntTensor> {
+    [HLO_CompatibleOperandsAndResultType], HLO_FpOrQuantizedIntTensor> {
   let summary = "Ceil operation";
   let description = [{
     Performs element-wise ceil of `operand` tensor and produces a `result` tensor.
@@ -252,7 +252,7 @@ def StableHLO_CeilOp: StableHLO_UnaryElementwiseOp<"ceil",
 }
 
 def StableHLO_ConvertOp : StableHLO_UnaryElementwiseOp<"convert",
-    [Pure, SameOperandsAndResultShape /*convert_c1*/], HLO_NonQuantizedTensor> { /*convert_i1*/
+    [SameOperandsAndResultShape /*convert_c1*/], HLO_NonQuantizedTensor> { /*convert_i1*/
   let summary = "Convert operation";
   let description = [{
     Performs an element-wise conversion from one element type to another on
@@ -271,7 +271,7 @@ def StableHLO_ConvertOp : StableHLO_UnaryElementwiseOp<"convert",
 }
 
 def StableHLO_ClzOp: StableHLO_UnaryElementwiseOp<"count_leading_zeros",
-    [Pure, HLO_CompatibleOperandsAndResultType /*count_leading_zeros_c1*/],
+    [HLO_CompatibleOperandsAndResultType /*count_leading_zeros_c1*/],
      HLO_IntTensor /*count_leading_zeros_i1*/> { /*count_leading_zeros_c1*/
   let summary = "Clz operation";
   let description = [{
@@ -289,7 +289,7 @@ def StableHLO_ClzOp: StableHLO_UnaryElementwiseOp<"count_leading_zeros",
 }
 
 def StableHLO_CosineOp: StableHLO_UnaryElementwiseOp<"cosine",
-    [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpComplexOrQuantizedIntTensor> {
+    [HLO_CompatibleOperandsAndResultType], HLO_FpComplexOrQuantizedIntTensor> {
   let summary = "Cosine operation";
   let description = [{
     Performs element-wise cosine operation on `operand` tensor and produces a
@@ -306,7 +306,7 @@ def StableHLO_CosineOp: StableHLO_UnaryElementwiseOp<"cosine",
 }
 
 def StableHLO_ExpOp: StableHLO_UnaryElementwiseOp<"exponential",
-    [Pure, HLO_CompatibleOperandsAndResultType /*exponential_c1*/],
+    [HLO_CompatibleOperandsAndResultType /*exponential_c1*/],
      HLO_FpComplexOrQuantizedIntTensor /*exponential_i1*/> {
   let summary = "Exp operation";
   let description = [{
@@ -324,7 +324,7 @@ def StableHLO_ExpOp: StableHLO_UnaryElementwiseOp<"exponential",
 }
 
 def StableHLO_Expm1Op: StableHLO_UnaryElementwiseOp<"exponential_minus_one",
-    [Pure, HLO_CompatibleOperandsAndResultType], /*exponential_minus_one_c1*/
+    [HLO_CompatibleOperandsAndResultType], /*exponential_minus_one_c1*/
     HLO_FpComplexOrQuantizedIntTensor /*exponential_minus_one_i1*/> { /*exponential_minus_one_c1*/
   let summary = "Expm1 operation";
   let description = [{
@@ -342,7 +342,7 @@ def StableHLO_Expm1Op: StableHLO_UnaryElementwiseOp<"exponential_minus_one",
 }
 
 def StableHLO_FloorOp: StableHLO_UnaryElementwiseOp<"floor",
-    [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpOrQuantizedIntTensor> {
+    [HLO_CompatibleOperandsAndResultType], HLO_FpOrQuantizedIntTensor> {
   let summary = "Floor operation";
   let description = [{
     Performs element-wise floor of `operand` tensor and produces a `result`
@@ -359,7 +359,7 @@ def StableHLO_FloorOp: StableHLO_UnaryElementwiseOp<"floor",
 }
 
 def StableHLO_ImagOp: StableHLO_UnaryElementwiseOp<"imag",
-    [Pure, DeclareOpInterfaceMethods<InferTypeOpInterface>],
+    [DeclareOpInterfaceMethods<InferTypeOpInterface>],
     HLO_FpOrComplexTensor /*imag_i1*/, HLO_FpTensor> {/*imag_c1*/
   let summary = "Imag operation";
   let description = [{
@@ -376,8 +376,8 @@ def StableHLO_ImagOp: StableHLO_UnaryElementwiseOp<"imag",
   }];
 }
 
-def StableHLO_IsFiniteOp: StableHLO_UnaryElementwiseOp<"is_finite", [Pure,
-    DeclareOpInterfaceMethods<InferTypeOpInterface>], HLO_FpOrQuantizedIntTensor> {
+def StableHLO_IsFiniteOp: StableHLO_UnaryElementwiseOp<"is_finite",
+    [DeclareOpInterfaceMethods<InferTypeOpInterface>], HLO_FpOrQuantizedIntTensor> {
     /*is_finite_c1*/
   let summary = "IsFinite operation";
   let description = [{
@@ -401,7 +401,7 @@ def StableHLO_IsFiniteOp: StableHLO_UnaryElementwiseOp<"is_finite", [Pure,
 }
 
 def StableHLO_LogOp: StableHLO_UnaryElementwiseOp<"log",
-    [Pure, HLO_CompatibleOperandsAndResultType /*log_c1*/],
+    [HLO_CompatibleOperandsAndResultType /*log_c1*/],
      HLO_FpComplexOrQuantizedIntTensor /*log_i1*/> {
   let summary = "Log operation";
   let description = [{
@@ -419,7 +419,7 @@ def StableHLO_LogOp: StableHLO_UnaryElementwiseOp<"log",
 }
 
 def StableHLO_Log1pOp: StableHLO_UnaryElementwiseOp<"log_plus_one",
-    [Pure, HLO_CompatibleOperandsAndResultType /*log_plus_one_c1*/],
+    [HLO_CompatibleOperandsAndResultType /*log_plus_one_c1*/],
     HLO_FpComplexOrQuantizedIntTensor /*log_plus_one_i1*/> { /*log_plus_one_c1*/
   let summary = "Log1p operation";
   let description = [{
@@ -437,7 +437,7 @@ def StableHLO_Log1pOp: StableHLO_UnaryElementwiseOp<"log_plus_one",
 }
 
 def StableHLO_LogisticOp: StableHLO_UnaryElementwiseOp<"logistic",
-    [Pure, HLO_CompatibleOperandsAndResultType /*logistic_c1*/],
+    [HLO_CompatibleOperandsAndResultType /*logistic_c1*/],
     HLO_FpComplexOrQuantizedIntTensor /*logistic_i1*/> { /*logistic_c1*/
   let summary = "Logistic operation";
   let description = [{
@@ -455,7 +455,7 @@ def StableHLO_LogisticOp: StableHLO_UnaryElementwiseOp<"logistic",
 }
 
 def StableHLO_NotOp: StableHLO_UnaryElementwiseOp<"not",
-    [Pure, HLO_CompatibleOperandsAndResultType], HLO_PredOrIntTensor> {
+    [HLO_CompatibleOperandsAndResultType], HLO_PredOrIntTensor> {
   let summary = "Not operation";
   let description = [{
     Performs element-wise NOT of tensor `operand` of type integer and produces
@@ -472,7 +472,7 @@ def StableHLO_NotOp: StableHLO_UnaryElementwiseOp<"not",
 }
 
 def StableHLO_NegOp: StableHLO_UnaryElementwiseOp<"negate",
-    [Pure, HLO_CompatibleOperandsAndResultType], HLO_IntFpOrComplexOrQuantizedIntTensor> {
+    [HLO_CompatibleOperandsAndResultType], HLO_IntFpOrComplexOrQuantizedIntTensor> {
   let summary = "Neg operation";
   let description = [{
     Performs element-wise negation of `operand` tensor and produces a `result`
@@ -489,7 +489,7 @@ def StableHLO_NegOp: StableHLO_UnaryElementwiseOp<"negate",
 }
 
 def StableHLO_PopulationCountOp: StableHLO_UnaryElementwiseOp<"popcnt",
-    [Pure, HLO_CompatibleOperandsAndResultType /*popcnt_c1*/],
+    [HLO_CompatibleOperandsAndResultType /*popcnt_c1*/],
     HLO_IntTensor /*popcnt_i1*/> { /*popcnt_c1*/
   let summary = "PopulationCount operation";
   let description = [{
@@ -507,7 +507,7 @@ def StableHLO_PopulationCountOp: StableHLO_UnaryElementwiseOp<"popcnt",
 }
 
 def StableHLO_RealOp: StableHLO_UnaryElementwiseOp<"real",
-    [Pure, DeclareOpInterfaceMethods<InferTypeOpInterface>],
+    [DeclareOpInterfaceMethods<InferTypeOpInterface>],
     HLO_FpOrComplexTensor /*real_i1*/, HLO_FpTensor> {/*real_c1*/
   let summary = "Real operation";
   let description = [{
@@ -525,7 +525,7 @@ def StableHLO_RealOp: StableHLO_UnaryElementwiseOp<"real",
 }
 
 def StableHLO_RoundOp: StableHLO_UnaryElementwiseOp<"round_nearest_afz",
-    [Pure, HLO_CompatibleOperandsAndResultType /*round_nearest_afz_c1*/],
+    [HLO_CompatibleOperandsAndResultType /*round_nearest_afz_c1*/],
     HLO_FpOrQuantizedIntTensor /*round_nearest_afz_i1*/> { /*round_nearest_afz_c1*/
   let summary = "Round operation";
   let description = [{
@@ -543,7 +543,7 @@ def StableHLO_RoundOp: StableHLO_UnaryElementwiseOp<"round_nearest_afz",
 }
 
 def StableHLO_RoundNearestEvenOp: StableHLO_UnaryElementwiseOp<"round_nearest_even",
-    [Pure, HLO_CompatibleOperandsAndResultType /*round_nearest_even_c1*/],
+    [HLO_CompatibleOperandsAndResultType /*round_nearest_even_c1*/],
     HLO_FpOrQuantizedIntTensor /*round_nearest_even_i1*/> { /*round_nearest_even_c1*/
   let summary = "RoundNearestEven operation";
   let description = [{
@@ -561,8 +561,8 @@ def StableHLO_RoundNearestEvenOp: StableHLO_UnaryElementwiseOp<"round_nearest_ev
   }];
 }
 
-def StableHLO_RsqrtOp: StableHLO_UnaryElementwiseOp<"rsqrt", [Pure,
-    HLO_CompatibleOperandsAndResultType /* rsqrt_c1 */],
+def StableHLO_RsqrtOp: StableHLO_UnaryElementwiseOp<"rsqrt",
+    [HLO_CompatibleOperandsAndResultType /* rsqrt_c1 */],
     HLO_FpComplexOrQuantizedIntTensor /* rsqrt_i1 */> {
   let summary = "Rsqrt operation";
   let description = [{
@@ -581,7 +581,7 @@ def StableHLO_RsqrtOp: StableHLO_UnaryElementwiseOp<"rsqrt", [Pure,
 }
 
 def StableHLO_SignOp: StableHLO_UnaryElementwiseOp<"sign",
-    [Pure, HLO_CompatibleOperandsAndResultType /*sign_c1*/],
+    [HLO_CompatibleOperandsAndResultType /*sign_c1*/],
     RankedTensorOf<[HLO_SInt, HLO_Float, HLO_Complex, HLO_QuantizedInt]> /*sign_i1*/> { /*sign_c1*/
   let summary = "Sign operation";
   let description = [{
@@ -599,7 +599,7 @@ def StableHLO_SignOp: StableHLO_UnaryElementwiseOp<"sign",
 }
 
 def StableHLO_SineOp: StableHLO_UnaryElementwiseOp<"sine",
-    [Pure, HLO_CompatibleOperandsAndResultType], HLO_FpComplexOrQuantizedIntTensor> {
+    [HLO_CompatibleOperandsAndResultType], HLO_FpComplexOrQuantizedIntTensor> {
   let summary = "Sine operation";
   let description = [{
     Performs element-wise sine operation on `operand` tensor and produces a
@@ -615,8 +615,8 @@ def StableHLO_SineOp: StableHLO_UnaryElementwiseOp<"sine",
   }];
 }
 
-def StableHLO_SqrtOp: StableHLO_UnaryElementwiseOp<"sqrt", [Pure,
-    HLO_CompatibleOperandsAndResultType /* sqrt_c1 */],
+def StableHLO_SqrtOp: StableHLO_UnaryElementwiseOp<"sqrt",
+    [HLO_CompatibleOperandsAndResultType /* sqrt_c1 */],
     HLO_FpComplexOrQuantizedIntTensor /* sqrt_i1 */> {
   let summary = "Sqrt operation";
   let description = [{
@@ -634,7 +634,7 @@ def StableHLO_SqrtOp: StableHLO_UnaryElementwiseOp<"sqrt", [Pure,
 }
 
 def StableHLO_TanhOp: StableHLO_UnaryElementwiseOp<"tanh",
-    [Pure, HLO_CompatibleOperandsAndResultType],
+    [HLO_CompatibleOperandsAndResultType],
     HLO_FpComplexOrQuantizedIntTensor> {
   let summary = "Tanh operation";
   let description = [{
@@ -3160,7 +3160,7 @@ def StableHLO_RngBitGeneratorOp : StableHLO_Op<"rng_bit_generator", [Pure]> {
 
 // TODO(b/230662142): Implement unknown scales/zero_point cases.
 def StableHLO_UniformQuantizeOp : StableHLO_UnaryElementwiseOp<"uniform_quantize",
-      [Pure], TensorOf<[HLO_Float, HLO_QuantizedInt, HLO_PerAxisQuantizedInt]> /*uniform_quantize_i1*/,
+      [], TensorOf<[HLO_Float, HLO_QuantizedInt, HLO_PerAxisQuantizedInt]> /*uniform_quantize_i1*/,
       TensorOf<[HLO_QuantizedInt, HLO_PerAxisQuantizedInt]>> { /*uniform_quantize_c1*/
   let summary = "UniformQuantize operation";
   let description = [{
@@ -3179,7 +3179,7 @@ def StableHLO_UniformQuantizeOp : StableHLO_UnaryElementwiseOp<"uniform_quantize
 }
 
 def StableHLO_UniformDequantizeOp : StableHLO_UnaryElementwiseOp<"uniform_dequantize",
-      [InferTensorType, Pure], TensorOf<[HLO_QuantizedInt, HLO_PerAxisQuantizedInt]> /*uniform_dequantize_i1*/,
+      [InferTensorType], TensorOf<[HLO_QuantizedInt, HLO_PerAxisQuantizedInt]> /*uniform_dequantize_i1*/,
       HLO_FpTensor> { /*uniform_dequantize_c1, uniform_dequantize_c2*/
   let summary = "UniformDequantize operation";
   let description = [{

--- a/stablehlo/tests/ops_speculatability.mlir
+++ b/stablehlo/tests/ops_speculatability.mlir
@@ -1,5 +1,425 @@
 // RUN: stablehlo-opt %s --hlo-test-speculatability --split-input-file --allow-unregistered-dialect | FileCheck %s
 
+// -----
+
+// UnaryElementwise ops
+
+// -----
+
+// CHECK-LABEL: func @abs_multidim
+// CHECK-NEXT:  return
+func.func @abs_multidim(%dynamic_arg: tensor<?x?xf64>) {
+  %not_speculatable = stablehlo.abs %dynamic_arg : (tensor<?x?xf64>) -> tensor<?x2xf64>
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable) : (tensor<?x2xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @abs
+// CHECK-NEXT:  return
+func.func @abs(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.abs %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.abs %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.abs %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.abs %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @cbrt
+// CHECK-NEXT:  return
+func.func @cbrt(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.cbrt %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.cbrt %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.cbrt %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.cbrt %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @ceil
+// CHECK-NEXT:  return
+func.func @ceil(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.ceil %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.ceil %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.ceil %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.ceil %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @convert
+// CHECK-NEXT:  return
+func.func @convert(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.convert %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.convert %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.convert %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.convert %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @count_leading_zeros
+// CHECK-NEXT:  return
+func.func @count_leading_zeros(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
+  %speculatable_0 = stablehlo.count_leading_zeros %static_arg : (tensor<2xi64>) -> tensor<2xi64>
+  %speculatable_1 = stablehlo.count_leading_zeros %static_arg : (tensor<2xi64>) -> tensor<?xi64>
+  %not_speculatable_0 = stablehlo.count_leading_zeros %dynamic_arg : (tensor<?xi64>) -> tensor<2xi64>
+  %speculatable_2 = stablehlo.count_leading_zeros %dynamic_arg : (tensor<?xi64>) -> tensor<?xi64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xi64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @cosine
+// CHECK-NEXT:  return
+func.func @cosine(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.cosine %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.cosine %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.cosine %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.cosine %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @exponential
+// CHECK-NEXT:  return
+func.func @exponential(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.exponential %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.exponential %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.exponential %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.exponential %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @exponential_minus_one
+// CHECK-NEXT:  return
+func.func @exponential_minus_one(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.exponential_minus_one %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.exponential_minus_one %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.exponential_minus_one %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.exponential_minus_one %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @floor
+// CHECK-NEXT:  return
+func.func @floor(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.floor %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.floor %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.floor %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.floor %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @imag
+// CHECK-NEXT:  return
+func.func @imag(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.imag %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.imag %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.imag %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.imag %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @is_finite
+// CHECK-NEXT:  return
+func.func @is_finite(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.is_finite %static_arg : (tensor<2xf64>) -> tensor<2xi1>
+  %speculatable_1 = stablehlo.is_finite %static_arg : (tensor<2xf64>) -> tensor<?xi1>
+  %not_speculatable_0 = stablehlo.is_finite %dynamic_arg : (tensor<?xf64>) -> tensor<2xi1>
+  %speculatable_2 = stablehlo.is_finite %dynamic_arg : (tensor<?xf64>) -> tensor<?xi1>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xi1>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xi1>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xi1>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xi1>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @log
+// CHECK-NEXT:  return
+func.func @log(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.log %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.log %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.log %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.log %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @log_plus_one
+// CHECK-NEXT:  return
+func.func @log_plus_one(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.log_plus_one %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.log_plus_one %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.log_plus_one %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.log_plus_one %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @logistic
+// CHECK-NEXT:  return
+func.func @logistic(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.logistic %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.logistic %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.logistic %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.logistic %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @not
+// CHECK-NEXT:  return
+func.func @not(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
+  %speculatable_0 = stablehlo.not %static_arg : (tensor<2xi64>) -> tensor<2xi64>
+  %speculatable_1 = stablehlo.not %static_arg : (tensor<2xi64>) -> tensor<?xi64>
+  %not_speculatable_0 = stablehlo.not %dynamic_arg : (tensor<?xi64>) -> tensor<2xi64>
+  %speculatable_2 = stablehlo.not %dynamic_arg : (tensor<?xi64>) -> tensor<?xi64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xi64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @negate
+// CHECK-NEXT:  return
+func.func @negate(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.negate %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.negate %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.negate %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.negate %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @popcnt
+// CHECK-NEXT:  return
+func.func @popcnt(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
+  %speculatable_0 = stablehlo.popcnt %static_arg : (tensor<2xi64>) -> tensor<2xi64>
+  %speculatable_1 = stablehlo.popcnt %static_arg : (tensor<2xi64>) -> tensor<?xi64>
+  %not_speculatable_0 = stablehlo.popcnt %dynamic_arg : (tensor<?xi64>) -> tensor<2xi64>
+  %speculatable_2 = stablehlo.popcnt %dynamic_arg : (tensor<?xi64>) -> tensor<?xi64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xi64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @real
+// CHECK-NEXT:  return
+func.func @real(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.real %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.real %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.real %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.real %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @round_nearest_afz
+// CHECK-NEXT:  return
+func.func @round_nearest_afz(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.round_nearest_afz %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.round_nearest_afz %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.round_nearest_afz %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.round_nearest_afz %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @round_nearest_even
+// CHECK-NEXT:  return
+func.func @round_nearest_even(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.round_nearest_even %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.round_nearest_even %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.round_nearest_even %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.round_nearest_even %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @rsqrt
+// CHECK-NEXT:  return
+func.func @rsqrt(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.rsqrt %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.rsqrt %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.rsqrt %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.rsqrt %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @sign
+// CHECK-NEXT:  return
+func.func @sign(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.sign %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.sign %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.sign %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.sign %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @sine
+// CHECK-NEXT:  return
+func.func @sine(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.sine %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.sine %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.sine %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.sine %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @sqrt
+// CHECK-NEXT:  return
+func.func @sqrt(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.sqrt %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.sqrt %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.sqrt %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.sqrt %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @tanh
+// CHECK-NEXT:  return
+func.func @tanh(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.tanh %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.tanh %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.tanh %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.tanh %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// Ops that take an output shape as operand
+
+// -----
+
 // CHECK-LABEL: func @dynamic_iota
 // CHECK-NEXT:  return
 func.func @dynamic_iota(%unknown_shape: tensor<2xi32>) {


### PR DESCRIPTION
Note: this PR builds on top of https://github.com/openxla/stablehlo/pull/2146. Please see the 2nd commit for changes that are unique to this PR.

A somewhat unfortunate thing is that we allow programs like:

```
func.func @foo(%arg: tensor<?xi64>) {
  %0 = stablehlo.abs %arg : (tensor<?xi64>) -> tensor<2xi64>
  return
}
```

Such a program is legal, but doesn't make much sense: in what scenario would we know the output shape, but not the input shape? If it weren't for such programs, the ops would all be `Pure`, but because at runtime dynamic dimensions in the input type could differ from static dimensions in the output type, these ops have to be `ConditionallySpeculatable`. Whether or not we should allow such programs could be a future discussion.

Also note that the spec asserts that floating point exceptions are defined: https://openxla.org/stablehlo/spec#floating-point_exceptions 

https://github.com/openxla/stablehlo/issues/1991