### PR TITLE
Fix deprecated uses of cast/dyn_cast/dyn_cast_or_null/isa

### DIFF
--- a/stablehlo/conversions/linalg/transforms/MapStablehloToScalarOp.h
+++ b/stablehlo/conversions/linalg/transforms/MapStablehloToScalarOp.h
@@ -235,13 +235,13 @@ struct MapStablehloOpToScalarOpImpl<SupportedType, void, Args...> {
 };
 
 struct IsAnyIntegerType {
-  bool operator()(Type t) { return t.isa<IntegerType>(); }
+  bool operator()(Type t) { return isa<IntegerType>(t); }
 };
 
 struct IsSignedIntegerType {
   bool operator()(Type t) {
     // Pretend that signless is signed. This will change eventually.
-    return t.isa<IntegerType>() && !t.isUnsignedInteger() &&
+    return isa<IntegerType>(t) && !t.isUnsignedInteger() &&
            !t.isSignlessInteger(1);
   }
 };
@@ -253,11 +253,11 @@ struct IsUnsignedIntegerType {
 };
 
 struct IsFloatType {
-  bool operator()(Type t) { return t.isa<FloatType>(); }
+  bool operator()(Type t) { return isa<FloatType>(t); }
 };
 
 struct IsComplexType {
-  bool operator()(Type t) { return t.isa<ComplexType>(); }
+  bool operator()(Type t) { return isa<ComplexType>(t); }
 };
 
 template <template <typename T> class MapTy, typename OpTy,
@@ -292,11 +292,11 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::AbsOp>(
     Location loc, ArrayRef<Type> resultTypes, ArrayRef<Type> argTypes,
     stablehlo::AbsOp::Adaptor adaptor, OpBuilder *b) {
   Type elementType = getElementTypeOrSelf(argTypes.front());
-  if (elementType.isa<FloatType>()) {
+  if (isa<FloatType>(elementType)) {
     return MapStablehloOpToScalarOpImpl<IsFloatType, ::mlir::math::AbsFOp>{}(
         loc, resultTypes, argTypes, adaptor.getOperands(), b);
   }
-  if (elementType.isa<ComplexType>()) {
+  if (isa<ComplexType>(elementType)) {
     return MapStablehloOpToScalarOpImpl<IsComplexType,
                                         ::mlir::complex::AbsOp>{}(
         loc, resultTypes, argTypes, adaptor.getOperands(), b);
@@ -318,7 +318,7 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::AbsOp>(
 // Return a constant for v of type t, splat if t is a vector type.
 inline Value getConstantOrSplat(OpBuilder *b, Location loc, Type t,
                                 Attribute v) {
-  if (VectorType vecType = t.dyn_cast<VectorType>()) {
+  if (VectorType vecType = dyn_cast<VectorType>(t)) {
     v = SplatElementsAttr::get(vecType, v);
   }
   return b->create<arith::ConstantOp>(loc, t, cast<TypedAttr>(v));
@@ -368,8 +368,8 @@ getCmpPredicate<arith::CmpIPredicate>(
 inline Value cmpComplex(Location loc, Value lhs, Value rhs,
                         stablehlo::ComparisonDirection comparisonDirection,
                         OpBuilder *b) {
-  auto complexType = lhs.getType().cast<ComplexType>();
-  if (complexType.getElementType().isa<FloatType>()) {
+  auto complexType = cast<ComplexType>(lhs.getType());
+  if (isa<FloatType>(complexType.getElementType())) {
     if (comparisonDirection == stablehlo::ComparisonDirection::EQ) {
       return b->create<complex::EqualOp>(loc, lhs, rhs);
     }
@@ -414,7 +414,7 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::CompareOp>(
   const auto &lhs = adaptor.getLhs();
   const auto &rhs = adaptor.getRhs();
   Type elementType = getElementTypeOrSelf(argTypes.front());
-  if (elementType.isa<IntegerType>()) {
+  if (isa<IntegerType>(elementType)) {
     bool isUnsigned = IsUnsignedIntegerType{}(elementType);
     std::optional<arith::CmpIPredicate> predicate =
         getCmpPredicate<arith::CmpIPredicate>(comparisonDirection, !isUnsigned);
@@ -422,7 +422,7 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::CompareOp>(
     return b->create<ScalarIOp<stablehlo::CompareOp>>(loc, predicate.value(),
                                                       lhs, rhs);
   }
-  if (auto floatType = elementType.dyn_cast<FloatType>()) {
+  if (auto floatType = dyn_cast<FloatType>(elementType)) {
     if (adaptor.getCompareType() &&
         *adaptor.getCompareType() == stablehlo::ComparisonType::TOTALORDER) {
       // The semantics of totalorder fp compare are
@@ -466,7 +466,7 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::CompareOp>(
     return b->create<ScalarFOp<stablehlo::CompareOp>>(loc, predicate.value(),
                                                       lhs, rhs);
   }
-  if (auto complexType = elementType.dyn_cast<ComplexType>())
+  if (auto complexType = dyn_cast<ComplexType>(elementType))
     return cmpComplex(loc, lhs, rhs, comparisonDirection, b);
   return nullptr;
 }
@@ -480,7 +480,7 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::ReducePrecisionOp>(
 
   // Integer and float types for casting and constant generation.
   auto floatType =
-      argTypes.front().cast<TensorType>().getElementType().cast<FloatType>();
+      cast<FloatType>(cast<TensorType>(argTypes.front()).getElementType());
   int64_t nbits = floatType.getWidth();
   auto intType = mlir::IntegerType::get(loc.getContext(), floatType.getWidth());
 
@@ -611,7 +611,7 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::MaxOp>(
   Value lhs = operands.front();
   Type complexTy = lhs.getType();
 
-  if (!complexTy.isa<ComplexType>())
+  if (!isa<ComplexType>(complexTy))
     return MapStablehloOpToScalarOpImpl<
         IsFloatType, arith::MaximumFOp, IsSignedIntegerType, arith::MaxSIOp,
         IsUnsignedIntegerType, arith::MaxUIOp>{}(loc, resultTypes, argTypes,
@@ -635,7 +635,7 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::MinOp>(
   Value lhs = operands.front();
   Type complexTy = lhs.getType();
 
-  if (!complexTy.isa<ComplexType>())
+  if (!isa<ComplexType>(complexTy))
     return MapStablehloOpToScalarOpImpl<
         IsFloatType, arith::MinimumFOp, IsSignedIntegerType, arith::MinSIOp,
         IsUnsignedIntegerType, arith::MinUIOp>{}(loc, resultTypes, argTypes,
@@ -655,7 +655,7 @@ template <>
 inline Value mapStablehloOpToStdScalarOp<stablehlo::RealOp>(
     Location loc, ArrayRef<Type> resultTypes, ArrayRef<Type> argTypes,
     stablehlo::RealOp::Adaptor adaptor, OpBuilder *b) {
-  if (!adaptor.getOperand().getType().isa<ComplexType>())
+  if (!isa<ComplexType>(adaptor.getOperand().getType()))
     return adaptor.getOperand();
   return MapStablehloOpToScalarOpImpl<complex::ReOp>{}(
       loc, resultTypes, argTypes, adaptor.getOperands(), b);
@@ -665,7 +665,7 @@ template <>
 inline Value mapStablehloOpToStdScalarOp<stablehlo::ImagOp>(
     Location loc, ArrayRef<Type> resultTypes, ArrayRef<Type> argTypes,
     stablehlo::ImagOp::Adaptor adaptor, OpBuilder *b) {
-  if (!adaptor.getOperand().getType().isa<ComplexType>())
+  if (!isa<ComplexType>(adaptor.getOperand().getType()))
     return b->create<arith::ConstantOp>(
         loc, b->getZeroAttr(adaptor.getOperand().getType()));
   return MapStablehloOpToScalarOpImpl<complex::ImOp>{}(
@@ -699,9 +699,9 @@ inline Value mapConvertOpToStdScalarOp(Location loc, ArrayRef<Type> targetTypes,
     return b->create<mlir::arith::SIToFPOp>(loc, resultTypes, args,
                                             std::nullopt);
   }
-  if (sourceType.isa<FloatType>() && targetType.isa<FloatType>()) {
-    auto src = sourceType.cast<FloatType>();
-    auto res = targetType.cast<FloatType>();
+  if (isa<FloatType>(sourceType) && isa<FloatType>(targetType)) {
+    auto src = cast<FloatType>(sourceType);
+    auto res = cast<FloatType>(targetType);
     if (src.getWidth() > res.getWidth()) {
       return b->create<mlir::arith::TruncFOp>(loc, resultTypes, args,
                                               std::nullopt);
@@ -729,16 +729,16 @@ inline Value mapConvertOpToStdScalarOp(Location loc, ArrayRef<Type> targetTypes,
       return b->create<mlir::arith::CmpIOp>(loc, arith::CmpIPredicate::ne,
                                             args.front(), zeroIntval);
     }
-    if (sourceType.isa<FloatType>()) {
+    if (isa<FloatType>(sourceType)) {
       Value zero = b->create<arith::ConstantOp>(
           loc, b->getZeroAttr(args.front().getType()));
       return b->create<mlir::arith::CmpFOp>(loc, arith::CmpFPredicate::UNE,
                                             args.front(), zero);
     }
   }
-  if (sourceType.isa<IntegerType>() && targetType.isa<IntegerType>()) {
-    auto src = sourceType.cast<IntegerType>();
-    auto res = targetType.cast<IntegerType>();
+  if (isa<IntegerType>(sourceType) && isa<IntegerType>(targetType)) {
+    auto src = cast<IntegerType>(sourceType);
+    auto res = cast<IntegerType>(targetType);
     if (src.getWidth() > res.getWidth()) {
       return b->create<mlir::arith::TruncIOp>(loc, resultTypes, args,
                                               std::nullopt);
@@ -766,17 +766,17 @@ inline Value mapConvertOpToStdScalarOp(Location loc, ArrayRef<Type> targetTypes,
     return b->create<mlir::arith::FPToSIOp>(loc, resultTypes, args,
                                             std::nullopt);
   }
-  if (targetType.isa<ComplexType>()) {
-    Type targetElementType = targetType.cast<ComplexType>().getElementType();
-    assert(!targetElementType.isa<ComplexType>() &&
+  if (isa<ComplexType>(targetType)) {
+    Type targetElementType = cast<ComplexType>(targetType).getElementType();
+    assert(!isa<ComplexType>(targetElementType) &&
            "elements of complex numbers should not be complex");
     Value targetReal;
     Value targetImag;
-    if (sourceType.isa<ComplexType>()) {
+    if (isa<ComplexType>(sourceType)) {
       // We are converting from complex type: convert real and imaginary parts
       // separately.
-      Type sourceElementType = sourceType.cast<ComplexType>().getElementType();
-      assert(!sourceElementType.isa<ComplexType>() &&
+      Type sourceElementType = cast<ComplexType>(sourceType).getElementType();
+      assert(!isa<ComplexType>(sourceElementType) &&
              "elements of complex numbers should not be complex");
       Value sourceReal =
           b->create<mlir::complex::ReOp>(loc, sourceElementType, args.front());
@@ -799,7 +799,7 @@ inline Value mapConvertOpToStdScalarOp(Location loc, ArrayRef<Type> targetTypes,
     return b->create<mlir::complex::CreateOp>(loc, targetType, targetReal,
                                               targetImag);
   }
-  if (auto sourceComplexType = sourceType.dyn_cast<ComplexType>()) {
+  if (auto sourceComplexType = dyn_cast<ComplexType>(sourceType)) {
     auto sourceElementType = sourceComplexType.getElementType();
     // When converting from complex to a non-complex type, we take just the real
     // part of the complex number.
@@ -837,14 +837,14 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::DotOp>(
   const auto &rhs = adaptor.getOperands()[1];
   const auto &result = adaptor.getOperands()[2];
   Type elementType = lhs.getType();
-  if (elementType.isa<FloatType>()) {
+  if (isa<FloatType>(elementType)) {
     Value floatMul =
         MapStablehloOpToScalarOpImpl<IsFloatType, ::mlir::arith::MulFOp>{}(
             loc, resultTypes, argTypes, {lhs, rhs}, b);
     return MapStablehloOpToScalarOpImpl<IsFloatType, ::mlir::arith::AddFOp>{}(
         loc, resultTypes, argTypes, {floatMul, result}, b);
   }
-  if (elementType.isa<IntegerType>()) {
+  if (isa<IntegerType>(elementType)) {
     Value intMul =
         MapStablehloOpToScalarOpImpl<IsAnyIntegerType, ::mlir::arith::MulIOp>{}(
             loc, resultTypes, argTypes, {lhs, rhs}, b);
@@ -859,9 +859,9 @@ template <>
 inline Value mapStablehloOpToStdScalarOp<stablehlo::IsFiniteOp>(
     Location loc, ArrayRef<Type> /*ResultTypes*/, ArrayRef<Type> /*argTypes*/,
     stablehlo::IsFiniteOp::Adaptor adaptor, OpBuilder *b) {
-  if (adaptor.getX().getType().isa<FloatType>()) {
+  if (isa<FloatType>(adaptor.getX().getType())) {
     auto posInf = APFloat::getInf(
-        adaptor.getX().getType().cast<FloatType>().getFloatSemantics());
+        cast<FloatType>(adaptor.getX().getType()).getFloatSemantics());
     auto constPosInf = b->create<arith::ConstantOp>(
         loc, b->getFloatAttr(adaptor.getX().getType(), posInf));
     Value absX = b->create<::mlir::math::AbsFOp>(loc, adaptor.getX());
@@ -894,7 +894,7 @@ struct CompareSelectOpToStdScalarOp<SupportedType, StdCompareOp, Predicate,
                    ArrayRef<Type> resultTypes, ArrayRef<Type> argTypes,
                    ValueRange args, OpBuilder *b) {
     Type elementType = getElementTypeOrSelf(argTypes.front());
-    if (elementType.isa<SupportedType>()) {
+    if (isa<SupportedType>(elementType)) {
       auto predicate = getCmpPredicate<Predicate>(
           comparisonDirection, !elementType.isUnsignedInteger());
       assert(predicate.has_value() && "expected valid comparison direction");
@@ -924,7 +924,7 @@ inline Value makeSafeIntDiv(ImplicitLocOpBuilder &lb, Type originalType,
                             Value lhs, Value rhs, Value returnedOnZero,
                             Value returnedOnSignedOverflow) {
   Type type = lhs.getType();
-  auto elementType = getElementTypeOrSelf(type).cast<IntegerType>();
+  auto elementType = cast<IntegerType>(getElementTypeOrSelf(type));
   Value zero = lb.create<arith::ConstantOp>(lb.getZeroAttr(type));
   auto makeConstant = [&](const APInt &i) {
     return getConstantOrSplat(&lb, lb.getLoc(), type,
@@ -962,7 +962,7 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::DivOp>(
     Location loc, ArrayRef<Type> resultTypes, ArrayRef<Type> argTypes,
     stablehlo::DivOp::Adaptor adaptor, OpBuilder *b) {
   Type originalType = getElementTypeOrSelf(argTypes.front());
-  if (originalType.isa<ComplexType, FloatType>()) {
+  if (isa<ComplexType, FloatType>(originalType)) {
     return MapStablehloOpToScalarOpImpl<IsFloatType, arith::DivFOp,
                                         IsComplexType, complex::DivOp>{}(
         loc, resultTypes, argTypes, adaptor.getOperands(), b);
@@ -974,7 +974,7 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::DivOp>(
   // INT_SMIN /s -1 = INT_SMIN
   ImplicitLocOpBuilder lb(loc, *b);
   Type type = adaptor.getLhs().getType();
-  auto elementType = getElementTypeOrSelf(type).cast<IntegerType>();
+  auto elementType = cast<IntegerType>(getElementTypeOrSelf(type));
   auto makeConstant = [&](const APInt &i) {
     return getConstantOrSplat(&lb, lb.getLoc(), type,
                               lb.getIntegerAttr(elementType, i));
@@ -992,7 +992,7 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::RemOp>(
     Location loc, ArrayRef<Type> resultTypes, ArrayRef<Type> argTypes,
     stablehlo::RemOp::Adaptor adaptor, OpBuilder *b) {
   Type originalType = getElementTypeOrSelf(argTypes.front());
-  if (originalType.isa<ComplexType, FloatType>()) {
+  if (isa<ComplexType, FloatType>(originalType)) {
     return MapStablehloOpToScalarOpImpl<IsFloatType, arith::RemFOp>{}(
         loc, resultTypes, argTypes, adaptor.getOperands(), b);
   }
@@ -1015,13 +1015,13 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::NegOp>(
     Location loc, ArrayRef<Type> resultTypes, ArrayRef<Type> argTypes,
     stablehlo::NegOp::Adaptor adaptor, OpBuilder *b) {
   Type elementType = getElementTypeOrSelf(adaptor.getOperand().getType());
-  if (elementType.isa<ComplexType, FloatType>()) {
+  if (isa<ComplexType, FloatType>(elementType)) {
     return MapStablehloOpToScalarOpImpl<IsFloatType, ::mlir::arith::NegFOp,
                                         IsComplexType,
                                         ::mlir::complex::NegOp>{}(
         loc, resultTypes, argTypes, adaptor.getOperands(), b);
   }
-  if (elementType.isa<IntegerType>()) {
+  if (isa<IntegerType>(elementType)) {
     // lmhlo.neg(x, result) -> result = sub(0, x)
     Value lhs = adaptor.getOperand();
     Value zeroIntval =
@@ -1036,7 +1036,7 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::NotOp>(
     Location loc, ArrayRef<Type> /*ResultTypes*/, ArrayRef<Type> /*argTypes*/,
     stablehlo::NotOp::Adaptor adaptor, OpBuilder *b) {
   Type elementType = getElementTypeOrSelf(adaptor.getOperand().getType());
-  if (auto integerType = elementType.dyn_cast<IntegerType>()) {
+  if (auto integerType = dyn_cast<IntegerType>(elementType)) {
     // lmhlo.not(x) -> x ^ -1
     Value allOnes = getConstantOrSplat(
         b, loc, adaptor.getOperand().getType(),
@@ -1073,7 +1073,7 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::PowOp>(
   auto lb = ImplicitLocOpBuilder(loc, *b);
   // Floating point can use std::powf
   auto resultType = resultTypes.front();
-  if (resultType.isa<ComplexType, FloatType>()) {
+  if (isa<ComplexType, FloatType>(resultType)) {
     return MapStablehloOpToScalarOpImpl<IsFloatType, math::PowFOp,
                                         IsComplexType, complex::PowOp>{}(
         loc, resultTypes, argTypes, adaptor.getOperands(), b);
@@ -1159,7 +1159,7 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::SignOp>(
     stablehlo::SignOp::Adaptor adaptor, OpBuilder *b) {
   Value operand = adaptor.getOperand();
   Type elementType = getElementTypeOrSelf(operand.getType());
-  if (auto floatType = elementType.dyn_cast<FloatType>()) {
+  if (auto floatType = dyn_cast<FloatType>(elementType)) {
     Value zero =
         b->create<arith::ConstantOp>(loc, b->getZeroAttr(operand.getType()));
     Value ne0I1 = b->create<::mlir::arith::CmpFOp>(
@@ -1172,7 +1172,7 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::SignOp>(
         loc, arith::CmpFPredicate::UNO, operand, operand);
     return b->create<::mlir::arith::SelectOp>(loc, isNan, operand, copySign);
   }
-  if (auto integerType = elementType.dyn_cast<IntegerType>()) {
+  if (auto integerType = dyn_cast<IntegerType>(elementType)) {
     // sign(x) = x == 0 ? 0 : ((x s>> 31) | 1)
     Value zero =
         b->create<arith::ConstantOp>(loc, b->getZeroAttr(operand.getType()));
@@ -1188,7 +1188,7 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::SignOp>(
     Value orOp = b->create<::mlir::arith::OrIOp>(loc, ashr, one);
     return b->create<::mlir::arith::SelectOp>(loc, cmp, zero, orOp);
   }
-  if (elementType.isa<ComplexType>()) {
+  if (isa<ComplexType>(elementType)) {
     return b->create<::mlir::complex::SignOp>(loc, elementType, operand);
   }
   return nullptr;
@@ -1200,7 +1200,7 @@ inline Value selectShiftedOrSaturated(ImplicitLocOpBuilder &lb, Value rhs,
                                       Value shifted, Value saturated,
                                       Type type) {
   Type etype =
-      type.isa<ShapedType>() ? type.cast<ShapedType>().getElementType() : type;
+      isa<ShapedType>(type) ? cast<ShapedType>(type).getElementType() : type;
   auto bitWidthInt = etype.getIntOrFloatBitWidth();
   Value bitWidth = getConstantOrSplat(&lb, lb.getLoc(), type,
                                       lb.getIntegerAttr(etype, bitWidthInt));
@@ -1250,7 +1250,7 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::ShiftRightArithmeticOp>(
   Value rhs = adaptor.getRhs();
   Type type = lhs.getType();
   Type etype =
-      type.isa<ShapedType>() ? type.cast<ShapedType>().getElementType() : type;
+      isa<ShapedType>(type) ? cast<ShapedType>(type).getElementType() : type;
   auto bitWidthInt = etype.getIntOrFloatBitWidth();
 
   // "Saturate" if the shift is greater than the bitwidth of the type

--- a/stablehlo/conversions/linalg/transforms/StablehloToLinalgRandom.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloToLinalgRandom.cpp
@@ -582,7 +582,7 @@ LogicalResult generateLinalgPhilox32(OpBuilder &builder, Location loc,
   Value dest3 = builder.create<tensor::EmptyOp>(loc, ArrayRef<int64_t>({count}),
                                                 resultETy);
 
-  ShapedType destTy = dest0.getType().cast<ShapedType>();
+  ShapedType destTy = cast<ShapedType>(dest0.getType());
 
   SmallVector<AffineMap> indexingMaps(4, builder.getMultiDimIdentityMap(1));
   SmallVector<utils::IteratorType> iterators(1, utils::IteratorType::parallel);
@@ -674,7 +674,7 @@ LogicalResult generateLinalgPhilox64(OpBuilder &builder, Location loc,
                                                 resultETy);
   Value dest1 = builder.create<tensor::EmptyOp>(loc, ArrayRef<int64_t>({count}),
                                                 resultETy);
-  ShapedType destTy = dest0.getType().cast<ShapedType>();
+  ShapedType destTy = cast<ShapedType>(dest0.getType());
 
   SmallVector<AffineMap> indexingMaps(2, builder.getMultiDimIdentityMap(1));
   SmallVector<utils::IteratorType> iterators(1, utils::IteratorType::parallel);

--- a/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.cpp
+++ b/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.cpp
@@ -95,13 +95,13 @@ struct ConvertStablehloDotOp : public OpRewritePattern<stablehlo::DotOp> {
 
   LogicalResult matchAndRewrite(stablehlo::DotOp op,
                                 PatternRewriter& rewriter) const override {
-    auto lhsType = op.getLhs().getType().dyn_cast<RankedTensorType>();
-    auto rhsType = op.getRhs().getType().dyn_cast<RankedTensorType>();
+    auto lhsType = dyn_cast<RankedTensorType>(op.getLhs().getType());
+    auto rhsType = dyn_cast<RankedTensorType>(op.getRhs().getType());
     if (!lhsType || !rhsType) {
       return rewriter.notifyMatchFailure(op, "input tensors are not ranked");
     }
 
-    auto resultType = op.getResult().getType().dyn_cast<ShapedType>();
+    auto resultType = dyn_cast<ShapedType>(op.getResult().getType());
     if (!resultType) {
       return rewriter.notifyMatchFailure(op,
                                          "result tensor does not have shape");
@@ -188,8 +188,8 @@ struct ConvertStablehloIotaOp : public OpRewritePattern<stablehlo::IotaOp> {
   LogicalResult matchAndRewrite(stablehlo::IotaOp op,
                                 PatternRewriter& rewriter) const override {
     auto resultType = op.getResult().getType();
-    auto elementType = resultType.cast<ShapedType>().getElementType();
-    auto resultRankedType = resultType.dyn_cast<RankedTensorType>();
+    auto elementType = cast<ShapedType>(resultType).getElementType();
+    auto resultRankedType = dyn_cast<RankedTensorType>(resultType);
 
     if (!resultRankedType) {
       return rewriter.notifyMatchFailure(op, "result tensor must be ranked");
@@ -206,7 +206,7 @@ struct ConvertStablehloIotaOp : public OpRewritePattern<stablehlo::IotaOp> {
     llvm::SmallVector<Attribute, 4> constValues;
     constValues.resize(iotaArrayLength);
     for (int i = 0; i < iotaArrayLength; i++) {
-      if (elementType.isa<FloatType>()) {
+      if (isa<FloatType>(elementType)) {
         constValues[i] = rewriter.getFloatAttr(elementType, i);
       } else {
         constValues[i] = rewriter.getIntegerAttr(elementType, i);
@@ -249,7 +249,7 @@ struct ConvertStablehloGatherOp : public OpRewritePattern<stablehlo::GatherOp> {
                                 PatternRewriter& rewriter) const override {
     // The input operand must be 3D, with shape [N, K, C].
     auto operand = op.getOperand();
-    auto operandType = operand.getType().dyn_cast<RankedTensorType>();
+    auto operandType = dyn_cast<RankedTensorType>(operand.getType());
     if (!operandType) {
       return rewriter.notifyMatchFailure(op, "requires ranked operand shape");
     }
@@ -259,7 +259,7 @@ struct ConvertStablehloGatherOp : public OpRewritePattern<stablehlo::GatherOp> {
 
     // The indices tensor must be 2D, with shape [N, W].
     auto startIndices = op.getStartIndices();
-    auto startIndicesType = startIndices.getType().dyn_cast<RankedTensorType>();
+    auto startIndicesType = dyn_cast<RankedTensorType>(startIndices.getType());
     if (!startIndicesType) {
       return rewriter.notifyMatchFailure(op,
                                          "requires ranked start_indices shape");
@@ -270,7 +270,7 @@ struct ConvertStablehloGatherOp : public OpRewritePattern<stablehlo::GatherOp> {
     }
 
     // The result tensor must be 3D, with shape [N, W, C].
-    auto resultType = op.getResult().getType().dyn_cast<RankedTensorType>();
+    auto resultType = dyn_cast<RankedTensorType>(op.getResult().getType());
     if (!resultType) {
       return rewriter.notifyMatchFailure(op, "requires ranked output shape");
     }
@@ -324,7 +324,7 @@ struct ConvertStablehloReduceOp : public OpRewritePattern<stablehlo::ReduceOp> {
     }
 
     auto operand = op.getInputs().front();
-    ShapedType inputType = operand.getType().cast<ShapedType>();
+    ShapedType inputType = cast<ShapedType>(operand.getType());
     Operation& innerOp = bodyBlock.front();
     uint64_t dimension = op.getDimensions()[0];
     SmallVector<int64_t> innerShape(inputType.getShape());

--- a/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.pdll
+++ b/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.pdll
@@ -17,7 +17,7 @@
 
 // Helper functions.
 Rewrite onesLike(op: Op, type: Type) -> Op [{
-  auto elementType = type.cast<mlir::TensorType>().getElementType();
+  auto elementType = llvm::cast<mlir::TensorType>(type).getElementType();
   llvm::SmallVector<mlir::Attribute, 4> outputValue;
 
   if (elementType.isF16() || elementType.isF32() || elementType.isBF16()) {
@@ -33,9 +33,9 @@ Rewrite onesLike(op: Op, type: Type) -> Op [{
 }];
 
 Rewrite positiveFloatInfinityLike(op: Op, type: Type) -> Op [{
-  auto elementType = type.cast<mlir::TensorType>().getElementType();
+  auto elementType = llvm::cast<mlir::TensorType>(type).getElementType();
   const llvm::fltSemantics& semantic =
-      elementType.cast<mlir::FloatType>().getFloatSemantics();
+      llvm::cast<mlir::FloatType>(elementType).getFloatSemantics();
 
   llvm::SmallVector<mlir::Attribute, 4> outputValue;
   outputValue.push_back(rewriter.getFloatAttr(
@@ -48,7 +48,7 @@ Rewrite positiveFloatInfinityLike(op: Op, type: Type) -> Op [{
 }];
 
 Rewrite changeElementTypeToI1(type: Type) -> Type [{
-  auto tensorType = type.cast<mlir::RankedTensorType>();
+  auto tensorType = llvm::cast<mlir::RankedTensorType>(type);
   return RankedTensorType::get(tensorType.getShape(), rewriter.getI1Type());
 }];
 

--- a/stablehlo/dialect/AssemblyFormat.h
+++ b/stablehlo/dialect/AssemblyFormat.h
@@ -324,12 +324,12 @@ ParseResult parseDotDimensionNumbers(AsmParser& parser, AttrTy& target) {
   // Parse `[...] x [...]` into two DenseI64ArrayAttr attributes.
   auto parseLhsRhsDims = [&](DenseI64ArrayAttr& lhsDims,
                              DenseI64ArrayAttr& rhsDims) -> ParseResult {
-    lhsDims = DenseI64ArrayAttr::parse(parser, Type{})
-                  .dyn_cast_or_null<DenseI64ArrayAttr>();
+    lhsDims = dyn_cast_or_null<DenseI64ArrayAttr>(
+        DenseI64ArrayAttr::parse(parser, Type{}));
     if (!lhsDims) return failure();
     if (failed(parser.parseKeyword("x"))) return failure();
-    rhsDims = DenseI64ArrayAttr::parse(parser, Type{})
-                  .dyn_cast_or_null<DenseI64ArrayAttr>();
+    rhsDims = dyn_cast_or_null<DenseI64ArrayAttr>(
+        DenseI64ArrayAttr::parse(parser, Type{}));
     if (!rhsDims) return failure();
     return success();
   };

--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -390,7 +390,7 @@ class CompatibleOperandsAndResultType
                                 inferredReturnTypes)))
       return failure();
     if (inferredReturnTypes.size() != 1) return failure();
-    auto inferredReturnType = inferredReturnTypes[0].dyn_cast<ShapedType>();
+    auto inferredReturnType = dyn_cast<ShapedType>(inferredReturnTypes[0]);
     if (!inferredReturnType) return failure();
     inferredReturnShapes.push_back(inferredReturnType);
     return success();

--- a/stablehlo/dialect/Base.td
+++ b/stablehlo/dialect/Base.td
@@ -54,32 +54,34 @@ def HLO_Complex : Complex<AnyTypeOf<[F32, F64]>>;
 
 // TODO(b/230381284): Upstream width-specific uniform quantized element types.
 class StableHLO_UniformQuantizedSignedInt<int width>
-  : Type<And<[CPred<"$_self.isa<mlir::quant::UniformQuantizedType>()">,
-           CPred<"$_self.cast<mlir::quant::UniformQuantizedType>()" #
+  : Type<And<[CPred<"isa<mlir::quant::UniformQuantizedType>($_self)">,
+           CPred<"cast<mlir::quant::UniformQuantizedType>($_self)" #
                  ".getStorageTypeIntegralWidth() == " # width>,
-           CPred<"$_self.cast<mlir::quant::UniformQuantizedType>()" #
-                 ".getStorageType().cast<mlir::IntegerType>().isSignless()">]>,
+           CPred<"cast<mlir::IntegerType>(" #
+                   "cast<mlir::quant::UniformQuantizedType>($_self).getStorageType()" #
+                 ").isSignless()">]>,
     "QI" # width # " type"> {
   string name = "UniformQuantizedSignedInt";
   int bitwidth = width;
 }
 
 class StableHLO_UniformQuantizedPerAxisSignedInt<int width>
-  : Type<And<[CPred<"$_self.isa<mlir::quant::UniformQuantizedPerAxisType>()">,
-           CPred<"$_self.cast<mlir::quant::UniformQuantizedPerAxisType>()" #
+  : Type<And<[CPred<"isa<mlir::quant::UniformQuantizedPerAxisType>($_self)">,
+           CPred<"cast<mlir::quant::UniformQuantizedPerAxisType>($_self)" #
                  ".getStorageTypeIntegralWidth() == " # width>,
-           CPred<"$_self.cast<mlir::quant::UniformQuantizedPerAxisType>()" #
-                 ".getStorageType().cast<mlir::IntegerType>().isSignless()">]>,
+           CPred<"cast<mlir::IntegerType>(" #
+                   "cast<mlir::quant::UniformQuantizedPerAxisType>($_self).getStorageType()" #
+                 ").isSignless()">]>,
     "QI" # width # " type"> {
   string name = "UniformQuantizedPerAxisSignedInt";
   int bitwidth = width;
 }
 
 class StableHLO_UniformQuantizedUnsignedInt<int width>
-  : Type<And<[CPred<"$_self.isa<mlir::quant::UniformQuantizedType>()">,
-           CPred<"$_self.cast<mlir::quant::UniformQuantizedType>()" #
+  : Type<And<[CPred<"isa<mlir::quant::UniformQuantizedType>($_self)">,
+           CPred<"cast<mlir::quant::UniformQuantizedType>($_self)" #
                  ".getStorageTypeIntegralWidth() == " # width>,
-           CPred<"!$_self.cast<mlir::quant::UniformQuantizedType>()" #
+           CPred<"!cast<mlir::quant::UniformQuantizedType>($_self)" #
                  ".isSigned()">]>,
     "QUI" # width # " type"> {
   string name = "UniformQuantizedUnsignedInt";
@@ -87,10 +89,10 @@ class StableHLO_UniformQuantizedUnsignedInt<int width>
 }
 
 class StableHLO_UniformQuantizedPerAxisUnsignedInt<int width>
-  : Type<And<[CPred<"$_self.isa<mlir::quant::UniformQuantizedPerAxisType>()">,
-           CPred<"$_self.cast<mlir::quant::UniformQuantizedPerAxisType>()" #
+  : Type<And<[CPred<"isa<mlir::quant::UniformQuantizedPerAxisType>($_self)">,
+           CPred<"cast<mlir::quant::UniformQuantizedPerAxisType>($_self)" #
                  ".getStorageTypeIntegralWidth() == " # width>,
-           CPred<"!$_self.cast<mlir::quant::UniformQuantizedPerAxisType>()" #
+           CPred<"!cast<mlir::quant::UniformQuantizedPerAxisType>($_self)" #
                  ".isSigned()">]>,
     "QUI" # width # " type"> {
   string name = "UniformQuantizedPerAxisUnsignedInt";
@@ -132,7 +134,7 @@ def HLO_PerAxisQuantizedInt :
     AnyTypeOf<[HLO_PerAxisQuantizedSignedInt, HLO_PerAxisQuantizedUnsignedInt]>;
 
 // Token type.
-def HLO_Token : Type<CPred<"$_self.isa<TokenType>()">, "token">;
+def HLO_Token : Type<CPred<"isa<TokenType>($_self)">, "token">;
 
 // Any integer tensor types
 def HLO_IntTensor : RankedTensorOf<[HLO_Int]>;

--- a/stablehlo/dialect/BroadcastUtils.cpp
+++ b/stablehlo/dialect/BroadcastUtils.cpp
@@ -29,8 +29,8 @@ namespace hlo {
 
 bool isLegalNumpyRankedBroadcast(Value lhs, Value rhs,
                                  llvm::ArrayRef<int64_t> broadcastDimensions) {
-  RankedTensorType lhsType = lhs.getType().dyn_cast<RankedTensorType>();
-  RankedTensorType rhsType = rhs.getType().dyn_cast<RankedTensorType>();
+  RankedTensorType lhsType = dyn_cast<RankedTensorType>(lhs.getType());
+  RankedTensorType rhsType = dyn_cast<RankedTensorType>(rhs.getType());
   if (!lhsType || !rhsType) return false;
   if (lhsType.getRank() == rhsType.getRank()) return true;
 
@@ -62,7 +62,7 @@ Value computeNaryElementwiseBroadcastingResultExtents(Location loc,
 
   int64_t resultRank = 0;
   for (Value s : shapes) {
-    auto ty = s.getType().cast<RankedTensorType>();
+    auto ty = cast<RankedTensorType>(s.getType());
     assert(ty.getRank() == 1 && "expect extent tensor type");
     if (ty.isDynamicDim(0)) {
       resultRank = ShapedType::kDynamic;

--- a/stablehlo/dialect/StablehloAttrs.td
+++ b/stablehlo/dialect/StablehloAttrs.td
@@ -141,7 +141,7 @@ def StableHLO_TypeExtensions : AttrDef<StableHLO_Dialect, "TypeExtensions", [
 // A layout attribute (1D tensor of index type)
 def StableHLO_LayoutAttr : Attr<
   And<[IndexElementsAttr.predicate,
-       CPred<[{$_self.cast<::mlir::DenseIntElementsAttr>().getType().getRank()
+       CPred<[{cast<::mlir::DenseIntElementsAttr>($_self).getType().getRank()
                == 1}]>]>,
   "A 1D tensor of index type (layout)"> {
   let storageType = IndexElementsAttr.storageType;

--- a/stablehlo/dialect/VhloBytecode.cpp
+++ b/stablehlo/dialect/VhloBytecode.cpp
@@ -674,15 +674,15 @@ void VhloBytecodeInterface::write(FftTypeV1Attr attr,
 namespace {
 /// Returns the floating semantics for the given type.
 const llvm::fltSemantics &getFloatSemantics(Type type) {
-  if (type.isa<FloatBF16V1Type>()) return APFloat::BFloat();
-  if (type.isa<FloatF16V1Type>()) return APFloat::IEEEhalf();
-  if (type.isa<FloatF32V1Type>()) return APFloat::IEEEsingle();
-  if (type.isa<FloatF64V1Type>()) return APFloat::IEEEdouble();
-  if (type.isa<FloatF8E4M3FNUZV1Type>()) return APFloat::Float8E4M3FNUZ();
-  if (type.isa<FloatF8E4M3B11FNUZV1Type>()) return APFloat::Float8E4M3B11FNUZ();
-  if (type.isa<FloatF8E4M3FNV1Type>()) return APFloat::Float8E4M3FN();
-  if (type.isa<FloatF8E5M2FNUZV1Type>()) return APFloat::Float8E5M2FNUZ();
-  if (type.isa<FloatF8E5M2V1Type>()) return APFloat::Float8E5M2();
+  if (isa<FloatBF16V1Type>(type)) return APFloat::BFloat();
+  if (isa<FloatF16V1Type>(type)) return APFloat::IEEEhalf();
+  if (isa<FloatF32V1Type>(type)) return APFloat::IEEEsingle();
+  if (isa<FloatF64V1Type>(type)) return APFloat::IEEEdouble();
+  if (isa<FloatF8E4M3FNUZV1Type>(type)) return APFloat::Float8E4M3FNUZ();
+  if (isa<FloatF8E4M3B11FNUZV1Type>(type)) return APFloat::Float8E4M3B11FNUZ();
+  if (isa<FloatF8E4M3FNV1Type>(type)) return APFloat::Float8E4M3FN();
+  if (isa<FloatF8E5M2FNUZV1Type>(type)) return APFloat::Float8E5M2FNUZ();
+  if (isa<FloatF8E5M2V1Type>(type)) return APFloat::Float8E5M2();
   llvm::report_fatal_error("unsupported floating-point type");
 }
 }  // namespace
@@ -713,11 +713,11 @@ void VhloBytecodeInterface::write(FloatV1Attr attr,
 
 namespace {
 unsigned getBitWidthForIntegerType(Type type) {
-  if (type.isa<IntegerSI4V1Type>() || type.isa<IntegerUI4V1Type>()) return 4;
-  if (type.isa<IntegerSI8V1Type>() || type.isa<IntegerUI8V1Type>()) return 8;
-  if (type.isa<IntegerSI16V1Type>() || type.isa<IntegerUI16V1Type>()) return 16;
-  if (type.isa<IntegerSI32V1Type>() || type.isa<IntegerUI32V1Type>()) return 32;
-  if (type.isa<IntegerSI64V1Type>() || type.isa<IntegerUI64V1Type>()) return 64;
+  if (isa<IntegerSI4V1Type>(type) || isa<IntegerUI4V1Type>(type)) return 4;
+  if (isa<IntegerSI8V1Type>(type) || isa<IntegerUI8V1Type>(type)) return 8;
+  if (isa<IntegerSI16V1Type>(type) || isa<IntegerUI16V1Type>(type)) return 16;
+  if (isa<IntegerSI32V1Type>(type) || isa<IntegerUI32V1Type>(type)) return 32;
+  if (isa<IntegerSI64V1Type>(type) || isa<IntegerUI64V1Type>(type)) return 64;
   llvm::report_fatal_error("unsupported integer type");
 }
 }  // namespace
@@ -730,7 +730,7 @@ IntegerV1Attr VhloBytecodeInterface::readIntegerV1Attr(
 
   // Extract the value storage width from the type.
   unsigned bitWidth;
-  if (type.isa<IndexV1Type>()) {
+  if (isa<IndexV1Type>(type)) {
     bitWidth = IndexType::kInternalStorageBitWidth;
   } else {
     bitWidth = getBitWidthForIntegerType(type);

--- a/stablehlo/dialect/VhloOps.cpp
+++ b/stablehlo/dialect/VhloOps.cpp
@@ -142,12 +142,12 @@ ParseResult parseAttributeDictionary(
 // Print function using: @name(arg : type, ...) -> (res_type...) { body_ops }
 void printFunctionBody(OpAsmPrinter& p, Operation*, Attribute name,
                        Region& region, Attribute funcType) {
-  p.printSymbolName(name.cast<StringV1Attr>().getValue());
+  p.printSymbolName(cast<StringV1Attr>(name).getValue());
   p << '(';
   llvm::interleaveComma(region.getArguments(), p,
                         [&](auto arg) { p.printRegionArgument(arg); });
   p << ") -> (";
-  auto fnType = funcType.cast<TypeV1Attr>().getValue().cast<FunctionV1Type>();
+  auto fnType = cast<FunctionV1Type>(cast<TypeV1Attr>(funcType).getValue());
   llvm::interleaveComma(fnType.getOutputs(), p,
                         [&](auto res) { p.printType(res); });
   p << ") ";
@@ -182,7 +182,7 @@ ParseResult parseFunctionBody(OpAsmParser& parser, Attribute& name,
 void TensorV1Attr::print(mlir::AsmPrinter& p) const {
   p << '<'
     << DenseIntOrFPElementsAttr::getFromRawBuffer(
-           convertTypeToBuiltinForPrint(getType()).cast<ShapedType>(),
+           llvm::cast<ShapedType>(convertTypeToBuiltinForPrint(getType())),
            getData())
     << '>';
 }
@@ -306,10 +306,10 @@ void VhloDialect::printAttribute(Attribute attr, DialectAsmPrinter& os) const {
 
 namespace {
 Type getVhloElementType(Type tensorType) {
-  if (auto ranked = tensorType.dyn_cast<RankedTensorV1Type>()) {
+  if (auto ranked = dyn_cast<RankedTensorV1Type>(tensorType)) {
     return ranked.getElementType();
   }
-  return tensorType.cast<UnrankedTensorV1Type>().getElementType();
+  return cast<UnrankedTensorV1Type>(tensorType).getElementType();
 }
 
 bool checkIfOperandAndResultElementTypesMatch(TypeRange operandTypes,

--- a/stablehlo/dialect/VhloTypes.cpp
+++ b/stablehlo/dialect/VhloTypes.cpp
@@ -38,20 +38,20 @@ Type convertBuiltinIntegerType(IntegerType type) {
   auto ctx = type.getContext();
   switch (type.getWidth()) {
     case 4:
-      return isSignless ? IntegerSI4V1Type::get(ctx).cast<Type>()
-                        : IntegerUI4V1Type::get(ctx).cast<Type>();
+      return isSignless ? cast<Type>(IntegerSI4V1Type::get(ctx))
+                        : cast<Type>(IntegerUI4V1Type::get(ctx));
     case 8:
-      return isSignless ? IntegerSI8V1Type::get(ctx).cast<Type>()
-                        : IntegerUI8V1Type::get(ctx).cast<Type>();
+      return isSignless ? cast<Type>(IntegerSI8V1Type::get(ctx))
+                        : cast<Type>(IntegerUI8V1Type::get(ctx));
     case 16:
-      return isSignless ? IntegerSI16V1Type::get(ctx).cast<Type>()
-                        : IntegerUI16V1Type::get(ctx).cast<Type>();
+      return isSignless ? cast<Type>(IntegerSI16V1Type::get(ctx))
+                        : cast<Type>(IntegerUI16V1Type::get(ctx));
     case 32:
-      return isSignless ? IntegerSI32V1Type::get(ctx).cast<Type>()
-                        : IntegerUI32V1Type::get(ctx).cast<Type>();
+      return isSignless ? cast<Type>(IntegerSI32V1Type::get(ctx))
+                        : cast<Type>(IntegerUI32V1Type::get(ctx));
     case 64:
-      return isSignless ? IntegerSI64V1Type::get(ctx).cast<Type>()
-                        : IntegerUI64V1Type::get(ctx).cast<Type>();
+      return isSignless ? cast<Type>(IntegerSI64V1Type::get(ctx))
+                        : cast<Type>(IntegerUI64V1Type::get(ctx));
   }
   return {};
 }

--- a/stablehlo/integrations/c/ChloAttributes.cpp
+++ b/stablehlo/integrations/c/ChloAttributes.cpp
@@ -33,12 +33,13 @@ MlirAttribute chloComparisonDirectionAttrGet(MlirContext ctx,
 }
 
 bool chloAttributeIsAComparisonDirectionAttr(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::chlo::ComparisonDirectionAttr>();
+  return llvm::isa<mlir::chlo::ComparisonDirectionAttr>(unwrap(attr));
 }
 
 MlirStringRef chloComparisonDirectionAttrGetValue(MlirAttribute attr) {
   return wrap(mlir::chlo::stringifyComparisonDirection(
-      unwrap(attr).cast<mlir::chlo::ComparisonDirectionAttr>().getValue()));
+      llvm::cast<mlir::chlo::ComparisonDirectionAttr>(unwrap(attr))
+          .getValue()));
 }
 
 //===----------------------------------------------------------------------===//
@@ -54,10 +55,10 @@ MlirAttribute chloComparisonTypeAttrGet(MlirContext ctx, MlirStringRef value) {
 }
 
 bool chloAttributeIsAComparisonTypeAttr(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::chlo::ComparisonTypeAttr>();
+  return llvm::isa<mlir::chlo::ComparisonTypeAttr>(unwrap(attr));
 }
 
 MlirStringRef chloComparisonTypeAttrGetValue(MlirAttribute attr) {
   return wrap(mlir::chlo::stringifyComparisonType(
-      unwrap(attr).cast<mlir::chlo::ComparisonTypeAttr>().getValue()));
+      llvm::cast<mlir::chlo::ComparisonTypeAttr>(unwrap(attr)).getValue()));
 }

--- a/stablehlo/integrations/c/StablehloAttributes.cpp
+++ b/stablehlo/integrations/c/StablehloAttributes.cpp
@@ -34,57 +34,50 @@ MlirAttribute stablehloScatterDimensionNumbersGet(
 }
 
 bool stablehloAttributeIsAScatterDimensionNumbers(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::stablehlo::ScatterDimensionNumbersAttr>();
+  return llvm::isa<mlir::stablehlo::ScatterDimensionNumbersAttr>(unwrap(attr));
 }
 
 intptr_t stablehloScatterDimensionNumbersGetUpdateWindowDimsSize(
     MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::ScatterDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::ScatterDimensionNumbersAttr>(unwrap(attr))
       .getUpdateWindowDims()
       .size();
 }
 
 int64_t stablehloScatterDimensionNumbersGetUpdateWindowDimsElem(
     MlirAttribute attr, intptr_t pos) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::ScatterDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::ScatterDimensionNumbersAttr>(unwrap(attr))
       .getUpdateWindowDims()[pos];
 }
 
 intptr_t stablehloScatterDimensionNumbersGetInsertedWindowDimsSize(
     MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::ScatterDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::ScatterDimensionNumbersAttr>(unwrap(attr))
       .getInsertedWindowDims()
       .size();
 }
 
 int64_t stablehloScatterDimensionNumbersGetInsertedWindowDimsElem(
     MlirAttribute attr, intptr_t pos) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::ScatterDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::ScatterDimensionNumbersAttr>(unwrap(attr))
       .getInsertedWindowDims()[pos];
 }
 
 intptr_t stablehloScatterDimensionNumbersGetScatteredDimsToOperandDimsSize(
     MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::ScatterDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::ScatterDimensionNumbersAttr>(unwrap(attr))
       .getScatterDimsToOperandDims()
       .size();
 }
 
 int64_t stablehloScatterDimensionNumbersGetScatteredDimsToOperandDimsElem(
     MlirAttribute attr, intptr_t pos) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::ScatterDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::ScatterDimensionNumbersAttr>(unwrap(attr))
       .getScatterDimsToOperandDims()[pos];
 }
 
 int64_t stablehloDimensionNumbersGetIndexVectorDim(MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::ScatterDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::ScatterDimensionNumbersAttr>(unwrap(attr))
       .getIndexVectorDim();
 }
 
@@ -104,56 +97,49 @@ MlirAttribute stablehloGatherDimensionNumbersGet(
 }
 
 bool stablehloAttributeIsAGatherDimensionNumbers(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::stablehlo::GatherDimensionNumbersAttr>();
+  return llvm::isa<mlir::stablehlo::GatherDimensionNumbersAttr>(unwrap(attr));
 }
 
 intptr_t stablehloGatherDimensionNumbersGetOffsetDimsSize(MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::GatherDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::GatherDimensionNumbersAttr>(unwrap(attr))
       .getOffsetDims()
       .size();
 }
 
 int64_t stablehloGatherDimensionNumbersGetOffsetDimsElem(MlirAttribute attr,
                                                          intptr_t pos) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::GatherDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::GatherDimensionNumbersAttr>(unwrap(attr))
       .getOffsetDims()[pos];
 }
 
 intptr_t stablehloGatherDimensionNumbersGetCollapsedSliceDimsSize(
     MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::GatherDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::GatherDimensionNumbersAttr>(unwrap(attr))
       .getCollapsedSliceDims()
       .size();
 }
 
 int64_t stablehloGatherDimensionNumbersGetCollapsedSliceDimsElem(
     MlirAttribute attr, intptr_t pos) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::GatherDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::GatherDimensionNumbersAttr>(unwrap(attr))
       .getCollapsedSliceDims()[pos];
 }
 
 intptr_t stablehloGatherDimensionNumbersGetStartIndexMapSize(
     MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::GatherDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::GatherDimensionNumbersAttr>(unwrap(attr))
       .getStartIndexMap()
       .size();
 }
 
 int64_t stablehloGatherDimensionNumbersGetStartIndexMapElem(MlirAttribute attr,
                                                             intptr_t pos) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::GatherDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::GatherDimensionNumbersAttr>(unwrap(attr))
       .getStartIndexMap()[pos];
 }
 
 int64_t stablehloGatherDimensionNumbersGetIndexVectorDim(MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::GatherDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::GatherDimensionNumbersAttr>(unwrap(attr))
       .getIndexVectorDim();
 }
 
@@ -176,66 +162,58 @@ MlirAttribute stablehloDotDimensionNumbersGet(
 }
 
 bool stablehloAttributeIsADotDimensionNumbers(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::stablehlo::DotDimensionNumbersAttr>();
+  return llvm::isa<mlir::stablehlo::DotDimensionNumbersAttr>(unwrap(attr));
 }
 
 intptr_t stablehloDotDimensionNumbersGetLhsBatchingDimensionsSize(
     MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::DotDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::DotDimensionNumbersAttr>(unwrap(attr))
       .getLhsBatchingDimensions()
       .size();
 }
 
 int64_t stablehloDotDimensionNumbersGetLhsBatchingDimensionsElem(
     MlirAttribute attr, intptr_t pos) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::DotDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::DotDimensionNumbersAttr>(unwrap(attr))
       .getLhsBatchingDimensions()[pos];
 }
 
 intptr_t stablehloDotDimensionNumbersGetRhsBatchingDimensionsSize(
     MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::DotDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::DotDimensionNumbersAttr>(unwrap(attr))
       .getRhsBatchingDimensions()
       .size();
 }
 
 int64_t stablehloDotDimensionNumbersGetRhsBatchingDimensionsElem(
     MlirAttribute attr, intptr_t pos) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::DotDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::DotDimensionNumbersAttr>(unwrap(attr))
       .getRhsBatchingDimensions()[pos];
 }
 
 intptr_t stablehloDotDimensionNumbersGetLhsContractingDimensionsSize(
     MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::DotDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::DotDimensionNumbersAttr>(unwrap(attr))
       .getLhsContractingDimensions()
       .size();
 }
 
 int64_t stablehloDotDimensionNumbersGetLhsContractingDimensionsElem(
     MlirAttribute attr, intptr_t pos) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::DotDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::DotDimensionNumbersAttr>(unwrap(attr))
       .getLhsContractingDimensions()[pos];
 }
 
 intptr_t stablehloDotDimensionNumbersGetRhsContractingDimensionsSize(
     MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::DotDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::DotDimensionNumbersAttr>(unwrap(attr))
       .getRhsContractingDimensions()
       .size();
 }
 
 int64_t stablehloDotDimensionNumbersGetRhsContractingDimensionsElem(
     MlirAttribute attr, intptr_t pos) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::DotDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::DotDimensionNumbersAttr>(unwrap(attr))
       .getRhsContractingDimensions()[pos];
 }
 
@@ -260,93 +238,81 @@ MlirAttribute stablehloConvDimensionNumbersGet(
 }
 
 bool stablehloAttributeIsAConvDimensionNumbers(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::stablehlo::ConvDimensionNumbersAttr>();
+  return llvm::isa<mlir::stablehlo::ConvDimensionNumbersAttr>(unwrap(attr));
 }
 
 int64_t stablehloConvDimensionNumbersGetInputBatchDimension(
     MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::ConvDimensionNumbersAttr>(unwrap(attr))
       .getInputBatchDimension();
 }
 
 int64_t stablehloConvDimensionNumbersGetInputFeatureDimension(
     MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::ConvDimensionNumbersAttr>(unwrap(attr))
       .getInputFeatureDimension();
 }
 
 intptr_t stablehloConvDimensionNumbersGetInputSpatialDimensionsSize(
     MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::ConvDimensionNumbersAttr>(unwrap(attr))
       .getInputSpatialDimensions()
       .size();
 }
 
 int64_t stablehloConvDimensionNumbersGetInputSpatialDimensionsElem(
     MlirAttribute attr, intptr_t pos) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::ConvDimensionNumbersAttr>(unwrap(attr))
       .getInputSpatialDimensions()[pos];
 }
 
 int64_t stablehloConvDimensionNumbersGetKernelInputFeatureDimension(
     MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::ConvDimensionNumbersAttr>(unwrap(attr))
       .getKernelInputFeatureDimension();
 }
 
 int64_t stablehloConvDimensionNumbersGetKernelOutputFeatureDimension(
     MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::ConvDimensionNumbersAttr>(unwrap(attr))
       .getKernelOutputFeatureDimension();
 }
 
 intptr_t stablehloConvDimensionNumbersGetKernelSpatialDimensionsSize(
     MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::ConvDimensionNumbersAttr>(unwrap(attr))
       .getKernelSpatialDimensions()
       .size();
 }
 
 int64_t stablehloConvDimensionNumbersGetKernelSpatialDimensionsElem(
     MlirAttribute attr, intptr_t pos) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::ConvDimensionNumbersAttr>(unwrap(attr))
       .getKernelSpatialDimensions()[pos];
 }
 
 int64_t stablehloConvDimensionNumbersGetOutputBatchDimension(
     MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::ConvDimensionNumbersAttr>(unwrap(attr))
       .getOutputBatchDimension();
 }
 
 int64_t stablehloConvDimensionNumbersGetOutputFeatureDimension(
     MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::ConvDimensionNumbersAttr>(unwrap(attr))
       .getOutputFeatureDimension();
 }
 
 intptr_t stablehloConvDimensionNumbersGetOutputSpatialDimensionsSize(
     MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::ConvDimensionNumbersAttr>(unwrap(attr))
       .getOutputSpatialDimensions()
       .size();
 }
 
 int64_t stablehloConvDimensionNumbersGetOutputSpatialDimensionsElem(
     MlirAttribute attr, intptr_t pos) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::ConvDimensionNumbersAttr>()
+  return llvm::cast<mlir::stablehlo::ConvDimensionNumbersAttr>(unwrap(attr))
       .getOutputSpatialDimensions()[pos];
 }
 
@@ -364,42 +330,37 @@ MLIR_CAPI_EXPORTED MlirAttribute stablehloOutputOperandAliasGet(
 }
 
 bool stablehloAttributeIsAOutputOperandAlias(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::stablehlo::OutputOperandAliasAttr>();
+  return llvm::isa<mlir::stablehlo::OutputOperandAliasAttr>(unwrap(attr));
 }
 
 intptr_t stablehloOutputOperandAliasGetOutputTupleIndicesSize(
     MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::OutputOperandAliasAttr>()
+  return llvm::cast<mlir::stablehlo::OutputOperandAliasAttr>(unwrap(attr))
       .getOutputTupleIndices()
       .size();
 }
 
 int64_t stablehloOutputOperandAliasGetOutputTupleIndicesElem(MlirAttribute attr,
                                                              intptr_t pos) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::OutputOperandAliasAttr>()
+  return llvm::cast<mlir::stablehlo::OutputOperandAliasAttr>(unwrap(attr))
       .getOutputTupleIndices()[pos];
 }
 
 int64_t stablehloOutputOperandAliasGetOperandIndex(MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::OutputOperandAliasAttr>()
+  return llvm::cast<mlir::stablehlo::OutputOperandAliasAttr>(unwrap(attr))
       .getOperandIndex();
 }
 
 intptr_t stablehloOutputOperandAliasGetOperandTupleIndicesSize(
     MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::OutputOperandAliasAttr>()
+  return llvm::cast<mlir::stablehlo::OutputOperandAliasAttr>(unwrap(attr))
       .getOperandTupleIndices()
       .size();
 }
 
 int64_t stablehloOutputOperandAliasGetOperandTupleIndicesElem(
     MlirAttribute attr, intptr_t pos) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::OutputOperandAliasAttr>()
+  return llvm::cast<mlir::stablehlo::OutputOperandAliasAttr>(unwrap(attr))
       .getOperandTupleIndices()[pos];
 }
 
@@ -417,13 +378,12 @@ MlirAttribute stablehloComparisonDirectionAttrGet(MlirContext ctx,
 }
 
 bool stablehloAttributeIsAComparisonDirectionAttr(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::stablehlo::ComparisonDirectionAttr>();
+  return llvm::isa<mlir::stablehlo::ComparisonDirectionAttr>(unwrap(attr));
 }
 
 MlirStringRef stablehloComparisonDirectionAttrGetValue(MlirAttribute attr) {
   return wrap(mlir::stablehlo::stringifyComparisonDirection(
-      unwrap(attr)
-          .cast<mlir::stablehlo::ComparisonDirectionAttr>()
+      llvm::cast<mlir::stablehlo::ComparisonDirectionAttr>(unwrap(attr))
           .getValue()));
 }
 
@@ -441,12 +401,13 @@ MlirAttribute stablehloComparisonTypeAttrGet(MlirContext ctx,
 }
 
 bool stablehloAttributeIsAComparisonTypeAttr(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::stablehlo::ComparisonTypeAttr>();
+  return llvm::isa<mlir::stablehlo::ComparisonTypeAttr>(unwrap(attr));
 }
 
 MlirStringRef stablehloComparisonTypeAttrGetValue(MlirAttribute attr) {
   return wrap(mlir::stablehlo::stringifyComparisonType(
-      unwrap(attr).cast<mlir::stablehlo::ComparisonTypeAttr>().getValue()));
+      llvm::cast<mlir::stablehlo::ComparisonTypeAttr>(unwrap(attr))
+          .getValue()));
 }
 
 //===----------------------------------------------------------------------===//
@@ -462,12 +423,12 @@ MlirAttribute stablehloPrecisionAttrGet(MlirContext ctx, MlirStringRef value) {
 }
 
 bool stablehloAttributeIsAPrecisionAttr(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::stablehlo::PrecisionAttr>();
+  return llvm::isa<mlir::stablehlo::PrecisionAttr>(unwrap(attr));
 }
 
 MlirStringRef stablehloPrecisionAttrGetValue(MlirAttribute attr) {
   return wrap(mlir::stablehlo::stringifyPrecision(
-      unwrap(attr).cast<mlir::stablehlo::PrecisionAttr>().getValue()));
+      llvm::cast<mlir::stablehlo::PrecisionAttr>(unwrap(attr)).getValue()));
 }
 
 //===----------------------------------------------------------------------===//
@@ -482,12 +443,12 @@ MlirAttribute stablehloFftTypeAttrGet(MlirContext ctx, MlirStringRef value) {
 }
 
 bool stablehloAttributeIsAFftTypeAttr(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::stablehlo::FftTypeAttr>();
+  return llvm::isa<mlir::stablehlo::FftTypeAttr>(unwrap(attr));
 }
 
 MlirStringRef stablehloFftTypeAttrGetValue(MlirAttribute attr) {
   return wrap(mlir::stablehlo::stringifyFftType(
-      unwrap(attr).cast<mlir::stablehlo::FftTypeAttr>().getValue()));
+      llvm::cast<mlir::stablehlo::FftTypeAttr>(unwrap(attr)).getValue()));
 }
 
 //===----------------------------------------------------------------------===//
@@ -503,12 +464,12 @@ MlirAttribute stablehloTransposeAttrGet(MlirContext ctx, MlirStringRef value) {
 }
 
 bool stablehloAttributeIsATransposeAttr(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::stablehlo::TransposeAttr>();
+  return llvm::isa<mlir::stablehlo::TransposeAttr>(unwrap(attr));
 }
 
 MlirStringRef stablehloTransposeAttrGetValue(MlirAttribute attr) {
   return wrap(mlir::stablehlo::stringifyTranspose(
-      unwrap(attr).cast<mlir::stablehlo::TransposeAttr>().getValue()));
+      llvm::cast<mlir::stablehlo::TransposeAttr>(unwrap(attr)).getValue()));
 }
 
 //===----------------------------------------------------------------------===//
@@ -525,12 +486,13 @@ MlirAttribute stablehloRngDistributionAttrGet(MlirContext ctx,
 }
 
 bool stablehloAttributeIsARngDistributionAttr(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::stablehlo::RngDistributionAttr>();
+  return llvm::isa<mlir::stablehlo::RngDistributionAttr>(unwrap(attr));
 }
 
 MlirStringRef stablehloRngDistributionAttrGetValue(MlirAttribute attr) {
   return wrap(mlir::stablehlo::stringifyRngDistribution(
-      unwrap(attr).cast<mlir::stablehlo::RngDistributionAttr>().getValue()));
+      llvm::cast<mlir::stablehlo::RngDistributionAttr>(unwrap(attr))
+          .getValue()));
 }
 
 //===----------------------------------------------------------------------===//
@@ -547,12 +509,12 @@ MlirAttribute stablehloRngAlgorithmAttrGet(MlirContext ctx,
 }
 
 bool stablehloAttributeIsARngAlgorithmAttr(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::stablehlo::RngAlgorithmAttr>();
+  return llvm::isa<mlir::stablehlo::RngAlgorithmAttr>(unwrap(attr));
 }
 
 MlirStringRef stablehloRngAlgorithmAttrGetValue(MlirAttribute attr) {
   return wrap(mlir::stablehlo::stringifyRngAlgorithm(
-      unwrap(attr).cast<mlir::stablehlo::RngAlgorithmAttr>().getValue()));
+      llvm::cast<mlir::stablehlo::RngAlgorithmAttr>(unwrap(attr)).getValue()));
 }
 
 //===----------------------------------------------------------------------===//
@@ -566,15 +528,16 @@ MlirAttribute stablehloChannelHandleGet(MlirContext ctx, int64_t handle,
 }
 
 bool stablehloAttributeIsChannelHandle(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::stablehlo::ChannelHandleAttr>();
+  return llvm::isa<mlir::stablehlo::ChannelHandleAttr>(unwrap(attr));
 }
 
 int64_t stablehloChannelHandleGetHandle(MlirAttribute attr) {
-  return unwrap(attr).cast<mlir::stablehlo::ChannelHandleAttr>().getHandle();
+  return llvm::cast<mlir::stablehlo::ChannelHandleAttr>(unwrap(attr))
+      .getHandle();
 }
 
 int64_t stablehloChannelHandleGetType(MlirAttribute attr) {
-  return unwrap(attr).cast<mlir::stablehlo::ChannelHandleAttr>().getType();
+  return llvm::cast<mlir::stablehlo::ChannelHandleAttr>(unwrap(attr)).getType();
 }
 
 //===----------------------------------------------------------------------===//
@@ -588,18 +551,16 @@ MlirAttribute stablehloTypeExtensionsGet(MlirContext ctx, intptr_t nBounds,
 }
 
 bool stablehloAttributeIsTypeExtensions(MlirAttribute attr) {
-  return unwrap(attr).isa<mlir::stablehlo::TypeExtensionsAttr>();
+  return llvm::isa<mlir::stablehlo::TypeExtensionsAttr>(unwrap(attr));
 }
 
 intptr_t stablehloTypeExtensionsGetBoundsSize(MlirAttribute attr) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::TypeExtensionsAttr>()
+  return llvm::cast<mlir::stablehlo::TypeExtensionsAttr>(unwrap(attr))
       .getBounds()
       .size();
 }
 
 int64_t stablehloTypeExtensionsGetBoundsElem(MlirAttribute attr, intptr_t pos) {
-  return unwrap(attr)
-      .cast<mlir::stablehlo::TypeExtensionsAttr>()
+  return llvm::cast<mlir::stablehlo::TypeExtensionsAttr>(unwrap(attr))
       .getBounds()[pos];
 }

--- a/stablehlo/integrations/c/StablehloTypes.cpp
+++ b/stablehlo/integrations/c/StablehloTypes.cpp
@@ -21,5 +21,5 @@ MlirType stablehloTokenTypeGet(MlirContext ctx) {
 }
 
 bool stablehloTypeIsAToken(MlirType type) {
-  return unwrap(type).isa<mlir::stablehlo::TokenType>();
+  return llvm::isa<mlir::stablehlo::TokenType>(unwrap(type));
 }

--- a/stablehlo/integrations/python/StablehloModule.cpp
+++ b/stablehlo/integrations/python/StablehloModule.cpp
@@ -496,7 +496,7 @@ PYBIND11_MODULE(_stablehlo, m) {
          std::vector<MlirAttribute> &args) -> std::vector<MlirAttribute> {
         std::vector<mlir::DenseElementsAttr> inputs;
         for (auto arg : args) {
-          auto attr = unwrap(arg).dyn_cast<mlir::DenseElementsAttr>();
+          auto attr = dyn_cast<mlir::DenseElementsAttr>(unwrap(arg));
           if (!attr) {
             PyErr_SetString(PyExc_ValueError,
                             "input args must be DenseElementsAttr");

--- a/stablehlo/integrations/python/StablehloModule.cpp
+++ b/stablehlo/integrations/python/StablehloModule.cpp
@@ -496,7 +496,7 @@ PYBIND11_MODULE(_stablehlo, m) {
          std::vector<MlirAttribute> &args) -> std::vector<MlirAttribute> {
         std::vector<mlir::DenseElementsAttr> inputs;
         for (auto arg : args) {
-          auto attr = dyn_cast<mlir::DenseElementsAttr>(unwrap(arg));
+          auto attr = llvm::dyn_cast<mlir::DenseElementsAttr>(unwrap(arg));
           if (!attr) {
             PyErr_SetString(PyExc_ValueError,
                             "input args must be DenseElementsAttr");

--- a/stablehlo/reference/Api.cpp
+++ b/stablehlo/reference/Api.cpp
@@ -89,13 +89,13 @@ class DefaultInterpreterFallback : public InterpreterFallback {
       std::queue<StringAttr> infeed;
       if (auto infeedAttr = runParallelOp.getInfeed())
         for (auto &value : infeedAttr->getValue())
-          infeed.push(value.cast<FlatSymbolRefAttr>().getAttr());
+          infeed.push(cast<FlatSymbolRefAttr>(value).getAttr());
 
       SmallVector<SmallVector<StringAttr>> programs(
           runParallelOp.getPrograms().size());
       for (auto [i, replica] : llvm::enumerate(runParallelOp.getPrograms()))
-        for (auto &program : replica.cast<ArrayAttr>())
-          programs[i].push_back(program.cast<FlatSymbolRefAttr>().getAttr());
+        for (auto &program : cast<ArrayAttr>(replica))
+          programs[i].push_back(cast<FlatSymbolRefAttr>(program).getAttr());
 
       SymbolTable symbolTable{op.getParentOfType<ModuleOp>()};
       auto results = stablehlo::interpreter::evalRunParallelOp(

--- a/stablehlo/reference/InterpreterOps.cpp
+++ b/stablehlo/reference/InterpreterOps.cpp
@@ -87,20 +87,20 @@ InterpreterDialect::InterpreterDialect(MLIRContext *context)
 //===----------------------------------------------------------------------===//
 
 LogicalResult RunParallelOp::verify() {
-  if (getPrograms().empty() || getPrograms()[0].cast<ArrayAttr>().empty())
+  if (getPrograms().empty() || cast<ArrayAttr>(getPrograms()[0]).empty())
     return emitOptionalError(getLoc(), "`programs` attribute cannot be empty");
 
   size_t numArgs = 0;
   size_t numResults = 0;
-  auto numPartitions = getPrograms()[0].cast<ArrayAttr>().size();
+  auto numPartitions = cast<ArrayAttr>(getPrograms()[0]).size();
   for (auto &replica : getPrograms()) {
-    if (replica.cast<ArrayAttr>().size() != numPartitions)
+    if (cast<ArrayAttr>(replica).size() != numPartitions)
       return emitOptionalError(
           getLoc(), "Sizes of second dimension of `programs` should all match ",
-          numPartitions, " but got ", replica.cast<ArrayAttr>().size());
+          numPartitions, " but got ", cast<ArrayAttr>(replica).size());
 
-    for (auto &program : replica.cast<ArrayAttr>()) {
-      auto funcName = program.cast<FlatSymbolRefAttr>().getAttr();
+    for (auto &program : cast<ArrayAttr>(replica)) {
+      auto funcName = cast<FlatSymbolRefAttr>(program).getAttr();
       auto func = getOperation()
                       ->getParentOfType<ModuleOp>()
                       .lookupSymbol<func::FuncOp>(funcName);
@@ -143,7 +143,7 @@ LogicalResult RunParallelOp::verify() {
                                  func.getNumResults());
 
       auto resultType = func.getResultTypes()[0];
-      if (!resultType.isa<ShapedType>())
+      if (!isa<ShapedType>(resultType))
         return emitOptionalError(
             getLoc(), "Function ", funcName,
             " should return a tensor type, but instead returns ", resultType);

--- a/stablehlo/reference/NumPy.cpp
+++ b/stablehlo/reference/NumPy.cpp
@@ -303,7 +303,7 @@ static decltype(auto) dispatchType(Type type, Args&&... args) {
   if (type.isF16()) return Functor<uint16_t>()(std::forward<Args>(args)...);
   if (type.isF32()) return Functor<float>()(std::forward<Args>(args)...);
   if (type.isF64()) return Functor<double>()(std::forward<Args>(args)...);
-  if (auto complexTy = type.dyn_cast<ComplexType>()) {
+  if (auto complexTy = dyn_cast<ComplexType>(type)) {
     auto complexElemTy = complexTy.getElementType();
 
     // Use a double data type to serialize the real (32bit) and imaginary (32

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -84,7 +84,7 @@ Tensor evalPadOp(const Tensor &operand, const Tensor &paddingValue,
   if (failed(inferStatus))
     report_fatal_error(invalidArgument("Could not infer PadOp's return type"));
   return evalPadOp(operand, paddingValue, edgePaddingLow, interiorPadding,
-                   inferredTypes[0].cast<ShapedType>());
+                   cast<ShapedType>(inferredTypes[0]));
 }
 
 SmallVector<Tensor> evalReduceOp(ArrayRef<Tensor> inputs,
@@ -127,7 +127,7 @@ Tensor evalSliceOp(const Tensor &operand, const Sizes &startIndices,
     report_fatal_error(
         invalidArgument("Could not infer SliceOp's return type"));
   return evalSliceOp(operand, startIndices, strides,
-                     inferredTypes[0].cast<ShapedType>());
+                     cast<ShapedType>(inferredTypes[0]));
 }
 
 SmallVector<InterpreterValue> evalCallOp(ArrayRef<Tensor> inputs,
@@ -752,7 +752,7 @@ SmallVector<InterpreterValue> eval(Region &region,
       auto initValues = scope.findTensors(reduceOp.getInitValues());
       SmallVector<ShapedType> resultTypes;
       for (auto resultType : reduceOp.getResultTypes())
-        resultTypes.push_back(resultType.cast<ShapedType>());
+        resultTypes.push_back(cast<ShapedType>(resultType));
       auto results =
           evalReduceOp(inputs, initValues, Axes(reduceOp.getDimensions()),
                        reduceOp.getBody(), process, scope, resultTypes);
@@ -809,7 +809,7 @@ SmallVector<InterpreterValue> eval(Region &region,
 
       SmallVector<ShapedType> resultTypes;
       for (auto resultType : reduceWindowOp.getResultTypes())
-        resultTypes.push_back(resultType.cast<ShapedType>());
+        resultTypes.push_back(cast<ShapedType>(resultType));
 
       auto results = evalReduceWindowOp(
           inputs, initValues, Sizes(reduceWindowOp.getWindowDimensions()),
@@ -985,7 +985,7 @@ SmallVector<InterpreterValue> eval(Region &region,
       failOnDecomposableOp(op);
     } else if (auto tupleOp = dyn_cast<TupleOp>(op)) {
       auto val = scope.find(tupleOp.getVal());
-      auto result = evalTupleOp(val, tupleOp.getType().cast<TupleType>());
+      auto result = evalTupleOp(val, cast<TupleType>(tupleOp.getType()));
       scope.add(tupleOp.getResult(), result);
     } else if (isa<UnaryEinsumOp>(op)) {
       failOnDecomposableOp(op);
@@ -1362,7 +1362,7 @@ Tensor evalConcatenateOp(ArrayRef<Tensor> inputs, Axis dimension,
 }
 
 Tensor evalConstantOp(ElementsAttr value) {
-  return makeTensor(value.cast<DenseElementsAttr>());
+  return makeTensor(cast<DenseElementsAttr>(value));
 }
 
 Tensor evalConvertOp(const Tensor &operand, ShapedType resultType) {
@@ -1789,7 +1789,7 @@ Tensor evalMapOp(ArrayRef<Tensor> inputs, Region &computation, Process *process,
   for (auto it = result.index_begin(); it != result.index_end(); ++it) {
     SmallVector<InterpreterValue> args;
     for (size_t i = 0; i < inputs.size(); ++i) {
-      Tensor tensor(computation.getArgument(i).getType().cast<ShapedType>());
+      Tensor tensor(cast<ShapedType>(computation.getArgument(i).getType()));
       tensor.set({}, inputs[i].get(*it));
       args.emplace_back(tensor);
     }

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -32,14 +32,14 @@ namespace stablehlo {
 namespace {
 
 int64_t getSizeInBytes(Type type) {
-  if (auto shapedType = type.dyn_cast<ShapedType>())
+  if (auto shapedType = dyn_cast<ShapedType>(type))
     return shapedType.getNumElements() *
            getSizeInBytes(shapedType.getElementType());
 
   if (type.isIntOrFloat())
     return std::max(type.getIntOrFloatBitWidth(), (unsigned)8) / 8;
 
-  if (auto complexType = type.dyn_cast<mlir::ComplexType>())
+  if (auto complexType = dyn_cast<mlir::ComplexType>(type))
     return getSizeInBytes(complexType.getElementType()) * 2;
 
   report_fatal_error(
@@ -155,7 +155,7 @@ Element Tensor::get(const Index &index) const {
   // StableHLO will adopt signfull integer semantics with signed and unsigned
   // integer variants.
   if (isSupportedIntegerType(elementType)) {
-    IntegerType intTy = elementType.cast<IntegerType>();
+    IntegerType intTy = cast<IntegerType>(elementType);
 
     if (elementType.isSignlessInteger(4) || elementType.isSignlessInteger(8)) {
       auto elementData = reinterpret_cast<const int8_t *>(elementPtr);
@@ -203,8 +203,8 @@ Element Tensor::get(const Index &index) const {
   }
 
   // Handle complex types.
-  if (elementType.isa<ComplexType>()) {
-    auto complexElemTy = elementType.cast<ComplexType>().getElementType();
+  if (isa<ComplexType>(elementType)) {
+    auto complexElemTy = cast<ComplexType>(elementType).getElementType();
 
     if (complexElemTy.isF32()) {
       auto elementData =
@@ -335,8 +335,8 @@ void Tensor::set(const Index &index, const Element &element) {
   }
 
   // Handle complex types.
-  if (elementType.isa<ComplexType>()) {
-    auto complexElemTy = elementType.cast<ComplexType>().getElementType();
+  if (isa<ComplexType>(elementType)) {
+    auto complexElemTy = cast<ComplexType>(elementType).getElementType();
     auto complexValue = element.getComplexValue();
 
     if (complexElemTy.isF32()) {
@@ -505,8 +505,8 @@ Tensor makeTensor(DenseElementsAttr attr) {
   }
 
   // Handle complex types.
-  if (elementType.isa<ComplexType>()) {
-    auto complexElemTy = elementType.cast<ComplexType>().getElementType();
+  if (isa<ComplexType>(elementType)) {
+    auto complexElemTy = cast<ComplexType>(elementType).getElementType();
     if (complexElemTy.isF32()) {
       auto complexValues = llvm::to_vector(llvm::map_range(
           attr.getValues<std::complex<APFloat>>(),
@@ -541,7 +541,7 @@ DenseElementsAttr makeDenseElementsAttr(Tensor tensor) {
   auto type = tensor.getType();
   auto elementType = type.getElementType();
 
-  if (elementType.isa<FloatType>()) {
+  if (isa<FloatType>(elementType)) {
     std::vector<llvm::APFloat> values;
     for (auto it = tensor.index_begin(); it != tensor.index_end(); ++it) {
       Element element = tensor.get(*it);
@@ -549,7 +549,7 @@ DenseElementsAttr makeDenseElementsAttr(Tensor tensor) {
     }
     return DenseFPElementsAttr::get(tensor.getType(), values);
   }
-  if (elementType.isa<IntegerType>()) {
+  if (isa<IntegerType>(elementType)) {
     std::vector<llvm::APInt> values;
     for (auto it = tensor.index_begin(); it != tensor.index_end(); ++it) {
       Element element = tensor.get(*it);

--- a/stablehlo/reference/Types.cpp
+++ b/stablehlo/reference/Types.cpp
@@ -51,7 +51,7 @@ bool isSupportedFloatType(Type type) {
 }
 
 bool isSupportedComplexType(Type type) {
-  auto complexTy = type.dyn_cast<ComplexType>();
+  auto complexTy = dyn_cast<ComplexType>(type);
   if (!complexTy) return false;
 
   auto complexElemTy = complexTy.getElementType();
@@ -60,7 +60,7 @@ bool isSupportedComplexType(Type type) {
 
 int64_t numBits(Type type) {
   if (isSupportedComplexType(type))
-    return numBits(type.cast<ComplexType>().getElementType()) * 2;
+    return numBits(cast<ComplexType>(type).getElementType()) * 2;
   return type.getIntOrFloatBitWidth();
 }
 

--- a/stablehlo/tests/CheckOps.cpp
+++ b/stablehlo/tests/CheckOps.cpp
@@ -61,7 +61,7 @@ CheckDialect::CheckDialect(MLIRContext *context)
 }
 
 llvm::Error evalExpectAlmostEqConstOp(const Tensor &lhs, ElementsAttr value) {
-  auto rhs = makeTensor(value.cast<DenseElementsAttr>());
+  auto rhs = makeTensor(cast<DenseElementsAttr>(value));
   return evalExpectAlmostEqOp(lhs, rhs);
 }
 
@@ -80,7 +80,7 @@ llvm::Error evalExpectAlmostEqOp(const Tensor &lhs, const Tensor &rhs) {
 }
 
 llvm::Error evalExpectEqConstOp(const Tensor &lhs, ElementsAttr value) {
-  auto rhs = makeTensor(value.cast<DenseElementsAttr>());
+  auto rhs = makeTensor(cast<DenseElementsAttr>(value));
   return evalExpectEqOp(lhs, rhs);
 }
 

--- a/stablehlo/tools/StablehloTranslateMain.cpp
+++ b/stablehlo/tools/StablehloTranslateMain.cpp
@@ -70,7 +70,7 @@ llvm::Error evalCustomCallCheckEq(stablehlo::CustomCallOp op,
 
   auto actualResult = scope.findTensors(op->getOperands())[0];
   auto expectedResult = scope.findTensors(op->getOperands())[1];
-  bool isInt = expectedResult.getElementType().isa<IntegerType>();
+  bool isInt = isa<IntegerType>(expectedResult.getElementType());
   auto status =
       isInt ? stablehlo::check::evalExpectEqOp(actualResult, expectedResult)
             : stablehlo::check::evalExpectAlmostEqOp(actualResult,

--- a/stablehlo/transforms/ChloLegalizeToStablehlo.cpp
+++ b/stablehlo/transforms/ChloLegalizeToStablehlo.cpp
@@ -689,7 +689,7 @@ static Value materializePolynomialApproximation(
 static Value materializeErfcApproximationF64ForMagnituteGeOne(
     ConversionPatternRewriter &rewriter, Location loc, ValueRange args) {
   Value x = args.front();
-  assert(x.getType().cast<ShapedType>().getElementType().isF64() &&
+  assert(cast<ShapedType>(x.getType()).getElementType().isF64() &&
          "expect f64 element type");
   const double kMaxlog = 7.09782712893383996843E2;
   const double kErfcPCoefficients[] = {
@@ -827,7 +827,7 @@ static Value materializeErfApproximationF64(ConversionPatternRewriter &rewriter,
 static Value materializeErfcApproximationF64(
     ConversionPatternRewriter &rewriter, Location loc, ValueRange args) {
   Value x = args.front();
-  assert(x.getType().cast<ShapedType>().getElementType().isF64() &&
+  assert(cast<ShapedType>(x.getType()).getElementType().isF64() &&
          "expect f64 element type");
 
   // Rely on erfc approximation for |x| >= 1
@@ -859,7 +859,7 @@ static Value materializeErfcApproximationF64(
 static Value materializeErfcApproximationF32ForMagnitudeGeOne(
     ConversionPatternRewriter &rewriter, Location loc, ValueRange args) {
   Value x = args.front();
-  assert(x.getType().cast<ShapedType>().getElementType().isF32() &&
+  assert(cast<ShapedType>(x.getType()).getElementType().isF32() &&
          "expect f32 element type");
   const double kMaxlog = 88.72283905206835;
   const float kErfcPCoefficients[] = {
@@ -925,7 +925,7 @@ static Value materializeErfcApproximationF32ForMagnitudeGeOne(
 static Value materializeErfApproximationF32ForMagnitudeLeOne(
     ConversionPatternRewriter &rewriter, Location loc, ValueRange args) {
   Value x = args.front();
-  assert(x.getType().cast<ShapedType>().getElementType().isF32() &&
+  assert(cast<ShapedType>(x.getType()).getElementType().isF32() &&
          "expect f32 element type");
   const float kErfTCoefficients[] = {
       +7.853861353153693E-5f, -8.010193625184903E-4f, +5.188327685732524E-3f,
@@ -945,7 +945,7 @@ static Value materializeErfApproximationF32ForMagnitudeLeOne(
 static Value materializeErfApproximationF32(ConversionPatternRewriter &rewriter,
                                             Location loc, ValueRange args) {
   Value x = args.front();
-  assert(x.getType().cast<ShapedType>().getElementType().isF32() &&
+  assert(cast<ShapedType>(x.getType()).getElementType().isF32() &&
          "expect f32 element type");
   const float kAlpha[] = {
       -2.72614225801306e-10f, 2.77068142495902e-08f,  -2.10102402082508e-06f,
@@ -982,7 +982,7 @@ static Value materializeErfApproximationF32(ConversionPatternRewriter &rewriter,
 static Value materializeErfcApproximationF32(
     ConversionPatternRewriter &rewriter, Location loc, ValueRange args) {
   Value x = args.front();
-  assert(x.getType().cast<ShapedType>().getElementType().isF32() &&
+  assert(cast<ShapedType>(x.getType()).getElementType().isF32() &&
          "expect f32 element type");
 
   // Rely on erfc approximation for |x| >= 1
@@ -1568,7 +1568,7 @@ static Value materializeDigamma(ConversionPatternRewriter &rewriter,
 
 static Value getConstantLikeSmallestFiniteValue(OpBuilder &b, Location loc,
                                                 Value val) {
-  auto ty = getElementTypeOrSelf(val.getType()).cast<FloatType>();
+  auto ty = cast<FloatType>(getElementTypeOrSelf(val.getType()));
   return getConstantLike(
       b, loc, llvm::APFloat::getSmallest(ty.getFloatSemantics()), val);
 }
@@ -1979,7 +1979,7 @@ struct ConvertSinhOp final : OpConversionPattern<mlir::chlo::SinhOp> {
       mlir::chlo::SinhOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     Value x = adaptor.getOperand();
-    if (cast<ShapedType>(x.getType()).getElementType().isa<ComplexType>()) {
+    if (isa<ComplexType>(cast<ShapedType>(x.getType()).getElementType())) {
       rewriter.replaceOp(op, materializeSinhApproximationForLargeX(
                                  rewriter, op.getLoc(), adaptor.getOperands()));
       return success();

--- a/stablehlo/transforms/ShapeLegalizeToStablehlo.cpp
+++ b/stablehlo/transforms/ShapeLegalizeToStablehlo.cpp
@@ -54,7 +54,7 @@ namespace stablehlo {
 namespace {
 
 bool isShapedOfI32(Value value) {
-  auto type = value.getType().dyn_cast<ShapedType>();
+  auto type = dyn_cast<ShapedType>(value.getType());
   return type && type.getElementType().isInteger(32);
 }
 
@@ -70,7 +70,7 @@ Value castToI32(PatternRewriter& rewriter, Location loc, Value value) {
   Type resultType;
   if (value.getType().isIndex())
     resultType = RankedTensorType::get({}, rewriter.getI32Type());
-  if (auto valueType = value.getType().dyn_cast<ShapedType>()) {
+  if (auto valueType = dyn_cast<ShapedType>(value.getType())) {
     if (!valueType.hasStaticShape()) return {};
     if (valueType.getElementType().isInteger(32)) return value;
     if (valueType.getElementType().isIndex())
@@ -85,7 +85,7 @@ Value castToI32(PatternRewriter& rewriter, Location loc, Value value) {
 
 bool isIndexOrShapedOfIndex(Value value) {
   if (value.getType().isIndex()) return true;
-  auto type = value.getType().dyn_cast<ShapedType>();
+  auto type = dyn_cast<ShapedType>(value.getType());
   return type && type.getElementType().isIndex();
 }
 
@@ -100,7 +100,7 @@ bool isIndexOrShapedOfIndex(Value value) {
 Value castToIndex(PatternRewriter& rewriter, Location loc, Value value) {
   Type resultType;
   if (value.getType().isIndex()) return value;
-  if (auto valueType = value.getType().dyn_cast<ShapedType>()) {
+  if (auto valueType = dyn_cast<ShapedType>(value.getType())) {
     if (!valueType.hasStaticShape()) return {};
     if (valueType.getElementType().isInteger(32)) {
       if (valueType.getRank() == 0) {
@@ -149,7 +149,7 @@ struct ConvertComputeReshapeShapeOpPattern
         castToI32(rewriter, op.getLoc(), op.getDynamicShape());
     if (!numElementsI32 || !dynamicShapeI32x1)
       return rewriter.notifyMatchFailure(op, "cast to i32 failed");
-    auto rank = dynamicShapeI32x1.getType().cast<ShapedType>().getNumElements();
+    auto rank = cast<ShapedType>(dynamicShapeI32x1.getType()).getNumElements();
 
     // Obtain individual input dimension sizes and also compute the product of
     // all these dimension sizes.
@@ -215,7 +215,7 @@ struct ConvertNumElementsOpPattern
     // This will error out if shape is !shape.shape.
     auto shapeI32 = castToI32(rewriter, op.getLoc(), op.getShape());
     if (!shapeI32) return rewriter.notifyMatchFailure(op, "cast to i32 failed");
-    auto rank = shapeI32.getType().cast<ShapedType>().getNumElements();
+    auto rank = cast<ShapedType>(shapeI32.getType()).getNumElements();
 
     // Compute the product of the individual dimension sizes.
     // Using this representation instead of ReduceOp because it is more
@@ -249,7 +249,7 @@ struct ConvertShapeOfOpPattern : public OpRewritePattern<shape::ShapeOfOp> {
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(shape::ShapeOfOp op,
                                 PatternRewriter& rewriter) const override {
-    auto operandType = op.getArg().getType().dyn_cast<RankedTensorType>();
+    auto operandType = dyn_cast<RankedTensorType>(op.getArg().getType());
     if (!operandType)
       return rewriter.notifyMatchFailure(op, "expected ranked operand");
 
@@ -291,7 +291,7 @@ struct ConvertConstShapeOpPattern
   using OpRewritePattern::OpRewritePattern;
   LogicalResult matchAndRewrite(shape::ConstShapeOp op,
                                 PatternRewriter& rewriter) const override {
-    auto operandType = op.getResult().getType().dyn_cast<RankedTensorType>();
+    auto operandType = dyn_cast<RankedTensorType>(op.getResult().getType());
     if (!operandType)
       return rewriter.notifyMatchFailure(op, "expected ranked operand");
 
@@ -316,7 +316,7 @@ struct ConvertIndexCastOpPattern : public OpRewritePattern<arith::IndexCastOp> {
                                 PatternRewriter& rewriter) const override {
     Value result = op.getIn();
     if (isIndexOrShapedOfIndex(op.getIn()) &&
-        !op.getIn().getType().isa<ShapedType>()) {
+        !isa<ShapedType>(op.getIn().getType())) {
       // Handle a special case where index is cast to something other than i32.
       // In practice this is only index -> i64.
       // This is converted to the following sequence:
@@ -332,7 +332,7 @@ struct ConvertIndexCastOpPattern : public OpRewritePattern<arith::IndexCastOp> {
                                  op.getLoc(), op.getOut().getType(), result));
       return success();
     }
-    if (!op.getIn().getType().isa<ShapedType>() &&
+    if (!isa<ShapedType>(op.getIn().getType()) &&
         isIndexOrShapedOfIndex(op.getOut())) {
       // Handle a special case of i32 -> index.
       // This is converted to the following sequence:
@@ -407,8 +407,8 @@ struct ConvertShapeBroadcastOpPattern
     auto shape1 = castToI32(rewriter, op.getLoc(), op.getShapes().front());
     auto shape2 = castToI32(rewriter, op.getLoc(), op.getShapes().back());
     if (!shape1 || !shape2) return failure();
-    auto tensorType1 = shape1.getType().dyn_cast<RankedTensorType>();
-    auto tensorType2 = shape2.getType().dyn_cast<RankedTensorType>();
+    auto tensorType1 = dyn_cast<RankedTensorType>(shape1.getType());
+    auto tensorType2 = dyn_cast<RankedTensorType>(shape2.getType());
     if (!tensorType1 || !tensorType2) return failure();
 
     // If the two operand shapes are of different sizes, the smaller one is
@@ -520,7 +520,7 @@ struct ConvertTensorFromElementsPattern
   LogicalResult matchAndRewrite(tensor::FromElementsOp op,
                                 PatternRewriter& rewriter) const override {
     auto tensorType =
-        op.getResult().getType().dyn_cast_or_null<RankedTensorType>();
+        dyn_cast_or_null<RankedTensorType>(op.getResult().getType());
     if (!tensorType)
       return rewriter.notifyMatchFailure(op, "expected constant index op");
 

--- a/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
+++ b/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp
@@ -43,7 +43,7 @@ struct CanonicalizeCustomCallOpPattern : public OpRewritePattern<CustomCallOp> {
     if (failed(hlo::getShapeRefinements(op.getLoc(), op, refinements)))
       return rewriter.notifyMatchFailure(op, "expected valid refinements");
     auto indicesAttr =
-        op->getAttr("indices_of_shape_operands").cast<DenseIntElementsAttr>();
+        cast<DenseIntElementsAttr>(op->getAttr("indices_of_shape_operands"));
     DenseSet<int64_t> indices(indicesAttr.value_begin<int64_t>(),
                               indicesAttr.value_end<int64_t>());
 
@@ -79,7 +79,7 @@ struct CanonicalizeCustomCallOpPattern : public OpRewritePattern<CustomCallOp> {
     for (auto& operand : op->getOpOperands()) {
       if (indices.contains(operand.getOperandNumber())) {
         auto resultType =
-            op->getResult(resultIndex).getType().dyn_cast<ShapedType>();
+            dyn_cast<ShapedType>(op->getResult(resultIndex).getType());
         if (!resultType || !resultType.hasStaticShape())
           return rewriter.notifyMatchFailure(op,
                                              "expected static result types");

--- a/stablehlo/transforms/StablehloInstrumentWithProbe.cpp
+++ b/stablehlo/transforms/StablehloInstrumentWithProbe.cpp
@@ -67,7 +67,7 @@ class StablehloInstrumentWithProbePass
 
 std::string StablehloInstrumentWithProbePass::getLocationNameOrUniqueId(
     Location location, unsigned int id) {
-  auto namedLocation = location.dyn_cast<NameLoc>();
+  auto namedLocation = dyn_cast<NameLoc>(location);
   std::string probeName = "probe";
 
   if (useDebugInfoOption && namedLocation)
@@ -120,7 +120,7 @@ bool StablehloInstrumentWithProbePass::shouldProbeOp(Operation& op) const {
 }
 
 bool StablehloInstrumentWithProbePass::shouldProbeValue(Value value) const {
-  return value.getType().isa<TensorType>();
+  return isa<TensorType>(value.getType());
 }
 
 }  // namespace

--- a/stablehlo/transforms/StablehloLegalizeToVhlo.cpp
+++ b/stablehlo/transforms/StablehloLegalizeToVhlo.cpp
@@ -63,7 +63,7 @@ class StablehloToVhloTypeConverter : public vhlo::VhloTypeConverter {
       return attr;
 
     if (auto stablehloAttr =
-            attr.dyn_cast_or_null<stablehlo::TypeExtensionsAttr>()) {
+            dyn_cast_or_null<stablehlo::TypeExtensionsAttr>(attr)) {
       return vhlo::TypeExtensionsV1Attr::get(stablehloAttr.getContext(),
                                              stablehloAttr.getBounds());
     }
@@ -90,31 +90,30 @@ Attribute convertGeneric(Attribute stablehloAttr,
   // Handle StableHLO attributes.
   // The logic that handles attributes from other dialects (e.g. builtin
   // attributes) lives below.
-  if (auto attr =
-          stablehloAttr.dyn_cast<stablehlo::ComparisonDirectionAttr>()) {
+  if (auto attr = dyn_cast<stablehlo::ComparisonDirectionAttr>(stablehloAttr)) {
     RETURN_CONVERTED_ENUM_ATTR(ComparisonDirection, V1);
   }
-  if (auto attr = stablehloAttr.dyn_cast<stablehlo::ComparisonTypeAttr>()) {
+  if (auto attr = dyn_cast<stablehlo::ComparisonTypeAttr>(stablehloAttr)) {
     RETURN_CONVERTED_ENUM_ATTR(ComparisonType, V1);
   }
-  if (auto attr = stablehloAttr.dyn_cast<stablehlo::FftTypeAttr>()) {
+  if (auto attr = dyn_cast<stablehlo::FftTypeAttr>(stablehloAttr)) {
     RETURN_CONVERTED_ENUM_ATTR(FftType, V1);
   }
-  if (auto attr = stablehloAttr.dyn_cast<stablehlo::OutputOperandAliasAttr>()) {
+  if (auto attr = dyn_cast<stablehlo::OutputOperandAliasAttr>(stablehloAttr)) {
     return vhlo::OutputOperandAliasV1Attr::get(
         attr.getContext(), attr.getOutputTupleIndices(), attr.getOperandIndex(),
         attr.getOperandTupleIndices());
   }
-  if (auto attr = stablehloAttr.dyn_cast<stablehlo::PrecisionAttr>()) {
+  if (auto attr = dyn_cast<stablehlo::PrecisionAttr>(stablehloAttr)) {
     RETURN_CONVERTED_ENUM_ATTR(Precision, V1);
   }
-  if (auto attr = stablehloAttr.dyn_cast<stablehlo::RngAlgorithmAttr>()) {
+  if (auto attr = dyn_cast<stablehlo::RngAlgorithmAttr>(stablehloAttr)) {
     RETURN_CONVERTED_ENUM_ATTR(RngAlgorithm, V1);
   }
-  if (auto attr = stablehloAttr.dyn_cast<stablehlo::RngDistributionAttr>()) {
+  if (auto attr = dyn_cast<stablehlo::RngDistributionAttr>(stablehloAttr)) {
     RETURN_CONVERTED_ENUM_ATTR(RngDistribution, V1);
   }
-  if (auto attr = stablehloAttr.dyn_cast<stablehlo::TransposeAttr>()) {
+  if (auto attr = dyn_cast<stablehlo::TransposeAttr>(stablehloAttr)) {
     RETURN_CONVERTED_ENUM_ATTR(Transpose, V1);
   }
   if (stablehloAttr.getDialect().getNamespace() ==
@@ -126,7 +125,7 @@ Attribute convertGeneric(Attribute stablehloAttr,
   // Handle supported non-StableHLO attributes.
   // Each of these attributes has a counterpart in the VHLO dialect -
   // VHLO programs never include attributes from other dialects.
-  if (auto stablehloAttrs = stablehloAttr.dyn_cast<ArrayAttr>()) {
+  if (auto stablehloAttrs = dyn_cast<ArrayAttr>(stablehloAttr)) {
     SmallVector<Attribute> vhloAttrs;
     for (auto stablehloAttr : stablehloAttrs) {
       auto vhloAttr = convertGeneric(stablehloAttr, typeConverter);
@@ -135,14 +134,14 @@ Attribute convertGeneric(Attribute stablehloAttr,
     }
     return vhlo::ArrayV1Attr::get(stablehloAttrs.getContext(), vhloAttrs);
   }
-  if (auto attr = stablehloAttr.dyn_cast<DenseIntOrFPElementsAttr>()) {
+  if (auto attr = dyn_cast<DenseIntOrFPElementsAttr>(stablehloAttr)) {
     auto vhloType = typeConverter->convertType(attr.getType());
     LLVM_DEBUG(llvm::dbgs() << "Converted " << vhloType << '\n');
     if (!vhloType) return {};
     return vhlo::TensorV1Attr::get(attr.getContext(), vhloType,
                                    attr.getRawData());
   }
-  if (auto attr = stablehloAttr.dyn_cast<DenseI64ArrayAttr>()) {
+  if (auto attr = dyn_cast<DenseI64ArrayAttr>(stablehloAttr)) {
     auto vhloType = vhlo::RankedTensorV1Type::get(
         attr.getContext(), {attr.size()},
         vhlo::IntegerSI64V1Type::get(attr.getContext()), Attribute{});
@@ -151,7 +150,7 @@ Attribute convertGeneric(Attribute stablehloAttr,
     return vhlo::TensorV1Attr::get(attr.getContext(), vhloType,
                                    attr.getRawData());
   }
-  if (auto attr = stablehloAttr.dyn_cast<DenseBoolArrayAttr>()) {
+  if (auto attr = dyn_cast<DenseBoolArrayAttr>(stablehloAttr)) {
     // Dense arrays of bool need special handling as their raw data is
     // encoded differently from a DenseElementsAttr of bool. Using a similar
     // conversion as for DenseI64ArrayAttr causes issues when attempting to
@@ -164,7 +163,7 @@ Attribute convertGeneric(Attribute stablehloAttr,
     auto dense = DenseElementsAttr::get(ty, data);
     return convertGeneric(dense, typeConverter);
   }
-  if (auto attr = stablehloAttr.dyn_cast<DictionaryAttr>()) {
+  if (auto attr = dyn_cast<DictionaryAttr>(stablehloAttr)) {
     SmallVector<std::pair<Attribute, Attribute>> vhloAttrs;
     for (auto namedAttr : attr.getValue()) {
       auto vhloName = convertGeneric(namedAttr.getName(), typeConverter);
@@ -174,14 +173,14 @@ Attribute convertGeneric(Attribute stablehloAttr,
     }
     return vhlo::DictionaryV1Attr::get(attr.getContext(), vhloAttrs);
   }
-  if (auto attr = stablehloAttr.dyn_cast<FloatAttr>()) {
+  if (auto attr = dyn_cast<FloatAttr>(stablehloAttr)) {
     auto vhloFloatType = typeConverter->convertType(attr.getType());
     if (!vhloFloatType) return {};
     return vhlo::FloatV1Attr::get(attr.getContext(), vhloFloatType,
                                   attr.getValue());
   }
-  if (auto integerAttr = stablehloAttr.dyn_cast<IntegerAttr>()) {
-    if (auto boolAttr = stablehloAttr.dyn_cast<BoolAttr>()) {
+  if (auto integerAttr = dyn_cast<IntegerAttr>(stablehloAttr)) {
+    if (auto boolAttr = dyn_cast<BoolAttr>(stablehloAttr)) {
       return vhlo::BooleanV1Attr::get(boolAttr.getContext(),
                                       boolAttr.getValue());
     } else {
@@ -191,11 +190,11 @@ Attribute convertGeneric(Attribute stablehloAttr,
                                       integerAttr.getValue());
     }
   }
-  if (auto attr = stablehloAttr.dyn_cast<FlatSymbolRefAttr>()) {
+  if (auto attr = dyn_cast<FlatSymbolRefAttr>(stablehloAttr)) {
     return convertGeneric(attr.getAttr(), typeConverter);
   }
-  if (auto attr = stablehloAttr.dyn_cast<StringAttr>()) {
-    if (!attr.getType().isa<NoneType>()) {
+  if (auto attr = dyn_cast<StringAttr>(stablehloAttr)) {
+    if (!isa<NoneType>(attr.getType())) {
       // Don't support custom string types
       LLVM_DEBUG(llvm::dbgs()
                  << "Failed to convert string with type: " << attr << '\n');
@@ -203,7 +202,7 @@ Attribute convertGeneric(Attribute stablehloAttr,
     }
     return vhlo::StringV1Attr::get(attr.getContext(), attr.getValue());
   }
-  if (auto attr = stablehloAttr.dyn_cast<TypeAttr>()) {
+  if (auto attr = dyn_cast<TypeAttr>(stablehloAttr)) {
     auto vhloType = typeConverter->convertType(attr.getValue());
     if (!vhloType) return {};
     return vhlo::TypeV1Attr::get(attr.getContext(), vhloType);
@@ -249,7 +248,7 @@ Attribute convertInts(const ConversionPattern& pattern,
 
 Attribute convertSymbol(const ConversionPattern& pattern,
                         Attribute stablehloAttr) {
-  auto stablehloSymbolAttr = stablehloAttr.dyn_cast<FlatSymbolRefAttr>();
+  auto stablehloSymbolAttr = dyn_cast<FlatSymbolRefAttr>(stablehloAttr);
   if (!stablehloSymbolAttr) return {};
   return convertGeneric(stablehloSymbolAttr.getAttr(),
                         pattern.getTypeConverter());
@@ -258,7 +257,7 @@ Attribute convertSymbol(const ConversionPattern& pattern,
 SpecialResult convertChannelHandle(const ConversionPattern& pattern,
                                    Attribute stablehloAttr,
                                    SmallVector<NamedAttribute>& vhloAttrs) {
-  auto attr = stablehloAttr.dyn_cast<stablehlo::ChannelHandleAttr>();
+  auto attr = dyn_cast<stablehlo::ChannelHandleAttr>(stablehloAttr);
   if (!attr) return specialFailure();
 
   auto vhloChannelId = convertInt(pattern, attr.getHandle());
@@ -276,7 +275,7 @@ SpecialResult convertChannelHandle(const ConversionPattern& pattern,
 SpecialResult convertChannelId(const ConversionPattern& pattern,
                                Attribute stablehloAttr,
                                SmallVector<NamedAttribute>& vhloAttrs) {
-  auto attr = stablehloAttr.dyn_cast<stablehlo::ChannelHandleAttr>();
+  auto attr = dyn_cast<stablehlo::ChannelHandleAttr>(stablehloAttr);
   if (!attr) return specialFailure();
 
   auto vhloChannelId = convertInt(pattern, attr.getHandle());
@@ -289,7 +288,7 @@ SpecialResult convertChannelId(const ConversionPattern& pattern,
 SpecialResult convertConvDimensionNumbers(
     const ConversionPattern& pattern, Attribute stablehloAttr,
     SmallVector<NamedAttribute>& vhloAttrs) {
-  auto attr = stablehloAttr.dyn_cast<stablehlo::ConvDimensionNumbersAttr>();
+  auto attr = dyn_cast<stablehlo::ConvDimensionNumbersAttr>(stablehloAttr);
   if (!attr) return specialFailure();
 
   auto vhloInputBatchDimension =
@@ -360,7 +359,7 @@ SpecialResult convertConvDimensionNumbers(
 SpecialResult convertCustomCallApiVersion(
     const ConversionPattern& pattern, Attribute stablehloAttr,
     SmallVector<NamedAttribute>& vhloAttrs) {
-  auto attr = stablehloAttr.dyn_cast<CustomCallApiVersionAttr>();
+  auto attr = dyn_cast<CustomCallApiVersionAttr>(stablehloAttr);
   if (!attr) return specialFailure();
 
   auto convert = [&]() -> Attribute {
@@ -376,7 +375,7 @@ SpecialResult convertCustomCallApiVersion(
 SpecialResult convertCustomCallCalledComputations(
     const ConversionPattern& pattern, Attribute stablehloAttr,
     SmallVector<NamedAttribute>& vhloAttrs) {
-  auto attr = stablehloAttr.dyn_cast<ArrayAttr>();
+  auto attr = dyn_cast<ArrayAttr>(stablehloAttr);
   if (!attr) return specialFailure();
 
   SmallVector<Attribute> vhloElementAttrs;
@@ -395,7 +394,7 @@ SpecialResult convertCustomCallCalledComputations(
 SpecialResult convertDotDimensionNumbers(
     const ConversionPattern& pattern, Attribute stablehloAttr,
     SmallVector<NamedAttribute>& vhloAttrs) {
-  auto attr = stablehloAttr.dyn_cast<stablehlo::DotDimensionNumbersAttr>();
+  auto attr = dyn_cast<stablehlo::DotDimensionNumbersAttr>(stablehloAttr);
   if (!attr) return specialFailure();
 
   auto vhloLhsBatchingDimensions =
@@ -441,7 +440,7 @@ SpecialResult convertFuncCallee(const ConversionPattern& pattern,
 SpecialResult convertGatherDimensionNumbers(
     const ConversionPattern& pattern, Attribute stablehloAttr,
     SmallVector<NamedAttribute>& vhloAttrs) {
-  auto attr = stablehloAttr.dyn_cast<stablehlo::GatherDimensionNumbersAttr>();
+  auto attr = dyn_cast<stablehlo::GatherDimensionNumbersAttr>(stablehloAttr);
   if (!attr) return specialFailure();
 
   auto vhloOffsetDims = convertInts(pattern, attr.getOffsetDims());
@@ -473,7 +472,7 @@ SpecialResult convertGatherDimensionNumbers(
 SpecialResult convertScatterDimensionNumbers(
     const ConversionPattern& pattern, Attribute stablehloAttr,
     SmallVector<NamedAttribute>& vhloAttrs) {
-  auto attr = stablehloAttr.dyn_cast<stablehlo::ScatterDimensionNumbersAttr>();
+  auto attr = dyn_cast<stablehlo::ScatterDimensionNumbersAttr>(stablehloAttr);
   if (!attr) return specialFailure();
 
   auto vhloUpdateWindowDims = convertInts(pattern, attr.getUpdateWindowDims());
@@ -507,7 +506,7 @@ SpecialResult convertScatterDimensionNumbers(
 SpecialResult convertUseGlobalDeviceIds(
     const ConversionPattern& pattern, Attribute stablehloAttr,
     SmallVector<NamedAttribute>& vhloAttrs) {
-  if (!stablehloAttr.isa<UnitAttr>()) return specialFailure();
+  if (!isa<UnitAttr>(stablehloAttr)) return specialFailure();
   vhloAttrs.emplace_back(
       StringAttr::get(pattern.getContext(), "use_global_device_ids"),
       vhlo::BooleanV1Attr::get(pattern.getContext(), true));

--- a/stablehlo/transforms/StablehloRefineArguments.cpp
+++ b/stablehlo/transforms/StablehloRefineArguments.cpp
@@ -108,14 +108,14 @@ LogicalResult validateRefinedTypes(func::FuncOp func, TypeRange refinedTypes) {
     if (type == refinedType) continue;
 
     // If mismatched, must be tensor types
-    auto tensorType = type.dyn_cast<TensorType>();
-    auto refinedTensorType = refinedType.dyn_cast<TensorType>();
+    auto tensorType = dyn_cast<TensorType>(type);
+    auto refinedTensorType = dyn_cast<TensorType>(refinedType);
     if (!tensorType || !refinedTensorType) {
       return refinementError(func, i, type, refinedType, "must be a tensor");
     }
 
     // Refined rank cannot be unranked if mismatch
-    if (refinedType.isa<UnrankedTensorType>()) {
+    if (isa<UnrankedTensorType>(refinedType)) {
       return refinementError(func, i, type, refinedType, "must be ranked");
     }
 
@@ -162,7 +162,7 @@ void wrapRefinedOperands(func::FuncOp func, TypeRange refinedTypes) {
     Type argType = arg.getType();
     Type refinedType = refinedTypes[i];
     if (argType != refinedType) {
-      auto rankedRefinedType = refinedType.cast<RankedTensorType>();
+      auto rankedRefinedType = cast<RankedTensorType>(refinedType);
       auto customCall =
           makeShapeRefinementOperandWrapper(builder, arg, rankedRefinedType);
       auto callResult = customCall.getResult(0);

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -172,7 +172,7 @@ LogicalResult refineReturnTypes(PatternRewriter& rewriter, Operation* op,
   for (auto it : llvm::zip(flattenedTypes, refinements)) {
     // Cannot use structured bindings to simplify this because capturing
     // structured bindings in a lambda is a C++ 20 extension.
-    ShapedType currentType = std::get<0>(it).dyn_cast<ShapedType>();
+    ShapedType currentType = dyn_cast<ShapedType>(std::get<0>(it));
     ShapedTypeComponents refinement = std::get<1>(it);
     auto failWithReason = [&](StringRef reason) {
       return rewriter.notifyMatchFailure(op, [&](Diagnostic& diag) {
@@ -218,7 +218,7 @@ LogicalResult refineReturnTypes(PatternRewriter& rewriter, Operation* op,
     // If either the current type or the refinement have encodings, then
     // we fail. Encodings are left for future work.
     Attribute currentEncoding = nullptr;
-    if (auto currentRankedType = currentType.dyn_cast<RankedTensorType>()) {
+    if (auto currentRankedType = dyn_cast<RankedTensorType>(currentType)) {
       currentEncoding = currentRankedType.getEncoding();
     }
     Attribute refinedEncoding = refinement.getAttribute();
@@ -256,7 +256,7 @@ DenseIntElementsAttr getTensorAttr(ShapedType type, ArrayRef<APSInt> values) {
 APSInt getAPSInt(Type type, uint64_t value) {
   unsigned numBits;
   bool isUnsigned;
-  if (auto integerType = type.dyn_cast<IntegerType>()) {
+  if (auto integerType = dyn_cast<IntegerType>(type)) {
     numBits = integerType.getWidth();
     // Signless types are treated as signed, per StableHLO convention.
     isUnsigned = integerType.isUnsignedInteger();
@@ -482,7 +482,7 @@ struct EvalConvertOpPattern : public OpRewritePattern<ConvertOp> {
   LogicalResult matchAndRewrite(ConvertOp op,
                                 PatternRewriter& rewriter) const override {
     auto resultType = op.getType();
-    if (!resultType.getElementType().isa<IntegerType>())
+    if (!isa<IntegerType>(resultType.getElementType()))
       return rewriter.notifyMatchFailure(op,
                                          "expected integer result tensor type");
     auto resultBitWidth = resultType.getElementType().getIntOrFloatBitWidth();
@@ -608,7 +608,7 @@ struct EvalSignOpPattern : public OpRewritePattern<SignOp> {
   LogicalResult matchAndRewrite(SignOp op,
                                 PatternRewriter& rewriter) const override {
     auto resultType = op.getType();
-    if (!resultType.getElementType().isa<IntegerType>())
+    if (!isa<IntegerType>(resultType.getElementType()))
       return rewriter.notifyMatchFailure(op,
                                          "expected integer result tensor type");
     return evalElementwise(rewriter, op, [&](APSInt operand) {
@@ -633,7 +633,7 @@ struct EvalSliceOpPattern : public OpRewritePattern<SliceOp> {
       return rewriter.notifyMatchFailure(
           op, "expected non-0 ranked tensor result type");
 
-    auto operand = op.getOperand().cast<TypedValue<RankedTensorType>>();
+    auto operand = cast<TypedValue<RankedTensorType>>(op.getOperand());
     RankedTensorType operandType = operand.getType();
     if (!operandType.hasStaticShape())
       return rewriter.notifyMatchFailure(
@@ -721,7 +721,7 @@ struct RefineBitcastConvertOpPattern
     auto resultType = op.getType();
     auto getBitWidthFn = [](ShapedType type) {
       auto elementType = type.getElementType();
-      if (auto complexType = elementType.dyn_cast<ComplexType>())
+      if (auto complexType = dyn_cast<ComplexType>(elementType))
         return complexType.getElementType().getIntOrFloatBitWidth();
       return elementType.getIntOrFloatBitWidth();
     };

--- a/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
+++ b/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
@@ -54,7 +54,7 @@ class VhloToStablehloTypeConverter : public vhlo::VhloTypeConverter {
   }
 
   Attribute convertEncoding(Attribute attr) const final {
-    if (auto vhloAttr = attr.dyn_cast_or_null<vhlo::TypeExtensionsV1Attr>()) {
+    if (auto vhloAttr = dyn_cast_or_null<vhlo::TypeExtensionsV1Attr>(attr)) {
       return stablehlo::TypeExtensionsAttr::get(vhloAttr.getContext(),
                                                 vhloAttr.getBounds());
     }
@@ -78,7 +78,7 @@ class VhloToStablehloTypeConverter : public vhlo::VhloTypeConverter {
 Attribute convertGeneric(Attribute vhloAttr,
                          const TypeConverter* typeConverter) {
   LLVM_DEBUG(llvm::dbgs() << "Converting attr " << vhloAttr);
-  if (auto vhloAttrs = vhloAttr.dyn_cast<vhlo::ArrayV1Attr>()) {
+  if (auto vhloAttrs = dyn_cast<vhlo::ArrayV1Attr>(vhloAttr)) {
     SmallVector<Attribute> stablehloAttrs;
     for (auto vhloAttr : vhloAttrs.getValue()) {
       auto stablehloAttr = convertGeneric(vhloAttr, typeConverter);
@@ -87,73 +87,73 @@ Attribute convertGeneric(Attribute vhloAttr,
     }
     return ArrayAttr::get(vhloAttrs.getContext(), stablehloAttrs);
   }
-  if (auto attr = vhloAttr.dyn_cast<vhlo::BooleanV1Attr>()) {
+  if (auto attr = dyn_cast<vhlo::BooleanV1Attr>(vhloAttr)) {
     return BoolAttr::get(attr.getContext(), attr.getValue());
   }
-  if (auto attr = vhloAttr.dyn_cast<vhlo::ComparisonDirectionV1Attr>()) {
+  if (auto attr = dyn_cast<vhlo::ComparisonDirectionV1Attr>(vhloAttr)) {
     RETURN_CONVERTED_ENUM_ATTR(ComparisonDirection, V1);
   }
-  if (auto attr = vhloAttr.dyn_cast<vhlo::ComparisonTypeV1Attr>()) {
+  if (auto attr = dyn_cast<vhlo::ComparisonTypeV1Attr>(vhloAttr)) {
     RETURN_CONVERTED_ENUM_ATTR(ComparisonType, V1);
   }
-  if (auto attr = vhloAttr.dyn_cast<vhlo::CustomCallApiVersionV1Attr>()) {
+  if (auto attr = dyn_cast<vhlo::CustomCallApiVersionV1Attr>(vhloAttr)) {
     RETURN_CONVERTED_ENUM_ATTR(CustomCallApiVersion, V1);
   }
-  if (auto attr = vhloAttr.dyn_cast<vhlo::DictionaryV1Attr>()) {
+  if (auto attr = dyn_cast<vhlo::DictionaryV1Attr>(vhloAttr)) {
     SmallVector<NamedAttribute> vhloAttrs;
     for (auto namedAttr : attr.getValue()) {
-      auto builtinName = convertGeneric(namedAttr.first, typeConverter)
-                             .dyn_cast_or_null<StringAttr>();
+      auto builtinName = dyn_cast_or_null<StringAttr>(
+          convertGeneric(namedAttr.first, typeConverter));
       auto builtinValue = convertGeneric(namedAttr.second, typeConverter);
       if (!builtinName || !builtinValue) return {};
       vhloAttrs.push_back({builtinName, builtinValue});
     }
     return DictionaryAttr::get(attr.getContext(), vhloAttrs);
   }
-  if (auto attr = vhloAttr.dyn_cast<vhlo::FftTypeV1Attr>()) {
+  if (auto attr = dyn_cast<vhlo::FftTypeV1Attr>(vhloAttr)) {
     RETURN_CONVERTED_ENUM_ATTR(FftType, V1);
   }
-  if (auto attr = vhloAttr.dyn_cast<vhlo::FloatV1Attr>()) {
+  if (auto attr = dyn_cast<vhlo::FloatV1Attr>(vhloAttr)) {
     auto builtinFloatType = typeConverter->convertType(attr.getType());
     if (!builtinFloatType) return {};
     // FIXME: What is the proper way to reconstruct a attr?
     return FloatAttr::get(builtinFloatType, attr.getValue().convertToDouble());
   }
-  if (auto attr = vhloAttr.dyn_cast<vhlo::IntegerV1Attr>()) {
+  if (auto attr = dyn_cast<vhlo::IntegerV1Attr>(vhloAttr)) {
     auto builtinIntegerType = typeConverter->convertType(attr.getType());
     if (!builtinIntegerType) return {};
     return IntegerAttr::get(builtinIntegerType, attr.getValue());
   }
-  if (auto attr = vhloAttr.dyn_cast<vhlo::OutputOperandAliasV1Attr>()) {
+  if (auto attr = dyn_cast<vhlo::OutputOperandAliasV1Attr>(vhloAttr)) {
     return stablehlo::OutputOperandAliasAttr::get(
         attr.getContext(), attr.getOutputTupleIndices(), attr.getOperandIndex(),
         attr.getOperandTupleIndices());
   }
-  if (auto attr = vhloAttr.dyn_cast<vhlo::PrecisionV1Attr>()) {
+  if (auto attr = dyn_cast<vhlo::PrecisionV1Attr>(vhloAttr)) {
     RETURN_CONVERTED_ENUM_ATTR(Precision, V1);
   }
-  if (auto attr = vhloAttr.dyn_cast<vhlo::RngAlgorithmV1Attr>()) {
+  if (auto attr = dyn_cast<vhlo::RngAlgorithmV1Attr>(vhloAttr)) {
     RETURN_CONVERTED_ENUM_ATTR(RngAlgorithm, V1);
   }
-  if (auto attr = vhloAttr.dyn_cast<vhlo::RngDistributionV1Attr>()) {
+  if (auto attr = dyn_cast<vhlo::RngDistributionV1Attr>(vhloAttr)) {
     RETURN_CONVERTED_ENUM_ATTR(RngDistribution, V1);
   }
-  if (auto attr = vhloAttr.dyn_cast<vhlo::StringV1Attr>()) {
+  if (auto attr = dyn_cast<vhlo::StringV1Attr>(vhloAttr)) {
     return StringAttr::get(attr.getContext(), attr.getValue());
   }
-  if (auto attr = vhloAttr.dyn_cast<vhlo::TensorV1Attr>()) {
+  if (auto attr = dyn_cast<vhlo::TensorV1Attr>(vhloAttr)) {
     auto builtinType =
-        typeConverter->convertType(attr.getType()).cast<ShapedType>();
+        cast<ShapedType>(typeConverter->convertType(attr.getType()));
     if (!builtinType) return {};
     return DenseIntOrFPElementsAttr::getFromRawBuffer(builtinType,
                                                       attr.getData());
   }
-  if (auto attr = vhloAttr.dyn_cast<vhlo::TransposeV1Attr>()) {
+  if (auto attr = dyn_cast<vhlo::TransposeV1Attr>(vhloAttr)) {
     RETURN_CONVERTED_ENUM_ATTR(Transpose, V1);
   }
   // NOTE: TypeExtensionsV1Attr is only used as a RankedTensorType's encoding,
   // so it's handled during type conversion (see convertEncoding above).
-  if (auto attr = vhloAttr.dyn_cast<vhlo::TypeV1Attr>()) {
+  if (auto attr = dyn_cast<vhlo::TypeV1Attr>(vhloAttr)) {
     auto builtinType = typeConverter->convertType(attr.getValue());
     if (!builtinType) return {};
     return TypeAttr::get(builtinType);
@@ -192,7 +192,7 @@ SpecialResult specialFailure() { return SpecialResult::SPECIAL_FAILURE; }
 SpecialResult notSpecial() { return SpecialResult::NOT_SPECIAL; }
 
 LogicalResult convertInt(Attribute vhloAttr, int64_t& result) {
-  auto vhloIntegerAttr = vhloAttr.dyn_cast<vhlo::IntegerV1Attr>();
+  auto vhloIntegerAttr = dyn_cast<vhlo::IntegerV1Attr>(vhloAttr);
   if (!vhloIntegerAttr) return failure();
   result = vhloIntegerAttr.getValue().getSExtValue();
   return success();
@@ -201,10 +201,10 @@ LogicalResult convertInt(Attribute vhloAttr, int64_t& result) {
 LogicalResult convertInts(Attribute vhloAttr,
                           const TypeConverter* typeConverter,
                           SmallVector<int64_t>& result) {
-  auto vhloTensorAttr = vhloAttr.dyn_cast<vhlo::TensorV1Attr>();
+  auto vhloTensorAttr = dyn_cast<vhlo::TensorV1Attr>(vhloAttr);
   if (!vhloTensorAttr) return failure();
-  auto stablehloAttr = convertGeneric(vhloAttr, typeConverter)
-                           .dyn_cast_or_null<DenseIntElementsAttr>();
+  auto stablehloAttr = dyn_cast_or_null<DenseIntElementsAttr>(
+      convertGeneric(vhloAttr, typeConverter));
   if (!stablehloAttr) return failure();
   llvm::append_range(result, stablehloAttr.getValues<int64_t>());
   return success();
@@ -212,10 +212,10 @@ LogicalResult convertInts(Attribute vhloAttr,
 
 Attribute convertSymbol(Attribute vhloAttr,
                         const TypeConverter* typeConverter) {
-  auto vhloStringAttr = vhloAttr.dyn_cast<vhlo::StringV1Attr>();
+  auto vhloStringAttr = dyn_cast<vhlo::StringV1Attr>(vhloAttr);
   if (!vhloStringAttr) return {};
-  auto stablehloStringAttr = convertGeneric(vhloStringAttr, typeConverter)
-                                 .dyn_cast_or_null<StringAttr>();
+  auto stablehloStringAttr = dyn_cast_or_null<StringAttr>(
+      convertGeneric(vhloStringAttr, typeConverter));
   if (!stablehloStringAttr) return {};
   return FlatSymbolRefAttr::get(stablehloStringAttr);
 }
@@ -279,7 +279,7 @@ Attribute convertConvDimensionNumbers(OpType vhloOp,
 
 Attribute convertCustomCallCalledComputations(
     Attribute vhloAttr, const TypeConverter* typeConverter) {
-  if (auto vhloArrayAttr = vhloAttr.dyn_cast<vhlo::ArrayV1Attr>()) {
+  if (auto vhloArrayAttr = dyn_cast<vhlo::ArrayV1Attr>(vhloAttr)) {
     SmallVector<Attribute> stablehloAttrs;
     for (auto vhloAttr : vhloArrayAttr.getValue()) {
       auto stablehloAttr = convertSymbol(vhloAttr, typeConverter);
@@ -444,7 +444,7 @@ SpecialResult convertDenseArray(StringAttr vhloName, Attribute vhloAttr,
 
   // Handle splats
   if (data.size() == 1) {
-    auto tensorType = tensorAttr.getType().dyn_cast<vhlo::RankedTensorV1Type>();
+    auto tensorType = dyn_cast<vhlo::RankedTensorV1Type>(tensorAttr.getType());
     if (!tensorType || (tensorType.getShape().size() != 1))
       return specialFailure();
     auto size = tensorType.getShape()[0];
@@ -487,7 +487,7 @@ SpecialResult convertSpecial(const OpConversionPattern<VhloOpTy>& pattern,
       if (!stablehloAttr) return specialFailure();
     }
     if (vhloName == "use_global_device_ids") {
-      auto vhloBooleanAttr = vhloAttr.dyn_cast<vhlo::BooleanV1Attr>();
+      auto vhloBooleanAttr = dyn_cast<vhlo::BooleanV1Attr>(vhloAttr);
       if (!vhloBooleanAttr) return specialFailure();
       if (!vhloBooleanAttr.getValue()) return specialSuccess();
       stablehloAttr = UnitAttr::get(pattern.getContext());
@@ -600,22 +600,22 @@ bool isBoolean(Attribute vhloAttr, bool value) {
 }
 
 bool isEmptyArray(Attribute vhloAttr) {
-  auto attr = vhloAttr.dyn_cast_or_null<vhlo::ArrayV1Attr>();
+  auto attr = dyn_cast_or_null<vhlo::ArrayV1Attr>(vhloAttr);
   return attr && attr.getValue().empty();
 }
 
 bool isEmptyDictionary(Attribute vhloAttr) {
-  auto attr = vhloAttr.dyn_cast_or_null<vhlo::DictionaryV1Attr>();
+  auto attr = dyn_cast_or_null<vhlo::DictionaryV1Attr>(vhloAttr);
   return attr && attr.getValue().empty();
 }
 
 bool isEmptyString(Attribute vhloAttr) {
-  auto attr = vhloAttr.dyn_cast_or_null<vhlo::StringV1Attr>();
+  auto attr = dyn_cast_or_null<vhlo::StringV1Attr>(vhloAttr);
   return attr && attr.getValue().empty();
 }
 
 bool isEmptyTensor(Attribute vhloAttr) {
-  auto attr = vhloAttr.dyn_cast_or_null<vhlo::TensorV1Attr>();
+  auto attr = dyn_cast_or_null<vhlo::TensorV1Attr>(vhloAttr);
   return attr && attr.getData().empty();
 }
 
@@ -627,7 +627,7 @@ bool isInteger(Attribute vhloAttr, int64_t value) {
 }
 
 bool isSplatArray(Attribute vhloAttr, Attribute splatValue) {
-  auto attr = vhloAttr.dyn_cast_or_null<vhlo::ArrayV1Attr>();
+  auto attr = dyn_cast_or_null<vhlo::ArrayV1Attr>(vhloAttr);
   return attr && llvm::all_of(attr.getValue(), [&](Attribute attr) {
            return attr == splatValue;
          });
@@ -643,7 +643,7 @@ bool isSplatTensor(const ConversionPattern& pattern, Attribute vhloAttr,
 }
 
 bool isString(Attribute vhloAttr, StringRef value) {
-  auto attr = vhloAttr.dyn_cast_or_null<vhlo::StringV1Attr>();
+  auto attr = dyn_cast_or_null<vhlo::StringV1Attr>(vhloAttr);
   return attr && attr.getValue() == value;
 }
 

--- a/stablehlo/transforms/VhloToVersion.cpp
+++ b/stablehlo/transforms/VhloToVersion.cpp
@@ -112,24 +112,24 @@ LogicalResult isLegalAttribute(const Attribute& attr, Version targetVersion) {
   }
 
   // Recursively check attrs if VHLO attr is a container
-  if (auto arrAttr = attr.dyn_cast<ArrayV1Attr>())
+  if (auto arrAttr = dyn_cast<ArrayV1Attr>(attr))
     return success(llvm::all_of(arrAttr.getValue(), [&](Attribute ele) {
       return succeeded(isLegalAttribute(ele, targetVersion));
     }));
-  if (auto arrAttr = attr.dyn_cast<DictionaryV1Attr>()) {
+  if (auto arrAttr = dyn_cast<DictionaryV1Attr>(attr)) {
     return success(llvm::all_of(
         arrAttr.getValue(), [&](std::pair<Attribute, Attribute> entry) {
           return succeeded(isLegalAttribute(entry.first, targetVersion)) &&
                  succeeded(isLegalAttribute(entry.second, targetVersion));
         }));
   }
-  if (auto floatAttr = attr.dyn_cast<FloatV1Attr>())
+  if (auto floatAttr = dyn_cast<FloatV1Attr>(attr))
     return isLegalType(floatAttr.getType(), targetVersion);
-  if (auto intAttr = attr.dyn_cast<IntegerV1Attr>())
+  if (auto intAttr = dyn_cast<IntegerV1Attr>(attr))
     return isLegalType(intAttr.getType(), targetVersion);
-  if (auto tensorAttr = attr.dyn_cast<TensorV1Attr>())
+  if (auto tensorAttr = dyn_cast<TensorV1Attr>(attr))
     return isLegalType(tensorAttr.getType(), targetVersion);
-  if (auto typeAttr = attr.dyn_cast<TypeV1Attr>())
+  if (auto typeAttr = dyn_cast<TypeV1Attr>(attr))
     return isLegalType(typeAttr.getValue(), targetVersion);
 
   // Is VHLO and valid version, success.
@@ -146,30 +146,30 @@ LogicalResult isLegalType(Type type, const Version& targetVersion) {
   }
 
   // Recursively check types if VHLO type is a container.
-  if (auto complex = type.dyn_cast<ComplexV1Type>())
+  if (auto complex = dyn_cast<ComplexV1Type>(type))
     return isLegalType(complex.getElementType(), targetVersion);
-  if (auto func = type.dyn_cast<FunctionV1Type>()) {
+  if (auto func = dyn_cast<FunctionV1Type>(type)) {
     auto validateType = [&](Type ele) {
       return succeeded(isLegalType(ele, targetVersion));
     };
     return success(llvm::all_of(func.getInputs(), validateType) &&
                    llvm::all_of(func.getOutputs(), validateType));
   }
-  if (auto ranked = type.dyn_cast<RankedTensorV1Type>()) {
+  if (auto ranked = dyn_cast<RankedTensorV1Type>(type)) {
     auto encoding = ranked.getEncoding();
     if (encoding && failed(isLegalAttribute(encoding, targetVersion)))
       return failure();
     return isLegalType(ranked.getElementType(), targetVersion);
   }
-  if (auto tuple = type.dyn_cast<TupleV1Type>())
+  if (auto tuple = dyn_cast<TupleV1Type>(type))
     return success(llvm::all_of(tuple.getTypes(), [&](Type ele) {
       return succeeded(isLegalType(ele, targetVersion));
     }));
-  if (auto quant = type.dyn_cast<UniformQuantizedV1Type>())
+  if (auto quant = dyn_cast<UniformQuantizedV1Type>(type))
     return success(
         succeeded(isLegalType(quant.getStorageType(), targetVersion)) &&
         succeeded(isLegalType(quant.getExpressedType(), targetVersion)));
-  if (auto unranked = type.dyn_cast<UnrankedTensorV1Type>())
+  if (auto unranked = dyn_cast<UnrankedTensorV1Type>(type))
     return isLegalType(unranked.getElementType(), targetVersion);
 
   // Is VHLO and valid version, success.


### PR DESCRIPTION
We should prefer functional style as the method style is deprecated: https://github.com/llvm/mlir-www/blob/a7e1daee9e627d951cac5d659296d055ba0059a1/website/content/deprecation/_index.md/#deprecated
 (https://mlir.llvm.org/deprecation/)

I mostly used automated replacements to produce this change.