### PR TITLE
Remove Pure trait from Cholesky

### DIFF
--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1957,7 +1957,8 @@ def StableHLO_DynamicBroadcastInDimOp : StableHLO_ShapedInterfaceOp<
 // directly.
 
 def StableHLO_CholeskyOp : StableHLO_Op<"cholesky",
-      [Pure, HLO_CompatibleOperandsAndResultElementType /*cholesky_c1*/,
+      [NoMemoryEffect,
+       HLO_CompatibleOperandsAndResultElementType /*cholesky_c1*/,
        InferTensorType /*cholesky_c1*/]> {
   let summary = "Cholesky operation";
   let description = [{


### PR DESCRIPTION
The spec says: https://github.com/openxla/stablehlo/blob/a053baba039d6d9f9cf11abd8c9555cc055144de/docs/spec.md?plain=1#L1584-L1585.

We could try to see if the inputs are constant and then try to determine if they are Hermitian positive-definite, and only then report that the op is speculatable, but that seems like a heavy check for a situation that isn't likely to occur frequently, so IMO it is more reasonable to say that this op is not speculatable.

Pure is "NoMemoryEffect + AlwaysSpeculatable". If an op doesn't implement ConditionallySpeculatable, then it is never Speculatable, so we replace Pure with NoMemoryEffect, because this op doesn't have memory effects.