### PR TITLE
Add missing dependency to chlo_ops target

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -278,6 +278,7 @@ cc_library(
         "@llvm-project//mlir:InferTypeOpInterface",
         "@llvm-project//mlir:InliningUtils",
         "@llvm-project//mlir:QuantOps",
+        "@llvm-project//mlir:SideEffectInterfaces",
         "@llvm-project//mlir:TransformUtils",
     ],
 )


### PR DESCRIPTION
I don't understand why this isn't failing in CI, but I can't build this target since 2a0595bd3, and a few others have reported the same for their local builds.

In any case, the code `#include`s SideEffectInterfaces.h, so its target should depend on the corresponding BUILD target.

Filed https://github.com/openxla/stablehlo/issues/2155 for follow-up.