### PR TITLE
Use cast instead of dyn_cast where possible

### DIFF
--- a/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
@@ -96,16 +96,14 @@ SmallVector<Value, 2> extractDynamicEinsumSizes(
     if (dimIndIt != lhsLoopVec.end()) {
       // Query from lhs vars.
       auto dimIndPos = dimIndIt - lhsLoopVec.begin();
-      auto lhsShape =
-          llvm::dyn_cast<RankedTensorType>(lhs.getType()).getShape();
+      auto lhsShape = llvm::cast<RankedTensorType>(lhs.getType()).getShape();
       if (lhsShape[dimIndPos] != ShapedType::kDynamic) continue;
       dimSize = b.create<tensor::DimOp>(loc, lhs, dimIndPos);
     } else {
       // query from rhs vars.
       dimIndIt = std::find(rhsLoopVec.begin(), rhsLoopVec.end(), dimInd);
       auto dimIndPos = dimIndIt - rhsLoopVec.begin();
-      auto rhsShape =
-          llvm::dyn_cast<RankedTensorType>(rhs.getType()).getShape();
+      auto rhsShape = llvm::cast<RankedTensorType>(rhs.getType()).getShape();
       if (rhsShape[dimIndPos] != ShapedType::kDynamic) continue;
       dimSize = b.create<tensor::DimOp>(loc, rhs, dimIndPos);
     }
@@ -619,11 +617,9 @@ struct HloDynamicBroadcastInDimConverter final
       mlir::stablehlo::DynamicBroadcastInDimOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     Value operand = adaptor.getOperand();
-    auto operandType = dyn_cast<RankedTensorType>(operand.getType());
-    if (!operandType) return failure();
+    auto operandType = cast<RankedTensorType>(operand.getType());
     auto resultType =
         getTypeConverter()->convertType<RankedTensorType>(op.getType());
-    if (!resultType) return failure();
 
     // Determine dimension expressions based on whether the dimension is
     // expanding (0) or non-expanding (identity), and fail if we cannot decide
@@ -687,11 +683,9 @@ struct DynamicBroadcastInDimOpToBroadcastConverter final
     Location loc = op.getLoc();
 
     Value operand = adaptor.getOperand();
-    auto operandTy = llvm::dyn_cast<RankedTensorType>(operand.getType());
-    if (!operandTy) return failure();
+    auto operandTy = llvm::cast<RankedTensorType>(operand.getType());
     auto resultTy =
         getTypeConverter()->convertType<RankedTensorType>(op.getType());
-    if (!resultTy) return failure();
 
     SmallVector<int64_t> broadcastDimensions =
         llvm::to_vector(op.getBroadcastDimensions());
@@ -763,7 +757,7 @@ struct DynamicBroadcastInDimOpToBroadcastConverter final
   static Value getBroadcastOperand(
       PatternRewriter &rewriter, Location loc, Value operand,
       llvm::function_ref<bool(int64_t)> isExpandingDim) {
-    auto operandTy = llvm::dyn_cast<RankedTensorType>(operand.getType());
+    auto operandTy = llvm::cast<RankedTensorType>(operand.getType());
 
     SmallVector<int64_t> updatedOperandShape =
         llvm::to_vector(operandTy.getShape());
@@ -1534,15 +1528,15 @@ struct DynamicUpdateSliceConverter final
       ConversionPatternRewriter &rewriter) const override {
     Location loc = op.getLoc();
     auto operandType =
-        llvm::dyn_cast<RankedTensorType>(adaptor.getOperand().getType());
-    if (!operandType || !operandType.hasStaticShape()) {
+        llvm::cast<RankedTensorType>(adaptor.getOperand().getType());
+    if (!operandType.hasStaticShape()) {
       return rewriter.notifyMatchFailure(
           op, "require static ranked type for operand");
     }
 
     auto updateType =
-        llvm::dyn_cast<RankedTensorType>(adaptor.getUpdate().getType());
-    if (!updateType || !updateType.hasStaticShape()) {
+        llvm::cast<RankedTensorType>(adaptor.getUpdate().getType());
+    if (!updateType.hasStaticShape()) {
       return rewriter.notifyMatchFailure(
           op, "require static ranked type for operand");
     }
@@ -1712,13 +1706,7 @@ struct GatherConversion final : OpConversionPattern<mlir::stablehlo::GatherOp> {
     auto resultType =
         getTypeConverter()->convertType<RankedTensorType>(gatherOp.getType());
     RankedTensorType startIndicesType =
-        dyn_cast<RankedTensorType>(startIndices.getType());
-    // We could actually deal with an unranked result by inferring the result
-    // rank, but the current reifyReturnTypes doesn't support unranked either.
-    if (!resultType || !startIndicesType) {
-      return rewriter.notifyMatchFailure(gatherOp,
-                                         "unranked start indices or result");
-    }
+        cast<RankedTensorType>(startIndices.getType());
 
     int64_t resultRank = resultType.getRank();
     // slice_sizes has to have the same size as operand.rank, and doing it this
@@ -1910,12 +1898,10 @@ struct SelectAndScatterNoOverlapConverter final
     Value operand = op.getOperand();
     Value init = op.getInitValue();
 
-    auto sourceTy = llvm::dyn_cast<RankedTensorType>(source.getType());
-    auto operandTy = llvm::dyn_cast<RankedTensorType>(operand.getType());
-    auto initTy = llvm::dyn_cast<RankedTensorType>(init.getType());
-    auto resultTy = llvm::dyn_cast<RankedTensorType>(op.getResult().getType());
-    if (!sourceTy || !operandTy || !initTy || !resultTy)
-      return rewriter.notifyMatchFailure(op, "inputs/outputs must be ranked");
+    auto sourceTy = llvm::cast<RankedTensorType>(source.getType());
+    auto operandTy = llvm::cast<RankedTensorType>(operand.getType());
+    auto initTy = llvm::cast<RankedTensorType>(init.getType());
+    auto resultTy = llvm::cast<RankedTensorType>(op.getResult().getType());
 
     auto indexETy = b.getI32Type();
     auto srcETy = operandTy.getElementType();
@@ -2514,10 +2500,7 @@ struct SetDimensionSizeConverter final
     // regular dynamic shape. Note that the bounds annotation is still around
     // but may be no longer valid depending on choices made by bufferization.
     Location loc = setDimensionSizeOp.getLoc();
-    auto resultType = dyn_cast<RankedTensorType>(setDimensionSizeOp.getType());
-    if (!resultType)
-      return rewriter.notifyMatchFailure(setDimensionSizeOp,
-                                         "expected a ranked tensor");
+    auto resultType = cast<RankedTensorType>(setDimensionSizeOp.getType());
 
     SmallVector<OpFoldResult> offsets(resultType.getRank(),
                                       rewriter.getIndexAttr(0));

--- a/stablehlo/conversions/linalg/transforms/StablehloToLinalgReduce.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloToLinalgReduce.cpp
@@ -37,12 +37,8 @@ static bool isUnsupported(mlir::stablehlo::ReduceOp op) {
 
   // We require all reduce shapes to be the same, up to the element types, so
   // we can just the first operand and the first result as a representative.
-  if (auto inputTy =
-          dyn_cast<RankedTensorType>(op.getInputs().getType().front())) {
-    return llvm::is_contained(inputTy.getShape(), 0);
-  }
-
-  return false;
+  auto inputTy = cast<RankedTensorType>(op.getInputs().getType().front());
+  return llvm::is_contained(inputTy.getShape(), 0);
 }
 
 /// Returns a permutation AffineMap that puts all reduction dimensions to the
@@ -231,7 +227,7 @@ struct ReduceOpToReduceConverter final
     llvm::sort(reductionDims);
 
     auto toRankedTensor = [](Value v) -> RankedTensorType {
-      return dyn_cast<RankedTensorType>(v.getType());
+      return cast<RankedTensorType>(v.getType());
     };
 
     SmallVector<Value> outputs;
@@ -244,13 +240,8 @@ struct ReduceOpToReduceConverter final
     for (auto [operand, initValue, resultType] : llvm::zip_equal(
              adaptor.getInputs(), adaptor.getInitValues(), resultTypes)) {
       auto initType = toRankedTensor(initValue);
-      if (!initType)
-        return rewriter.notifyMatchFailure(op,
-                                           "expects known-rank init values");
       initTypes.push_back(initType);
       auto operandType = toRankedTensor(operand);
-      if (!operandType)
-        return rewriter.notifyMatchFailure(op, "expects known-rank operands");
       operandTypes.push_back(operandType);
       initValue = rewriter.createOrFold<tensor::ExtractOp>(loc, initValue);
       auto tensorResultType = cast<RankedTensorType>(resultType);

--- a/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.cpp
+++ b/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.cpp
@@ -95,11 +95,8 @@ struct ConvertStablehloDotOp : public OpRewritePattern<stablehlo::DotOp> {
 
   LogicalResult matchAndRewrite(stablehlo::DotOp op,
                                 PatternRewriter& rewriter) const override {
-    auto lhsType = dyn_cast<RankedTensorType>(op.getLhs().getType());
-    auto rhsType = dyn_cast<RankedTensorType>(op.getRhs().getType());
-    if (!lhsType || !rhsType) {
-      return rewriter.notifyMatchFailure(op, "input tensors are not ranked");
-    }
+    auto lhsType = cast<RankedTensorType>(op.getLhs().getType());
+    auto rhsType = cast<RankedTensorType>(op.getRhs().getType());
 
     auto resultType = dyn_cast<ShapedType>(op.getResult().getType());
     if (!resultType) {
@@ -189,11 +186,8 @@ struct ConvertStablehloIotaOp : public OpRewritePattern<stablehlo::IotaOp> {
                                 PatternRewriter& rewriter) const override {
     auto resultType = op.getResult().getType();
     auto elementType = cast<ShapedType>(resultType).getElementType();
-    auto resultRankedType = dyn_cast<RankedTensorType>(resultType);
+    auto resultRankedType = cast<RankedTensorType>(resultType);
 
-    if (!resultRankedType) {
-      return rewriter.notifyMatchFailure(op, "result tensor must be ranked");
-    }
     if (!resultRankedType.hasStaticShape()) {
       return rewriter.notifyMatchFailure(op, "result tensor must be static");
     }
@@ -249,31 +243,21 @@ struct ConvertStablehloGatherOp : public OpRewritePattern<stablehlo::GatherOp> {
                                 PatternRewriter& rewriter) const override {
     // The input operand must be 3D, with shape [N, K, C].
     auto operand = op.getOperand();
-    auto operandType = dyn_cast<RankedTensorType>(operand.getType());
-    if (!operandType) {
-      return rewriter.notifyMatchFailure(op, "requires ranked operand shape");
-    }
+    auto operandType = cast<RankedTensorType>(operand.getType());
     if (operandType.getRank() != 3) {
       return rewriter.notifyMatchFailure(op, "operand must have rank of 3");
     }
 
     // The indices tensor must be 2D, with shape [N, W].
     auto startIndices = op.getStartIndices();
-    auto startIndicesType = dyn_cast<RankedTensorType>(startIndices.getType());
-    if (!startIndicesType) {
-      return rewriter.notifyMatchFailure(op,
-                                         "requires ranked start_indices shape");
-    }
+    auto startIndicesType = cast<RankedTensorType>(startIndices.getType());
     if (startIndicesType.getRank() != 2) {
       return rewriter.notifyMatchFailure(op,
                                          "start_indices must have rank of 2");
     }
 
     // The result tensor must be 3D, with shape [N, W, C].
-    auto resultType = dyn_cast<RankedTensorType>(op.getResult().getType());
-    if (!resultType) {
-      return rewriter.notifyMatchFailure(op, "requires ranked output shape");
-    }
+    auto resultType = cast<RankedTensorType>(op.getResult().getType());
     if (resultType.getRank() != 3) {
       return rewriter.notifyMatchFailure(op, "result must have rank of 3");
     }

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -685,9 +685,7 @@ void getSliceSizeValues(DynamicGatherOp* /*dGather*/, OpBuilder& builder,
 template <typename Op>
 LogicalResult reifyGatherShape(Op* op, OpBuilder& builder, ValueRange operands,
                                SmallVectorImpl<Value>& reifiedReturnShapes) {
-  // No support for unranked gather output shape a.t.m.
-  auto resultTy = dyn_cast<RankedTensorType>(op->getResult().getType());
-  if (!resultTy) return failure();
+  auto resultTy = cast<RankedTensorType>(op->getResult().getType());
 
   typename Op::Adaptor adaptor(operands);
   Value startIndices = adaptor.getStartIndices();
@@ -1158,11 +1156,8 @@ LogicalResult BatchNormInferenceOp::inferReturnTypeComponents(
 LogicalResult BitcastConvertOp::reifyReturnTypeShapes(
     OpBuilder& builder, ValueRange operands,
     SmallVectorImpl<Value>& reifiedReturnShapes) {
-  auto operandType = dyn_cast<RankedTensorType>(operands[0].getType());
-  auto resultType = dyn_cast<RankedTensorType>(getType());
-
-  // Only ranked tensors are supported.
-  if (!operandType || !resultType) return failure();
+  auto operandType = cast<RankedTensorType>(operands[0].getType());
+  auto resultType = cast<RankedTensorType>(getType());
 
   // Shape-changing bitcast convert is not implemented.
   // TODO(kramerb): This could be done by adjusting the last dimension.
@@ -1217,9 +1212,7 @@ LogicalResult BroadcastOp::reifyReturnTypeShapes(
   BroadcastOp::Adaptor adaptor(operands);
   Value operand = adaptor.getOperand();
 
-  auto operandType = dyn_cast<RankedTensorType>(operand.getType());
-  // Unranked tensors are not supported.
-  if (!operandType) return failure();
+  auto operandType = cast<RankedTensorType>(operand.getType());
 
   Location loc = getLoc();
   SmallVector<Value, 4> shapeValues;
@@ -1360,10 +1353,6 @@ LogicalResult ConcatenateOp::reifyReturnTypeShapes(
   ConcatenateOp::Adaptor adaptor(operands);
   auto inputs = adaptor.getInputs();
 
-  auto operandType = dyn_cast<RankedTensorType>(inputs[0].getType());
-  // Not support unranked type a.t.m.
-  if (!operandType) return failure();
-
   Location loc = this->getLoc();
   Type shapeScalarType = builder.getIndexType();
   auto toShapeScalarType = [&](Value v) {
@@ -1373,8 +1362,7 @@ LogicalResult ConcatenateOp::reifyReturnTypeShapes(
   SmallVector<SmallVector<Value, 4>, 4> allShapeValues;
   for (size_t inputId = 0; inputId < inputs.size(); ++inputId) {
     Value operand = inputs[inputId];
-    auto operandType = dyn_cast<RankedTensorType>(operand.getType());
-    if (!operandType) return failure();
+    auto operandType = cast<RankedTensorType>(operand.getType());
 
     SmallVector<Value, 4> shapeVals;
     for (const auto& element : llvm::enumerate(operandType.getShape())) {
@@ -1474,9 +1462,7 @@ LogicalResult RealDynamicSliceOp::reifyReturnTypeShapes(
   Value limitIndices = adaptor.getLimitIndices();
   Value strides = adaptor.getStrides();
 
-  auto operandType = dyn_cast<RankedTensorType>(operand.getType());
-  // Not support unranked type a.t.m.
-  if (!operandType) return failure();
+  auto operandType = cast<RankedTensorType>(operand.getType());
 
   Location loc = this->getLoc();
   SmallVector<Value, 4> shapeValues;
@@ -1759,9 +1745,7 @@ LogicalResult ReduceOp::reifyReturnTypeShapes(
   ReduceOp::Adaptor adaptor(operands);
   auto inputs = adaptor.getInputs();
 
-  auto operandType = dyn_cast<RankedTensorType>(inputs[0].getType());
-  // Not support unranked type a.t.m.
-  if (!operandType) return failure();
+  auto operandType = cast<RankedTensorType>(inputs[0].getType());
 
   Location loc = this->getLoc();
   SmallVector<Value, 4> shapeValues;
@@ -1990,9 +1974,7 @@ LogicalResult DynamicPadOp::reifyReturnTypeShapes(
   Value edgePaddingHigh = adaptor.getEdgePaddingHigh();
   Value interiorPadding = adaptor.getInteriorPadding();
 
-  auto operandType = dyn_cast<RankedTensorType>(operand.getType());
-  // Not support unranked pad a.t.m.
-  if (!operandType) return failure();
+  auto operandType = cast<RankedTensorType>(operand.getType());
 
   auto loc = this->getLoc();
   SmallVector<Value, 4> shapeValues;
@@ -2053,7 +2035,7 @@ LogicalResult ReshapeOp::verify() {
 }
 
 mlir::Speculation::Speculatability ReshapeOp::getSpeculatability() {
-  if (cast<RankedTensorType>(getOperand().getType()).hasStaticShape())
+  if (getOperand().getType().hasStaticShape())
     return mlir::Speculation::Speculatable;
   return mlir::Speculation::NotSpeculatable;
 }
@@ -2158,9 +2140,7 @@ LogicalResult TransposeOp::reifyReturnTypeShapes(
   TransposeOp::Adaptor adaptor(operands);
   Value operand = adaptor.getOperand();
 
-  auto operandType = dyn_cast<RankedTensorType>(operand.getType());
-  // Not support unranked type a.t.m.
-  if (!operandType) return failure();
+  auto operandType = cast<RankedTensorType>(operand.getType());
 
   Location loc = this->getLoc();
   SmallVector<int64_t, 4> permutation(this->getPermutation());

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2984,7 +2984,10 @@ LogicalResult inferSortOp(
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   // sort_c2
   for (auto resultType : inputs.getTypes()) {
-    inferredReturnShapes.emplace_back<ShapedType>(cast<ShapedType>(resultType));
+    auto rankedResult = cast<RankedTensorType>(resultType);
+    inferredReturnShapes.emplace_back(rankedResult.getShape(),
+                                      rankedResult.getElementType(),
+                                      rankedResult.getEncoding());
   }
   return success();
 }

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2993,10 +2993,10 @@ LogicalResult inferTopKOp(
     std::optional<Location> location, Value operand, int64_t k,
     SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
   Builder builder(operand.getContext());
-  auto operandType = operand.getType().dyn_cast<RankedTensorType>();
+  auto operandType = dyn_cast<RankedTensorType>(operand.getType());
   if (!operandType) {
     inferredReturnShapes.emplace_back(
-        operand.getType().cast<ShapedType>().getElementType());
+        cast<ShapedType>(operand.getType()).getElementType());
     inferredReturnShapes.emplace_back(builder.getI32Type());
     return success();
   }


### PR DESCRIPTION
For type inference, if the infer/verify logic were a method on the op itself, we could remove the cast altogether, but with the current setup we can at least change dyn_cast into cast to remove any ambiguity and clean up redundant checks.

In some cases it's not possible to remove the dyn_casts, for various reasons:
- CHLO ops still allow RankedTensorType
- Some dyn_casts are used on things that may not be tensors

https://github.com/openxla/stablehlo/issues/2065