### PR TITLE
Avoid calling functions in asserts

### DIFF
--- a/stablehlo/conversions/linalg/transforms/LegalizeToLinalgUtils.cpp
+++ b/stablehlo/conversions/linalg/transforms/LegalizeToLinalgUtils.cpp
@@ -77,9 +77,9 @@ Value getEmptyTensorFor(OpBuilder &b, Location loc, ShapedType resultType,
     // Ask the op for its output shape.
     auto shapeSource = cast<InferShapedTypeOpInterface>(op);
     SmallVector<Value, 1> reifiedShapes;
-    assert(succeeded(
-               shapeSource.reifyReturnTypeShapes(b, operands, reifiedShapes)) &&
-           "could not reify");
+    if (failed(shapeSource.reifyReturnTypeShapes(b, operands, reifiedShapes))) {
+      llvm_unreachable("could not reify");
+    }
     assert(reifiedShapes.size() == 1 && "Expected one reified result");
     // Construct sizes for the required dimensions.
     for (const auto &en : llvm::enumerate(resultType.getShape())) {

--- a/stablehlo/conversions/linalg/transforms/LegalizeToLinalgUtils.cpp
+++ b/stablehlo/conversions/linalg/transforms/LegalizeToLinalgUtils.cpp
@@ -78,7 +78,7 @@ Value getEmptyTensorFor(OpBuilder &b, Location loc, ShapedType resultType,
     auto shapeSource = cast<InferShapedTypeOpInterface>(op);
     SmallVector<Value, 1> reifiedShapes;
     if (failed(shapeSource.reifyReturnTypeShapes(b, operands, reifiedShapes))) {
-      llvm_unreachable("could not reify");
+      llvm::report_fatal_error("could not reify");
     }
     assert(reifiedShapes.size() == 1 && "Expected one reified result");
     // Construct sizes for the required dimensions.


### PR DESCRIPTION
Due to a problem with the compilation options, the `shapeSource.reifyReturnTypeShapes` was not called, fix it.