### PR TITLE
Migrate CHLO to use properties

### DIFF
--- a/stablehlo/dialect/ChloOps.td
+++ b/stablehlo/dialect/ChloOps.td
@@ -53,8 +53,6 @@ def CHLO_Dialect : Dialect {
     and provide conversion patterns to fully materialize into lower level
     dialects.
   }];
-
-  let usePropertiesForAttributes = 0;
 }
 
 class CHLO_Op<string mnemonic, list<Trait> traits> :


### PR DESCRIPTION
Migrate CHLO to use properties.

1. Use adaptors when possible to avoid needing to think about attrs vs properties.
2. Avoid using `get("string")` as in `attributes.get("broadcast_dimensions")` to get property values.

Closes #1584