### PR TITLE
Implement ConditionallySpeculatable for TriangularSolve

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2042,8 +2042,7 @@ mlir::Speculation::Speculatability TriangularSolveOp::getSpeculatability() {
   // Diagonal could be non-unit at runtime, leading to undefined behavior.
   // If `a` is constant, we could check the diagonal to confirm that it
   // is unit, but this may be costly and should go in the op's verifier.
-  if (getUnitDiagonal())
-    return mlir::Speculation::NotSpeculatable;
+  if (getUnitDiagonal()) return mlir::Speculation::NotSpeculatable;
 
   // If the inputs are statically shaped, they will be fully verified
   // statically. If the inputs are dynamic, then mismatches could occur at

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2051,6 +2051,7 @@ mlir::Speculation::Speculatability TriangularSolveOp::getSpeculatability() {
   auto rhsType = cast<RankedTensorType>(getOperand(1).getType());
   if (lhsType.hasStaticShape() && rhsType.hasStaticShape())
     return mlir::Speculation::Speculatable;
+
   return mlir::Speculation::NotSpeculatable;
 }
 

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2039,9 +2039,9 @@ LogicalResult TriangularSolveOp::inferReturnTypeComponents(
 }
 
 mlir::Speculation::Speculatability TriangularSolveOp::getSpeculatability() {
-  // Diagonal could be non-unit at runtime, leading to undefined behavior.
-  // If `a` is constant, we could check the diagonal to confirm that it
-  // is unit, but this may be costly and should go in the op's verifier.
+  // If `unit_diagonal` is true, the implementation can assume that the diagonal
+  // elements of `a` are equal to 1, which may not be the case at runtime, which
+  // may lead to undefined behavior.
   if (getUnitDiagonal()) return mlir::Speculation::NotSpeculatable;
 
   // If the inputs are statically shaped, they will be fully verified

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2901,7 +2901,8 @@ def StableHLO_TransposeOp: StableHLO_ShapedInterfaceOp<"transpose",
 }
 
 def StableHLO_TriangularSolveOp: StableHLO_Op<"triangular_solve",
-    [Pure, HLO_CompatibleOperandsAndResultElementType, InferTensorType]> {
+    [NoMemoryEffect, ConditionallySpeculatable,
+     HLO_CompatibleOperandsAndResultElementType, InferTensorType]> {
   let summary = "TriangularSolve operation";
   let description = [{
     Solves batches of systems of linear equations with lower or upper triangular
@@ -2929,6 +2930,11 @@ def StableHLO_TriangularSolveOp: StableHLO_Op<"triangular_solve",
     StableHLO_TransposeAttr:$transpose_a
   );
   let results = (outs HLO_FpOrComplexTensor);
+
+  let extraClassDeclaration = commonClassDeclaration # [{
+    /// Interface method for ConditionallySpeculatable.
+    mlir::Speculation::Speculatability getSpeculatability();
+  }];
 }
 
 def StableHLO_ReduceWindowOp: StableHLO_Op<"reduce_window", [

--- a/stablehlo/tests/ops_speculatability.mlir
+++ b/stablehlo/tests/ops_speculatability.mlir
@@ -899,6 +899,34 @@ func.func @reshape(
   "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<12xi64>) -> ()
   "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<12xi64>) -> ()
   "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<12xi64>) -> ()
+}
+
+// CHECK-LABEL: func @triangular_solve
+// CHECK-NEXT:  return
+func.func @triangular_solve(
+  %static: tensor<2x2xf64>,
+  %dynamic: tensor<?x?xf64>
+) {
+  %static_inputs = "stablehlo.triangular_solve"(%static, %static) {
+    left_side = true, lower = true, transpose_a = #stablehlo<transpose NO_TRANSPOSE>, unit_diagonal = false
+  } : (tensor<2x2xf64>, tensor<2x2xf64>) -> tensor<?x?xf64>
+  %dynamic_inputs_0 = "stablehlo.triangular_solve"(%dynamic, %static) {
+    left_side = true, lower = true, transpose_a = #stablehlo<transpose NO_TRANSPOSE>, unit_diagonal = false
+  } : (tensor<?x?xf64>, tensor<2x2xf64>) -> tensor<?x?xf64>
+  %dynamic_inputs_1 = "stablehlo.triangular_solve"(%static, %dynamic) {
+    left_side = true, lower = true, transpose_a = #stablehlo<transpose NO_TRANSPOSE>, unit_diagonal = false
+  } : (tensor<2x2xf64>, tensor<?x?xf64>) -> tensor<?x?xf64>
+  %dynamic_inputs_2 = "stablehlo.triangular_solve"(%dynamic, %dynamic) {
+    left_side = true, lower = true, transpose_a = #stablehlo<transpose NO_TRANSPOSE>, unit_diagonal = false
+  } : (tensor<?x?xf64>, tensor<?x?xf64>) -> tensor<?x?xf64>
+  %unit_diagonal = "stablehlo.triangular_solve"(%static, %static) {
+    left_side = true, lower = true, transpose_a = #stablehlo<transpose NO_TRANSPOSE>, unit_diagonal = true
+  } : (tensor<2x2xf64>, tensor<2x2xf64>) -> tensor<?x?xf64>
+  "hlo_test_speculatability.is_speculatable"(%static_inputs) : (tensor<?x?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%dynamic_inputs_0) : (tensor<?x?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%dynamic_inputs_1) : (tensor<?x?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%dynamic_inputs_2) : (tensor<?x?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%unit_diagonal) : (tensor<?x?xf64>) -> ()
   return
 }
 

--- a/stablehlo/tests/ops_speculatability.mlir
+++ b/stablehlo/tests/ops_speculatability.mlir
@@ -899,7 +899,10 @@ func.func @reshape(
   "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<12xi64>) -> ()
   "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<12xi64>) -> ()
   "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<12xi64>) -> ()
+  return
 }
+
+// -----
 
 // CHECK-LABEL: func @triangular_solve
 // CHECK-NEXT:  return


### PR DESCRIPTION
If `a` is constant, we could check the diagonal to confirm that it
is unit, but this may be costly and should go in the op's verifier.