### PR TITLE
Implement ConditionallySpeculatable for collective ops

### DIFF
--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1315,7 +1315,7 @@ def StableHLO_WhileOp: StableHLO_Op<"while", [
 }
 
 def StableHLO_AllGatherOp : StableHLO_Op<"all_gather",
-    [SameOperandsAndResultElementType] /*all_gather_c6*/> {
+    [ConditionallySpeculatable, SameOperandsAndResultElementType] /*all_gather_c6*/> {
   string summary = "AllGather operation";
   string description = [{
     Within each process group in the process grid, concatenates the values of the
@@ -1344,10 +1344,16 @@ def StableHLO_AllGatherOp : StableHLO_Op<"all_gather",
   );
   let results = (outs HLO_Tensor);
   let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    /// Interface method for ConditionallySpeculatable.
+    mlir::Speculation::Speculatability getSpeculatability();
+  }];
 }
 
 def StableHLO_AllReduceOp : StableHLO_Op<"all_reduce",
-    [InferTensorType /*all_reduce_c6, all_reduce_c7*/]> {
+    [HLO_SpeculatableIfStaticDimInOutputIsStaticInInput,
+     InferTensorType /*all_reduce_c6, all_reduce_c7*/]> {
   let summary = "AllReduce operation";
   let description = [{
     Within each process group in the process grid, applies a reduction function
@@ -1382,7 +1388,7 @@ def StableHLO_AllReduceOp : StableHLO_Op<"all_reduce",
   let hasVerifier = 1;
 }
 
-def StableHLO_ReduceScatterOp : StableHLO_Op<"reduce_scatter"> {
+def StableHLO_ReduceScatterOp : StableHLO_Op<"reduce_scatter", [ConditionallySpeculatable]> {
   let summary = "ReduceScatter operation";
   let description = [{
      Within each process group in the process grid, performs reduction, using
@@ -1417,10 +1423,16 @@ def StableHLO_ReduceScatterOp : StableHLO_Op<"reduce_scatter"> {
   let regions = (region SizedRegion<1>:$computation /*reduce_scatter_i6*/);
   let results = (outs HLO_Tensor);
   let hasVerifier = 1;
+
+  let extraClassDeclaration = commonClassDeclaration # [{
+    /// Interface method for ConditionallySpeculatable.
+    mlir::Speculation::Speculatability getSpeculatability();
+  }];
 }
 
 def StableHLO_AllToAllOp : StableHLO_Op<"all_to_all",
-    [SameOperandsAndResultElementType /*all_to_all_c9*/,
+    [ConditionallySpeculatable,
+     SameOperandsAndResultElementType /*all_to_all_c9*/,
      InferTensorType /*all_to_all_c9*/]> {
   let summary = "AllToAll operation";
   let description = [{
@@ -1462,6 +1474,11 @@ def StableHLO_AllToAllOp : StableHLO_Op<"all_to_all",
       "::mlir::IntegerAttr": $concat_dimension,
       "::mlir::IntegerAttr": $split_count,
       "::mlir::DenseIntElementsAttr": $replica_groups)>];
+
+  let extraClassDeclaration = commonClassDeclaration # [{
+    /// Interface method for ConditionallySpeculatable.
+    mlir::Speculation::Speculatability getSpeculatability();
+  }];
 }
 
 def StableHLO_ReduceOp: StableHLO_ShapedInterfaceOp<"reduce", [
@@ -2050,7 +2067,8 @@ def StableHLO_ConcatenateOp : StableHLO_ShapedInterfaceOp<"concatenate",
 
 
 def StableHLO_CollectiveBroadcastOp: StableHLO_Op<"collective_broadcast",
-    [HLO_CompatibleOperandsAndResultType,
+    [HLO_SpeculatableIfStaticDimInOutputIsStaticInInput,
+     HLO_CompatibleOperandsAndResultType,
      SameOperandsAndResultElementType /*collective_broadcast_c3*/]> {
   let summary = "CollectiveBroadcast operation";
   let description = [{
@@ -2086,7 +2104,8 @@ def StableHLO_CollectiveBroadcastOp: StableHLO_Op<"collective_broadcast",
 }
 
 def StableHLO_CollectivePermuteOp: StableHLO_Op<"collective_permute",
-    [HLO_CompatibleOperandsAndResultType,
+    [HLO_SpeculatableIfStaticDimInOutputIsStaticInInput,
+     HLO_CompatibleOperandsAndResultType,
      SameOperandsAndResultElementType /*collective_permute_c5*/]> {
   let summary = "CollectivePermute operation";
   let description = [{
@@ -2556,7 +2575,7 @@ def StableHLO_ReshapeOp: StableHLO_Op<"reshape",
 
   let assemblyFormat = "operands attr-dict `:` functional-type(operands, results)";
 
-  let extraClassDeclaration = [{
+  let extraClassDeclaration = commonClassDeclaration # [{
     /// Interface method for ConditionallySpeculatable.
     mlir::Speculation::Speculatability getSpeculatability();
   }];

--- a/stablehlo/tests/TestUtils.cpp
+++ b/stablehlo/tests/TestUtils.cpp
@@ -99,6 +99,7 @@ LogicalResult checkSpeculatability(PatternRewriter &rewriter, Operation *op,
 
   if (definingOp.getSpeculatability() == spec) {
     rewriter.eraseOp(op);
+    rewriter.eraseOp(definingOp);
     return success();
   }
 


### PR DESCRIPTION
I'm actually not sure if speculation make sense for these ops. I don't see any indication in the spec that they could have UB except in the cases added here, so it's likely fine. Also, I'm not sure if these ops can have memory effects or not. They definitely involve interacting with some kind of global state, so they have side effects. The ops weren't marked "Pure" before this change, so there is no difference on that front being introduced with this change.

Also I slightly updated the logic in TestUtils to delete the op when the speculation check succeeds. Indeed before we were relying on DCE, but these ops don't state that they don't have side effects so DCE won't remove them.