### PR TITLE
collective_broadcast, collective_permute : remove HLO_CompatibleOperandsAndResultType trait 

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -170,7 +170,6 @@ INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(Atan2Op)
 INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(CbrtOp)
 INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(CeilOp)
 INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(ClzOp)
-INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(CollectiveBroadcastOp)
 INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(CollectivePermuteOp)
 INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(CosineOp)
 INFER_RETURN_TYPE_COMPONENTS_FROM_OPERANDS(CrossReplicaSumOp)
@@ -872,6 +871,34 @@ void CollectiveBroadcastOp::build(OpBuilder& odsBuilder,
                                   DenseIntElementsAttr replica_groups) {
   CollectiveBroadcastOp::build(odsBuilder, odsState, resultType, operand,
                                replica_groups, /*channel_handle=*/nullptr);
+}
+
+LogicalResult CollectiveBroadcastOp::inferReturnTypes(
+    MLIRContext* /*context*/, std::optional<Location> location,
+    ValueRange operands, DictionaryAttr attributes, OpaqueProperties properties,
+    RegionRange regions, SmallVectorImpl<Type>& inferredReturnTypes) {
+  CollectiveBroadcastOp::Adaptor adaptor(operands, attributes, properties,
+                                         regions);
+  return hlo::inferCollectiveBroadcastOp(location, adaptor.getOperands(),
+                                         inferredReturnTypes);
+}
+
+LogicalResult CollectiveBroadcastOp::inferReturnTypeComponents(
+    MLIRContext* context, std::optional<Location> location,
+    ValueShapeRange operands, DictionaryAttr attributes,
+    OpaqueProperties properties, RegionRange regions,
+    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+  SmallVector<Type> inferredReturnTypes;
+  CollectiveBroadcastOp::Adaptor adaptor(operands, attributes, properties,
+                                         regions);
+  if (failed(hlo::inferCollectiveBroadcastOp(location, adaptor.getOperands(),
+                                             inferredReturnTypes)))
+    return failure();
+  if (inferredReturnTypes.size() != 1) return failure();
+  auto inferredReturnType = dyn_cast<ShapedType>(inferredReturnTypes[0]);
+  if (!inferredReturnType) return failure();
+  inferredReturnShapes.push_back(inferredReturnType);
+  return success();
 }
 
 LogicalResult CollectiveBroadcastOp::verify() {

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2113,8 +2113,10 @@ def StableHLO_CollectiveBroadcastOp: StableHLO_Op<"collective_broadcast",
 
 def StableHLO_CollectivePermuteOp: StableHLO_Op<"collective_permute",
     [HLO_SpeculatableIfStaticDimInOutputIsStaticInInput,
-     HLO_CompatibleOperandsAndResultType,
-     SameOperandsAndResultElementType /*collective_permute_c5*/]> {
+     SameOperandsAndResultElementType, /*collective_permute_c5*/
+     DeclareOpInterfaceMethods<InferTypeOpInterface>,
+     DeclareOpInterfaceMethods<InferShapedTypeOpInterface, ["inferReturnTypeComponents"]>
+    ]> {
   let summary = "CollectivePermute operation";
   let description = [{
     Within each process group in the process grid, sends the value of the

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2074,8 +2074,10 @@ def StableHLO_ConcatenateOp : StableHLO_ShapedInterfaceOp<"concatenate",
 
 def StableHLO_CollectiveBroadcastOp: StableHLO_Op<"collective_broadcast",
     [HLO_SpeculatableIfStaticDimInOutputIsStaticInInput,
-     HLO_CompatibleOperandsAndResultType,
-     SameOperandsAndResultElementType /*collective_broadcast_c3*/]> {
+     SameOperandsAndResultElementType /*collective_broadcast_c3*/,
+     DeclareOpInterfaceMethods<InferTypeOpInterface>,
+     DeclareOpInterfaceMethods<InferShapedTypeOpInterface, ["inferReturnTypeComponents"]>
+    ]> {
   let summary = "CollectiveBroadcast operation";
   let description = [{
     Within each process group in the process grid, send the value of the

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1880,8 +1880,9 @@ LogicalResult inferConvertOp(
   return success();
 }
 
-LogicalResult inferCollectiveBroadcastOp(std::optional<Location>, ValueRange operands,
-                           SmallVectorImpl<Type>& inferredReturnTypes) {
+LogicalResult inferCollectiveBroadcastOp(
+    std::optional<Location>, ValueRange operands,
+    SmallVectorImpl<Type>& inferredReturnTypes) {
   for (const auto& resultType : operands.getTypes())
     inferredReturnTypes.push_back(resultType);
   return success();

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1880,6 +1880,13 @@ LogicalResult inferConvertOp(
   return success();
 }
 
+LogicalResult inferCollectiveBroadcastOp(std::optional<Location>, ValueRange operands,
+                           SmallVectorImpl<Type>& inferredReturnTypes) {
+  for (const auto& resultType : operands.getTypes())
+    inferredReturnTypes.push_back(resultType);
+  return success();
+}
+
 /*
  * We intend to verify the following properties
  *  P1. Verify the input, kernel types.

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -1888,6 +1888,14 @@ LogicalResult inferCollectiveBroadcastOp(
   return success();
 }
 
+LogicalResult inferCollectivePermuteOp(
+    std::optional<Location>, ValueRange operands,
+    SmallVectorImpl<Type>& inferredReturnTypes) {
+  for (const auto& resultType : operands.getTypes())
+    inferredReturnTypes.push_back(resultType);
+  return success();
+}
+
 /*
  * We intend to verify the following properties
  *  P1. Verify the input, kernel types.

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -157,6 +157,10 @@ LogicalResult inferClampOp(
     std::optional<Location> location, Value min, Value operand, Value max,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
 
+LogicalResult inferCollectiveBroadcastOp(
+    std::optional<Location>, ValueRange operands,
+    SmallVectorImpl<Type>& inferredReturnTypes);
+
 LogicalResult inferCompareOp(
     MLIRContext* context, std::optional<Location>, Value lhs,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -161,6 +161,10 @@ LogicalResult inferCollectiveBroadcastOp(
     std::optional<Location>, ValueRange operands,
     SmallVectorImpl<Type>& inferredReturnTypes);
 
+LogicalResult inferCollectivePermuteOp(
+    std::optional<Location>, ValueRange operands,
+    SmallVectorImpl<Type>& inferredReturnTypes);
+
 LogicalResult inferCompareOp(
     MLIRContext* context, std::optional<Location>, Value lhs,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);

--- a/stablehlo/tests/infer_stablehlo.mlir
+++ b/stablehlo/tests/infer_stablehlo.mlir
@@ -170,6 +170,18 @@ func.func @concat(%arg0: tensor<1xi32>, %arg1: tensor<2xi32>)  -> tensor<3xindex
 
 // -----
 
+// CHECK-LABEL: func @collective_broadcast_c3
+func.func @collective_broadcast_c3(%arg0: tensor<16x8xf32>) -> tensor<16x8xindex> {
+  %0 = "stablehlo.collective_broadcast"(%arg0) {
+    replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
+  } : (tensor<16x8xf32>) -> tensor<16x8xf32>
+  // CHECK: types0 = tensor<16x8xf32>
+  %1 = "hlo_test_infer.get_return_types"(%0) : (tensor<16x8xf32>) -> tensor<16x8xindex>
+  func.return %1 : tensor<16x8xindex>
+}
+
+// -----
+
 // CHECK-LABEL: func @collective_permute_c5
 func.func @collective_permute_c5(%arg0: tensor<2x2xi64>) -> tensor<2x2xindex> {
   %0 = "stablehlo.collective_permute"(%arg0) {


### PR DESCRIPTION
for `collective_broadcast` and `collective_permute` ops,  `HLO_CompatibleOperandsAndResultType` trait is no longer required. `SameOperandsAndResultElementType` is covering  `(C3) type(result) = type(operand)` constraints. Previously  `HLO_CompatibleOperandsAndResultType` trait was defining type and shape inference functions. This PR removes `HLO_CompatibleOperandsAndResultType` for the OP and copied-out required inference functions.

Tested:
1. return type inference is ok. Added test to infer_stablehlo.mlir  to validate. 
2. no builder errors

ref: https://github.com/openxla/stablehlo/issues/2145