### PR TITLE
Implement ConditionallySpeculatable for Map, Reduce and ReduceWindow

### DIFF
--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -435,6 +435,20 @@ struct SpeculatableIfAllInputsStaticImplTrait
   }
 };
 
+template <typename ConcreteType>
+struct RecursivelySpeculatableIfAllInputsStaticImplTrait
+    : public mlir::OpTrait::TraitBase<
+          ConcreteType, RecursivelySpeculatableIfAllInputsStaticImplTrait> {
+  mlir::Speculation::Speculatability getSpeculatability() {
+    return llvm::all_of(this->getOperation()->getOperandTypes(),
+                        [](Type t) {
+                          return cast<RankedTensorType>(t).hasStaticShape();
+                        })
+               ? mlir::Speculation::RecursivelySpeculatable
+               : mlir::Speculation::NotSpeculatable;
+  }
+};
+
 }  // namespace OpTrait
 }  // namespace hlo
 }  // namespace mlir

--- a/stablehlo/dialect/Base.td
+++ b/stablehlo/dialect/Base.td
@@ -348,4 +348,14 @@ def HLO_SpeculatableIfAllInputsStaticImplTrait
 def HLO_SpeculatableIfAllInputsStatic : TraitList<[
     ConditionallySpeculatable, HLO_SpeculatableIfAllInputsStaticImplTrait]>;
 
+def HLO_RecursivelySpeculatableIfAllInputsStaticImplTrait
+  : HLO_NativeOpTrait<"RecursivelySpeculatableIfAllInputsStaticImplTrait">;
+
+// This trait is the same as HLO_SpeculatableIfAllInputsStatic, but for ops that
+// have regions. If all the inputs are static, such an op is
+// RecursivelySpeculatable (the ops in its regions have to be checked for
+// speculatability).
+def HLO_RecursivelySpeculatableIfAllInputsStatic : TraitList<[
+    ConditionallySpeculatable, HLO_RecursivelySpeculatableIfAllInputsStaticImplTrait]>;
+
 #endif // STABLEHLO_DIALECT_BASE

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1431,6 +1431,18 @@ LogicalResult MapOp::reifyReturnTypeShapes(
                                      &reifiedReturnShapes);
 }
 
+mlir::Speculation::Speculatability MapOp::getSpeculatability() {
+  // If any dimension of any operand is dynamic, it could disagree with the
+  // others at runtime, so the op is not speculatable. If all the operands are
+  // statically shaped, whether the op is speculatable or not depends on what
+  // ops are in the op's body.
+  return llvm::all_of(
+             this->getOperation()->getOperandTypes(),
+             [](Type t) { return cast<RankedTensorType>(t).hasStaticShape(); })
+             ? mlir::Speculation::RecursivelySpeculatable
+             : mlir::Speculation::NotSpeculatable;
+}
+
 //===----------------------------------------------------------------------===//
 // OutfeedOp
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1485,6 +1485,7 @@ def StableHLO_AllToAllOp : StableHLO_Op<"all_to_all",
 }
 
 def StableHLO_ReduceOp: StableHLO_ShapedInterfaceOp<"reduce", [
+      HLO_RecursivelySpeculatableIfAllInputsStatic,
       RecursiveMemoryEffects,
       SameVariadicOperandSize /*reduce_c3*/,
       InferTensorTypeWithReify /*reduce_c7, reduce_c8*/,
@@ -2529,7 +2530,8 @@ def StableHLO_GetDimensionSizeOp: StableHLO_Op<"get_dimension_size",
 }
 
 def StableHLO_MapOp: StableHLO_ShapedInterfaceOp<"map",
-      [RecursiveMemoryEffects, SameOperandsAndResultShape /*map_c1, map_c2*/,
+      [HLO_RecursivelySpeculatableIfAllInputsStatic, RecursiveMemoryEffects,
+       SameOperandsAndResultShape /*map_c1, map_c2*/,
        SingleBlockImplicitTerminator<"ReturnOp">, InferTensorTypeWithReify]> {
   let summary = "Map operation";
   let description = [{
@@ -2556,6 +2558,11 @@ def StableHLO_MapOp: StableHLO_ShapedInterfaceOp<"map",
   );
   let regions = (region SizedRegion<1>:$computation /*map_i3*/);
   let results = (outs HLO_Tensor);
+
+  let extraClassDeclaration = commonClassDeclaration # [{
+    /// Interface method for ConditionallySpeculatable.
+    mlir::Speculation::Speculatability getSpeculatability();
+  }];
 }
 
 def StableHLO_ReshapeOp: StableHLO_Op<"reshape",
@@ -2965,6 +2972,7 @@ def StableHLO_TriangularSolveOp: StableHLO_Op<"triangular_solve",
 }
 
 def StableHLO_ReduceWindowOp: StableHLO_Op<"reduce_window", [
+      HLO_RecursivelySpeculatableIfAllInputsStatic,
       RecursiveMemoryEffects,
       SameVariadicOperandSize /*reduce_window_c1*/,
       SingleBlockImplicitTerminator<"ReturnOp">,

--- a/stablehlo/tests/TestUtils.cpp
+++ b/stablehlo/tests/TestUtils.cpp
@@ -116,6 +116,17 @@ struct IsSpeculatablePattern : public RewritePattern {
   }
 };
 
+struct IsRecursivelySpeculatablePattern : public RewritePattern {
+  explicit IsRecursivelySpeculatablePattern(MLIRContext *context)
+      : RewritePattern("hlo_test_speculatability.is_recursively_speculatable",
+                       1, context) {}
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    return checkSpeculatability(rewriter, op,
+                                mlir::Speculation::RecursivelySpeculatable);
+  }
+};
+
 struct IsNotSpeculatablePattern : public RewritePattern {
   explicit IsNotSpeculatablePattern(MLIRContext *context)
       : RewritePattern("hlo_test_speculatability.is_not_speculatable", 1,
@@ -156,6 +167,7 @@ struct HloTestSpeculatabilityPass
     RewritePatternSet patterns_(context);
     patterns_.add<IsSpeculatablePattern>(context);
     patterns_.add<IsNotSpeculatablePattern>(context);
+    patterns_.add<IsRecursivelySpeculatablePattern>(context);
     patterns = std::move(patterns_);
     return success();
   }


### PR DESCRIPTION
All of these ops have `same(shape(inputs...))` as a constraint,
but they also have regions, so if all their inputs are static, the
op is recursively speculatable.

(Note that `scatter` also has this constraint, but it can have UB
in other circumstances so it will be handled in a follow-up change.)