### PR TITLE
Migrate StableHLO to use properties

### DIFF
--- a/stablehlo/conversions/linalg/transforms/MapStablehloToScalarOp.h
+++ b/stablehlo/conversions/linalg/transforms/MapStablehloToScalarOp.h
@@ -1281,7 +1281,9 @@ struct StablehloOpToStdScalarOp {
     static_assert(!std::is_same<StablehloOpTy, stablehlo::ConvertOp>::value);
     return mapOpOfType<StablehloOpTy>(
         op.getLoc(), resultTypes, argTypes,
-        typename StablehloOpTy::Adaptor(args, op->getAttrDictionary()), b);
+        typename StablehloOpTy::Adaptor(args, op->getAttrDictionary(),
+                                        op.getProperties()),
+        b);
   }
   // Overload for stablehlo::ConvertOp.
   static Value mapOpWithArgTypes(stablehlo::ConvertOp op,

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -492,7 +492,7 @@ void CustomCallOp::getEffects(
         effects) {
   // CustomCall has "all possible effects" unless the has_side_effect is present
   // and set to false.
-  auto hasSideEffect = (*this)->getAttrOfType<BoolAttr>("has_side_effect");
+  auto hasSideEffect = getHasSideEffectAttr();
   if (hasSideEffect && !hasSideEffect.getValue()) return;
   effects.emplace_back(MemoryEffects::Allocate::get());
   effects.emplace_back(MemoryEffects::Free::get());
@@ -1752,7 +1752,8 @@ LogicalResult PadOp::inferReturnTypes(
 LogicalResult PadOp::reifyReturnTypeShapes(
     OpBuilder& builder, ValueRange operands,
     SmallVectorImpl<Value>& reifiedReturnShapes) {
-  PadOp::Adaptor adaptor(operands, this->getOperation()->getAttrDictionary());
+  PadOp::Adaptor adaptor(operands, getOperation()->getAttrDictionary(),
+                         getProperties());
   auto loc = this->getLoc();
   Value operand = adaptor.getOperand();
   auto operandTy = cast<RankedTensorType>(operand.getType());

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -38,7 +38,6 @@ def StableHLO_Dialect : Dialect {
 
   let useDefaultAttributePrinterParser = 0;
   let useDefaultTypePrinterParser = 0;
-  let usePropertiesForAttributes = 0;
 }
 
 class StableHLO_Op<string mnemonic, list<Trait> traits = []> :

--- a/stablehlo/tests/chlo/chlo_legalize_to_stablehlo.mlir
+++ b/stablehlo/tests/chlo/chlo_legalize_to_stablehlo.mlir
@@ -2492,11 +2492,11 @@ func.func @tan_complexf32(%arg0 : tensor<1xf32>, %arg1 : tensor<1xf32>) -> (tens
 // CHECK-SAME: (%[[ARG:.*]]: tensor<16x16xf32>)
 func.func @top_k(%arg : tensor<16x16xf32>) -> (tensor<16x8xf32>, tensor<16x8xi32>) {
   // CHECK:      %[[IOTA:.*]] = stablehlo.iota dim = 1 : tensor<16x16xi32>
-  // CHECK-NEXT: %[[SORT:.*]]:2 = "stablehlo.sort"(%[[ARG]], %[[IOTA]]) ({
+  // CHECK-NEXT: %[[SORT:.*]]:2 = "stablehlo.sort"(%[[ARG]], %[[IOTA]]) <{dimension = 1 : i64, is_stable = true}> ({
   // CHECK-NEXT: ^{{.*}}(%[[LHS:.*]]: tensor<f32>, %[[RHS:.*]]: tensor<f32>, %{{.*}}: tensor<i32>, %{{.*}}: tensor<i32>):
   // CHECK-NEXT:   %[[CMP:.*]] = stablehlo.compare GT, %[[LHS]], %[[RHS]], TOTALORDER
   // CHECK-NEXT:   stablehlo.return %[[CMP]]
-  // CHECK-NEXT: }) {dimension = 1 : i64, is_stable = true} : (tensor<16x16xf32>, tensor<16x16xi32>) -> (tensor<16x16xf32>, tensor<16x16xi32>)
+  // CHECK-NEXT: }) : (tensor<16x16xf32>, tensor<16x16xi32>) -> (tensor<16x16xf32>, tensor<16x16xi32>)
   // CHECK-NEXT: %[[VAL:.*]] = stablehlo.slice %[[SORT]]#0 [0:16, 0:8] : (tensor<16x16xf32>) -> tensor<16x8xf32>
   // CHECK-NEXT: %[[IDX:.*]] = stablehlo.slice %[[SORT]]#1 [0:16, 0:8] : (tensor<16x16xi32>) -> tensor<16x8xi32>
   // CHECK-NEXT: return %[[VAL]], %[[IDX]]
@@ -2521,11 +2521,11 @@ func.func @dyn_top_k(%arg0: tensor<?x5x?xi1>) -> (tensor<?x5x2xi1>, tensor<?x5x2
   // CHECK-NEXT: [[K_I32x1:%.*]] = stablehlo.reshape [[K_I32]] : (tensor<i32>) -> tensor<1xi32>
   // CHECK-NEXT: [[RESULT_SHAPE:%.*]] = stablehlo.concatenate [[DIM_0_I32x1]], [[DIM_1_I32x1]], [[K_I32x1]], dim = 0 : (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<3xi32>
   // CHECK-NEXT: [[IOTA:%.*]] = stablehlo.dynamic_iota [[IOTA_SHAPE]], dim = 2 : (tensor<3xi32>) -> tensor<?x5x?xi32>
-  // CHECK-NEXT: [[SORT:%.*]]:2 = "stablehlo.sort"([[ARG]], [[IOTA]]) ({
+  // CHECK-NEXT: [[SORT:%.*]]:2 = "stablehlo.sort"([[ARG]], [[IOTA]]) <{dimension = 2 : i64, is_stable = true}> ({
   // CHECK-NEXT: ^bb0([[ARG_1:%.*]]: tensor<i1>, [[ARG_2:%.*]]: tensor<i1>, [[ARG_3:%.*]]: tensor<i32>, [[ARG_4:%.*]]: tensor<i32>):
   // CHECK-NEXT:   [[CMP:%.*]] = stablehlo.compare  GT, [[ARG_1]], [[ARG_2]],  NOTYPE : (tensor<i1>, tensor<i1>) -> tensor<i1>
   // CHECK-NEXT:   stablehlo.return [[CMP]] : tensor<i1>
-  // CHECK-NEXT: }) {dimension = 2 : i64, is_stable = true} : (tensor<?x5x?xi1>, tensor<?x5x?xi32>) -> (tensor<?x5x?xi1>, tensor<?x5x?xi32>)
+  // CHECK-NEXT: }) : (tensor<?x5x?xi1>, tensor<?x5x?xi32>) -> (tensor<?x5x?xi1>, tensor<?x5x?xi32>)
   // CHECK-NEXT: [[STARTS:%.*]] = stablehlo.constant dense<0> : tensor<3xi64>
   // CHECK-NEXT: [[LIMITS:%.*]] = stablehlo.convert [[RESULT_SHAPE]] : (tensor<3xi32>) -> tensor<3xi64>
   // CHECK-NEXT: [[STRIDES:%.*]] = stablehlo.constant dense<1> : tensor<3xi64>

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2014,7 +2014,7 @@ func.func @rng_bit_generator_dynamic(%arg0: tensor<?xui64>) -> (tensor<?xui64>, 
 
 // CHECK-LABEL: func @rng_normal
 func.func @rng_normal(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<2x3x5xf32> {
-  %cst = "stablehlo.constant"() {value = dense<[2, 3, 5]> : tensor<3xi64>} : () -> tensor<3xi64>
+  %cst = stablehlo.constant dense<[2, 3, 5]> : tensor<3xi64>
   %0 = "stablehlo.rng"(%arg0, %arg1, %cst) {rng_distribution = #stablehlo<rng_distribution NORMAL>}: (tensor<f32>, tensor<f32>, tensor<3xi64>) -> tensor<2x3x5xf32>
   func.return %0 : tensor<2x3x5xf32>
 }
@@ -2030,7 +2030,7 @@ func.func @rng_normal_no_constant(%a: tensor<f32>, %b: tensor<f32>, %shape: tens
 // -----
 
 func.func @rng_normal_invalid_shape(%arg0: tensor<f32>, %arg1: tensor<f32>) {
-  %cst = "stablehlo.constant"() {value = dense<7> : tensor<1xi64>} : () -> tensor<1xi64>
+  %cst = stablehlo.constant dense<7> : tensor<1xi64>
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error @+1 {{inferred type(s) 'tensor<7xf32>' are incompatible with return type(s) of operation 'tensor<12xf32>'}}
   %0 = "stablehlo.rng"(%arg0, %arg1, %cst) {rng_distribution = #stablehlo<rng_distribution NORMAL>}: (tensor<f32>, tensor<f32>, tensor<1xi64>) -> tensor<12xf32>
@@ -2067,7 +2067,7 @@ func.func @rng_normal_invalid_shape_rank(%mu: tensor<f32>, %sigma: tensor<f32>) 
 // -----
 
 func.func @rng_normal_invalid_type(%arg0: tensor<complex<f32>>, %arg1: tensor<f32>) {
-  %cst = "stablehlo.constant"() {value = dense<7> : tensor<1xi64>} : () -> tensor<1xi64>
+  %cst = stablehlo.constant dense<7> : tensor<1xi64>
   // expected-error @+1 {{#0 must be 0D tensor of pred (AKA boolean or 1-bit integer) or 4/8/16/32/64-bit signless integer or 4/8/16/32/64-bit unsigned integer or f8E4M3B11FNUZ type or f8E4M3FN type or f8E4M3FNUZ type or f8E5M2 type or f8E5M2FNUZ type or 16-bit float or 32-bit float or 64-bit float or bfloat16 type values, but got 'tensor<complex<f32>>'}}
   %0 = "stablehlo.rng"(%arg0, %arg1, %cst) {rng_distribution = #stablehlo<rng_distribution NORMAL>}: (tensor<complex<f32>>, tensor<f32>, tensor<1xi64>) -> tensor<7xf32>
   func.return
@@ -2691,7 +2691,7 @@ func.func @floor_invalid_i32_type(%arg0: tensor<4xi32>) -> tensor<4xi32> {
 // CHECK-LABEL: func @constants
 func.func @constants() -> () {
   // CHECK: stablehlo.constant dense<0> : tensor<i32>
-  %0 = "stablehlo.constant"() {value = dense<0> : tensor<i32>} : () -> (tensor<i32>)
+  %0 = "stablehlo.constant"() <{value = dense<0> : tensor<i32>}> : () -> (tensor<i32>)
 
   // CHECK: stablehlo.constant {extra_attr = 3 : i32} dense<0> : tensor<i32>
   %1 = "stablehlo.constant"() {extra_attr = 3 : i32, value = dense<0> : tensor<i32>} : () -> (tensor<i32>)
@@ -2703,7 +2703,7 @@ func.func @constants() -> () {
 func.func @constant_invalid() -> () {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{'stablehlo.constant' op inferred type(s) 'tensor<i32>' are incompatible with return type(s) of operation 'tensor<3xi32>'}}
-  %0 = "stablehlo.constant"() {value = dense<0> : tensor<i32>} : () -> (tensor<3xi32>)
+  %0 = "stablehlo.constant"() <{value = dense<0> : tensor<i32>}> : () -> (tensor<3xi32>)
   func.return
 }
 
@@ -2711,7 +2711,7 @@ func.func @constant_invalid() -> () {
 
 func.func @constant_invalid() -> () {
   // expected-error@+1 {{op result #0 must be statically shaped tensor}}
-  %0 = "stablehlo.constant"() {value = dense<1> : tensor<i32>} : () -> tensor<?xi32>
+  %0 = "stablehlo.constant"() <{value = dense<1> : tensor<i32>}> : () -> tensor<?xi32>
   func.return
 }
 
@@ -2719,7 +2719,7 @@ func.func @constant_invalid() -> () {
 
 func.func @constant_invalid() -> () {
   // expected-error@+1 {{elements literal type must have static shape}}
-  %0 = "stablehlo.constant"() {value = dense<1> : tensor<?xi32>} : () -> tensor<?xi32>
+  %0 = "stablehlo.constant"() <{value = dense<1> : tensor<?xi32>}> : () -> tensor<?xi32>
   func.return
 }
 
@@ -4872,7 +4872,7 @@ func.func @quantized_constants() -> (tensor<2x!quant.uniform<i8:f32, 2.0:15>>, t
   %3 = stablehlo.uniform_quantize %2 : (tensor<2xf32>) -> tensor<2x!quant.uniform<i8:f32, 2.0:15>>
   %4 = stablehlo.uniform_quantize %1 : (tensor<2xf32>) -> tensor<2x!quant.uniform<ui8:f32, 34.0:16>>
   func.return %0, %4, %3 : tensor<2x!quant.uniform<i8:f32, 2.0:15>>, tensor<2x!quant.uniform<ui8:f32, 34.0:16>>, tensor<2x!quant.uniform<i8:f32, 2.0:15>>
-  // CHECK: stablehlo.constant() {value = dense<[1, 2]> : tensor<2xi8>} : () -> tensor<2x!quant.uniform<i8:f32, 2.000000e+00:15>>
+  // CHECK: stablehlo.constant() <{value = dense<[1, 2]> : tensor<2xi8>}> : () -> tensor<2x!quant.uniform<i8:f32, 2.000000e+00:15>>
   // CHECK-NEXT: stablehlo.constant dense<[1.000000e+01, 1.200000e+01]> : tensor<2xf32>
   // CHECK-NEXT: stablehlo.constant dense<[3.000000e+00, 1.000000e+02]> : tensor<2xf32>
 }

--- a/stablehlo/tests/stablehlo_canonicalize_dynamism.mlir
+++ b/stablehlo/tests/stablehlo_canonicalize_dynamism.mlir
@@ -272,7 +272,7 @@ func.func @dynamic_conv_inapplicable_dynamic_padding(%arg0: tensor<100x26x26x32x
 // CHECK-LABEL: @dynamic_gather_success_static_result_type
 func.func @dynamic_gather_success_static_result_type(%arg0 : tensor<2x4x9xi32>, %arg1 : tensor<1x5x2xi32>) -> tensor<1x5x8xi32> {
   //  CHECK-NOT: stablehlo.dynamic_gather
-  //      CHECK: "stablehlo.gather"(%arg0, %arg1) {
+  //      CHECK: "stablehlo.gather"(%arg0, %arg1) <{
   // CHECK-SAME:   dimension_numbers = #stablehlo.gather<
   // CHECK-SAME:     offset_dims = [2],
   // CHECK-SAME:     collapsed_slice_dims = [0, 1],
@@ -280,7 +280,7 @@ func.func @dynamic_gather_success_static_result_type(%arg0 : tensor<2x4x9xi32>, 
   // CHECK-SAME:     index_vector_dim = 2
   // CHECK-SAME:   >,
   // CHECK-SAME:   slice_sizes = array<i64: 1, 1, 8>
-  // CHECK-SAME: } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
+  // CHECK-SAME: }> : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
   %0 = stablehlo.constant dense<[1, 1, 8]> : tensor<3xi32>
   %1 = "stablehlo.dynamic_gather"(%arg0, %arg1, %0) {
     dimension_numbers = #stablehlo.gather<
@@ -298,7 +298,7 @@ func.func @dynamic_gather_success_static_result_type(%arg0 : tensor<2x4x9xi32>, 
 // CHECK-LABEL: @dynamic_gather_success_dynamic_result_type
 func.func @dynamic_gather_success_dynamic_result_type(%arg0 : tensor<2x4x9xi32>, %arg1 : tensor<1x5x2xi32>) -> tensor<1x5x?xi32> {
   //  CHECK-NOT: stablehlo.dynamic_gather
-  //      CHECK: "stablehlo.gather"(%arg0, %arg1) {
+  //      CHECK: "stablehlo.gather"(%arg0, %arg1) <{
   // CHECK-SAME:   dimension_numbers = #stablehlo.gather<
   // CHECK-SAME:     offset_dims = [2],
   // CHECK-SAME:     collapsed_slice_dims = [0, 1],
@@ -306,16 +306,16 @@ func.func @dynamic_gather_success_dynamic_result_type(%arg0 : tensor<2x4x9xi32>,
   // CHECK-SAME:     index_vector_dim = 2
   // CHECK-SAME:   >,
   // CHECK-SAME:   slice_sizes = array<i64: 1, 1, 8>
-  // CHECK-SAME: } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x?xi32>
+  // CHECK-SAME: }> : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x?xi32>
   %0 = stablehlo.constant dense<[1, 1, 8]> : tensor<3xi32>
-  %1 = "stablehlo.dynamic_gather"(%arg0, %arg1, %0) {
+  %1 = "stablehlo.dynamic_gather"(%arg0, %arg1, %0) <{
     dimension_numbers = #stablehlo.gather<
       collapsed_slice_dims = [0, 1],
       index_vector_dim = 2,
       offset_dims = [2],
       start_index_map = [0, 1]
     >
-  } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>, tensor<3xi32>) -> tensor<1x5x?xi32>
+  }> : (tensor<2x4x9xi32>, tensor<1x5x2xi32>, tensor<3xi32>) -> tensor<1x5x?xi32>
   return %1 : tensor<1x5x?xi32>
 }
 
@@ -324,14 +324,14 @@ func.func @dynamic_gather_success_dynamic_result_type(%arg0 : tensor<2x4x9xi32>,
 // CHECK-LABEL: @dynamic_gather_inapplicable_dynamic_slice_sizes
 func.func @dynamic_gather_inapplicable_dynamic_slice_sizes(%arg0 : tensor<2x4x9xi32>, %arg1 : tensor<1x5x2xi32>, %arg2 : tensor<3xi32>) -> tensor<1x5x8xi32> {
   // CHECK: stablehlo.dynamic_gather
-  %0 = "stablehlo.dynamic_gather"(%arg0, %arg1, %arg2) {
+  %0 = "stablehlo.dynamic_gather"(%arg0, %arg1, %arg2) <{
     dimension_numbers = #stablehlo.gather<
       collapsed_slice_dims = [0, 1],
       index_vector_dim = 2,
       offset_dims = [2],
       start_index_map = [0, 1]
     >
-  } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>, tensor<3xi32>) -> tensor<1x5x8xi32>
+  }> : (tensor<2x4x9xi32>, tensor<1x5x2xi32>, tensor<3xi32>) -> tensor<1x5x8xi32>
   return %0 : tensor<1x5x8xi32>
 }
 


### PR DESCRIPTION
Part of #1584. Last step is to migrate CHLO.

Regarding use of adapters in `reify` functions, see the following code comment which talks about why operands (and only operands) must be passed as arguments:

```
  ::mlir::LogicalResult inferReturnTypeComponents(::mlir::MLIRContext* context, ::std::optional<::mlir::Location> location, ::mlir::ValueShapeRange operands, ::mlir::DictionaryAttr attributes, ::mlir::RegionRange regions, ::llvm::SmallVectorImpl<::mlir::ShapedTypeComponents>& inferredReturnShapes);
  /// Reify the shape computation for the operation.
  /// 
  ///       Insert operations using the given OpBuilder that computes the
  ///       result shape. This interface is supposed to be workable during dialect
  ///       conversion (e.g. convert from tensor world to buffer world),
  ///       where `getOperand` may be invalid. For example, some ops (e.g.
  ///       dynamic_reshape(input, target_shape)) may depend on their operands
  ///       to calculate the result shape. When the `matchAndRewrite ` method
  ///       of a conversion pattern is called, the operands of the op to convert
  ///       may have been converted into other types, which makes it invalid to
  ///       call the `getOperand` method of such op directly inside the
  ///       conversion pattern.  To solve this problem, this interface follows
  ///       the design of the conversion pattern, that is, accepting passed in
  ///       operands to avoid calling `getOperand` directly inside the interface
  ///       implementation.
  ::mlir::LogicalResult reifyReturnTypeShapes(::mlir::OpBuilder& builder, ::mlir::ValueRange operands, ::llvm::SmallVectorImpl<::mlir::Value> & reifiedReturnShapes);

```