### PR TITLE
Implement ConditionallySpeculatable for a few unary ops

### DIFF
--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -398,9 +398,10 @@ class CompatibleOperandsAndResultType
 };
 
 template <typename ConcreteType>
-struct UnaryElementwiseSpeculatableImplTrait
-    : public mlir::OpTrait::TraitBase<ConcreteType,
-                                      UnaryElementwiseSpeculatableImplTrait> {
+struct SpeculatableIfStaticDimInOutputIsStaticInInputImplTrait
+    : public mlir::OpTrait::TraitBase<
+          ConcreteType,
+          SpeculatableIfStaticDimInOutputIsStaticInInputImplTrait> {
   // A unary elementwise op is not speculatable if a dimension of the result
   // type is static while the corresponding dimension in the input type is
   // dynamic. Indeed, the input dimension could differ at runtime.

--- a/stablehlo/dialect/Base.td
+++ b/stablehlo/dialect/Base.td
@@ -321,11 +321,18 @@ def HLO_BoundedAttrInterface : AttrInterface<"BoundedAttrInterface"> {
   >];
 }
 
-def HLO_UnaryElementwiseSpeculatableImplTrait
-  : HLO_NativeOpTrait<"UnaryElementwiseSpeculatableImplTrait">;
+def HLO_SpeculatableIfStaticDimInOutputIsStaticInInputImplTrait
+  : HLO_NativeOpTrait<"SpeculatableIfStaticDimInOutputIsStaticInInputImplTrait">;
 
-def HLO_UnaryElementwiseSpeculatable : TraitList<[
-    ConditionallySpeculatable, HLO_UnaryElementwiseSpeculatableImplTrait]>;
+// This trait can be used with ops where the result has the same rank as the
+// input and each dimension of the input maps to the same dimension in the
+// result. In that case, if a dim is static in the output but dynamic in the
+// input, the dimension could differ at runtime, leading to undefined behavior.
+// If the output dimension is dynamic, there is no expectation, so there
+// cannot be a mismatch. If the input dimension is static, the output dimension
+// can be inferred from it, so there cannot be a mismatch either.
+def HLO_SpeculatableIfStaticDimInOutputIsStaticInInput : TraitList<[
+    ConditionallySpeculatable, HLO_SpeculatableIfStaticDimInOutputIsStaticInInputImplTrait]>;
 
 def HLO_BinaryElementwiseSpeculatableImplTrait
   : HLO_NativeOpTrait<"BinaryElementwiseSpeculatableImplTrait">;

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -178,8 +178,9 @@ def StableHLO_CreateTokenOp : StableHLO_Op<"create_token", [Pure,
 // See https://www.tensorflow.org/xla/operation_semantics#element-wise_unary_functions
 
 class StableHLO_UnaryElementwiseOp<string mnemonic, list<Trait> traits,
-    Type OperandType, Type ResultType = OperandType> : StableHLO_Op<mnemonic, traits # [Elementwise,
-    InferShapedTypeOpInterface, SameOperandsAndResultShape, HLO_UnaryElementwiseSpeculatable, NoMemoryEffect]> {
+    Type OperandType, Type ResultType = OperandType> : StableHLO_Op<mnemonic,
+    traits # [Elementwise, InferShapedTypeOpInterface, SameOperandsAndResultShape,
+              HLO_SpeculatableIfStaticDimInOutputIsStaticInInput, NoMemoryEffect]> {
   let arguments = (ins OperandType:$operand);
   let results = (outs ResultType:$result);
   let extraClassDeclaration = commonClassDeclaration # [{
@@ -2767,7 +2768,8 @@ def StableHLO_SortOp : StableHLO_Op<"sort",
 }
 
 def StableHLO_ReverseOp: StableHLO_ShapedInterfaceOp<"reverse",
-      [Pure, HLO_CompatibleOperandsAndResultType,
+      [HLO_SpeculatableIfStaticDimInOutputIsStaticInInput, NoMemoryEffect,
+       HLO_CompatibleOperandsAndResultType,
        SameOperandsAndResultElementType /*reverse_c1*/]> {
   let summary = "Reverse operation";
   let description = [{
@@ -3202,7 +3204,8 @@ def StableHLO_UniformDequantizeOp : StableHLO_UnaryElementwiseOp<"uniform_dequan
 }
 
 def StableHLO_ReducePrecisionOp : StableHLO_Op<"reduce_precision",
-      [Pure, Elementwise,
+      [HLO_SpeculatableIfStaticDimInOutputIsStaticInInput, NoMemoryEffect,
+       Elementwise,
        HLO_CompatibleOperandsAndResultType /*reduce_precision_c1*/]> {
   let summary = "ReducePrecision operation";
   let description = [{

--- a/stablehlo/tests/ops_speculatability.mlir
+++ b/stablehlo/tests/ops_speculatability.mlir
@@ -416,6 +416,42 @@ func.func @tanh(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 
 // -----
 
+// Other unary ops
+
+// -----
+
+// CHECK-LABEL: func @reduce_precision
+// CHECK-NEXT:  return
+func.func @reduce_precision(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.reduce_precision %static_arg, format = e5m10 : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.reduce_precision %static_arg, format = e5m10 : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.reduce_precision %dynamic_arg, format = e5m10 : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.reduce_precision %dynamic_arg, format = e5m10 : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func @reverse
+// CHECK-NEXT:  return
+func.func @reverse(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
+  %speculatable_0 = stablehlo.reverse %static_arg, dims = [0] : (tensor<2xf64>) -> tensor<2xf64>
+  %speculatable_1 = stablehlo.reverse %static_arg, dims = [0] : (tensor<2xf64>) -> tensor<?xf64>
+  %not_speculatable_0 = stablehlo.reverse %dynamic_arg, dims = [0] : (tensor<?xf64>) -> tensor<2xf64>
+  %speculatable_2 = stablehlo.reverse %dynamic_arg, dims = [0] : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  return
+}
+
+// -----
+
 // BinaryElementwise and BinaryBitwiseOrLogicalElementwise ops
 
 // -----


### PR DESCRIPTION
Also, rework "UnaryElementwiseSpeculatable" to be more descriptive and more generic: the relevant condition is "every static dimension in the output is static in the input".