### PR TITLE
Implement ConditionallySpeculatable for BatchNorm* ops

### DIFF
--- a/stablehlo/dialect/Base.td
+++ b/stablehlo/dialect/Base.td
@@ -334,10 +334,10 @@ def HLO_SpeculatableIfStaticDimInOutputIsStaticInInputImplTrait
 def HLO_SpeculatableIfStaticDimInOutputIsStaticInInput : TraitList<[
     ConditionallySpeculatable, HLO_SpeculatableIfStaticDimInOutputIsStaticInInputImplTrait]>;
 
-def HLO_BinaryElementwiseSpeculatableImplTrait
-  : HLO_NativeOpTrait<"BinaryElementwiseSpeculatableImplTrait">;
+def HLO_SpeculatableIfAllInputsStaticImplTrait
+  : HLO_NativeOpTrait<"SpeculatableIfAllInputsStaticImplTrait">;
 
-def HLO_BinaryElementwiseSpeculatable : TraitList<[
-    ConditionallySpeculatable, HLO_BinaryElementwiseSpeculatableImplTrait]>;
+def HLO_SpeculatableIfAllInputsStatic : TraitList<[
+    ConditionallySpeculatable, HLO_SpeculatableIfAllInputsStaticImplTrait]>;
 
 #endif // STABLEHLO_DIALECT_BASE

--- a/stablehlo/dialect/Base.td
+++ b/stablehlo/dialect/Base.td
@@ -337,6 +337,12 @@ def HLO_SpeculatableIfStaticDimInOutputIsStaticInInput : TraitList<[
 def HLO_SpeculatableIfAllInputsStaticImplTrait
   : HLO_NativeOpTrait<"SpeculatableIfAllInputsStaticImplTrait">;
 
+// This trait is appropriate to use for ops where the op is only speculatable
+// if all the inputs are static. This can happen if e.g. the inputs are expected
+// to all have the same shape. If all the inputs are static, the verifier can
+// validate statically that all the static dimensions are the same. However,
+// if there is any dynamic dimension, it could differ from the shape of another
+// input at runtime, leading to undefined behavior.
 def HLO_SpeculatableIfAllInputsStatic : TraitList<[
     ConditionallySpeculatable, HLO_SpeculatableIfAllInputsStaticImplTrait]>;
 

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -661,7 +661,7 @@ class StableHLO_BinaryElementwiseOp<string mnemonic, list<Trait> traits,
     Type OperandType = HLO_Tensor, Type ResultType = OperandType> :
     StableHLO_Op<mnemonic, traits # [InferShapedTypeOpInterface,
     SameOperandsAndResultShape, Elementwise,
-    HLO_BinaryElementwiseSpeculatable, NoMemoryEffect]> {
+    HLO_SpeculatableIfAllInputsStatic, NoMemoryEffect]> {
   let arguments = (ins
     OperandType:$lhs,
     OperandType:$rhs
@@ -959,7 +959,7 @@ def StableHLO_SubtractOp : StableHLO_BinaryElementwiseOp<"subtract",
 class StableHLO_BinaryBiwiseOrLogicalElementwiseOp<string mnemonic> :
         StableHLO_BinaryElementwiseOp<mnemonic,
           [HLO_Commutative, HLO_CompatibleOperandsAndResultType,
-           HLO_BinaryElementwiseSpeculatable, NoMemoryEffect]> {
+           HLO_SpeculatableIfAllInputsStatic, NoMemoryEffect]> {
   let arguments = (ins
     HLO_PredOrIntTensor:$lhs,
     HLO_PredOrIntTensor:$rhs
@@ -1718,7 +1718,8 @@ def StableHLO_DynamicUpdateSliceOp: StableHLO_Op<"dynamic_update_slice",
 // StableHLO Other op definitions.
 //===----------------------------------------------------------------------===//
 
-def StableHLO_BatchNormGradOp : StableHLO_Op<"batch_norm_grad", [Pure,
+def StableHLO_BatchNormGradOp : StableHLO_Op<"batch_norm_grad",
+   [HLO_SpeculatableIfAllInputsStatic, NoMemoryEffect,
     HLO_CompatibleOperandsAndResultElementType /*batch_norm_grad_c2*/,
     InferTensorType /*batch_norm_grad_c3, batch_norm_grad_c4*/]> {
   let summary = "BatchNormGrad operation";
@@ -1758,7 +1759,8 @@ def StableHLO_BatchNormGradOp : StableHLO_Op<"batch_norm_grad", [Pure,
 }
 
 def StableHLO_BatchNormInferenceOp : StableHLO_Op<"batch_norm_inference",
-    [Pure, HLO_CompatibleOperandsAndResultElementType /*batch_norm_inference_c2*/,
+    [HLO_SpeculatableIfAllInputsStatic, NoMemoryEffect,
+     HLO_CompatibleOperandsAndResultElementType /*batch_norm_inference_c2*/,
      InferTensorType /*batch_norm_inference_c7*/]> {
   let summary = "BatchNormInference operation";
   let description = [{
@@ -1791,7 +1793,8 @@ def StableHLO_BatchNormInferenceOp : StableHLO_Op<"batch_norm_inference",
 }
 
 def StableHLO_BatchNormTrainingOp : StableHLO_Op<"batch_norm_training",
-    [Pure, HLO_CompatibleOperandsAndResultElementType /*batch_norm_training_c2*/,
+    [HLO_SpeculatableIfAllInputsStatic, NoMemoryEffect,
+     HLO_CompatibleOperandsAndResultElementType /*batch_norm_training_c2*/,
      InferTensorType /*batch_norm_training_c5, batch_norm_training_c6, batch_norm_training_c7*/]> {
   let summary = "BatchNormTraining operation";
   let description = [{

--- a/stablehlo/tests/ops_speculatability.mlir
+++ b/stablehlo/tests/ops_speculatability.mlir
@@ -901,3 +901,51 @@ func.func @reshape(
   "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<12xi64>) -> ()
   return
 }
+
+// -----
+
+// CHECK-LABEL: func @batch_norm_grad
+// CHECK-NEXT:  return
+func.func @batch_norm_grad(%static: tensor<2xf64>, %dynamic: tensor<?xf64>) {
+  %all_inputs_static:3 = "stablehlo.batch_norm_grad" (%static, %static, %static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
+  %first_input_dynamic:3 = "stablehlo.batch_norm_grad" (%dynamic, %static, %static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
+  %last_input_dynamic:3 = "stablehlo.batch_norm_grad" (%static, %static, %static, %static, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<?xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
+  %all_inputs_dynamic:3 = "stablehlo.batch_norm_grad" (%dynamic, %dynamic, %dynamic, %dynamic, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>, tensor<?xf64>, tensor<?xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
+  "hlo_test_speculatability.is_speculatable"(%all_inputs_static#0) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%first_input_dynamic#0) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%last_input_dynamic#0) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%all_inputs_dynamic#0) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @batch_norm_inference
+// CHECK-NEXT:  return
+func.func @batch_norm_inference(%static: tensor<2xf64>, %dynamic: tensor<?xf64>) {
+  %all_inputs_static = "stablehlo.batch_norm_inference" (%static, %static, %static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>)
+  %first_input_dynamic = "stablehlo.batch_norm_inference" (%dynamic, %static, %static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>)
+  %last_input_dynamic = "stablehlo.batch_norm_inference" (%static, %static, %static, %static, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<?xf64>) -> (tensor<?xf64>)
+  %all_inputs_dynamic = "stablehlo.batch_norm_inference" (%dynamic, %dynamic, %dynamic, %dynamic, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>, tensor<?xf64>, tensor<?xf64>) -> (tensor<?xf64>)
+  "hlo_test_speculatability.is_speculatable"(%all_inputs_static) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%first_input_dynamic) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%last_input_dynamic) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%all_inputs_dynamic) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @batch_norm_training
+// CHECK-NEXT:  return
+func.func @batch_norm_training(%static: tensor<2xf64>, %dynamic: tensor<?xf64>) {
+  %all_inputs_static:3 = "stablehlo.batch_norm_training" (%static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
+  %first_input_dynamic:3 = "stablehlo.batch_norm_training" (%dynamic, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
+  %last_input_dynamic:3 = "stablehlo.batch_norm_training" (%static, %static, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<?xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
+  %all_inputs_dynamic:3 = "stablehlo.batch_norm_training" (%dynamic, %dynamic, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
+  "hlo_test_speculatability.is_speculatable"(%all_inputs_static#0) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%first_input_dynamic#0) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%last_input_dynamic#0) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%all_inputs_dynamic#0) : (tensor<?xf64>) -> ()
+  return
+}


### PR DESCRIPTION
Also, rework "BinaryElementwiseSpeculatable" trait to be more descriptive and more generic: the relevant condition is "are all the inputs statically shaped".