### PR TITLE
Add missing ReshapeOp common decl

### DIFF
--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2556,7 +2556,7 @@ def StableHLO_ReshapeOp: StableHLO_Op<"reshape",
 
   let assemblyFormat = "operands attr-dict `:` functional-type(operands, results)";
 
-  let extraClassDeclaration = [{
+  let extraClassDeclaration = commonClassDeclaration # [{
     /// Interface method for ConditionallySpeculatable.
     mlir::Speculation::Speculatability getSpeculatability();
   }];


### PR DESCRIPTION
In https://github.com/openxla/stablehlo/pull/2162 I added an extraDeclaration for this op but forgot to concatenate the common decl.