### PR TITLE
Augment bazelrc to support asan & ubsan

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -29,12 +29,9 @@ build --repo_env=CC=clang
 
 # turn on fission https://gcc.gnu.org/wiki/DebugFission
 # this separates the debug information and can improve link times
-build --fission=yes
+build --fission=dbg
 
-build:dbg --compilation_mode=dbg
-build:opt --compilation_mode=opt
-
-build:san-common --config=dbg --strip=never --copt=-O0 --copt=-fno-omit-frame-pointer
+build:san-common --strip=never --copt=-fno-omit-frame-pointer
 
 # Some of this is from "Can I run AddressSanitizer with more aggressive diagnostics enabled?"
 # on https://github.com/google/sanitizers/wiki/AddressSanitizer#faq and some is from

--- a/.bazelrc
+++ b/.bazelrc
@@ -63,8 +63,8 @@ build:ubsan --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
 # Do not build runfile trees by default. If an execution strategy relies on runfile
 # symlink tree, the tree is created on-demand. See: https://github.com/bazelbuild/bazel/issues/6627
 # and https://github.com/bazelbuild/bazel/commit/03246077f948f2790a83520e7dccc2625650e6df
-#build --nobuild_runfile_links
-#test --nobuild_runfile_links
+build --nobuild_runfile_links
+test --nobuild_runfile_links
 
 # https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
 build --nolegacy_external_runfiles

--- a/.bazelrc
+++ b/.bazelrc
@@ -14,6 +14,11 @@
 
 build --cxxopt=-std=c++17
 build --host_cxxopt=-std=c++17
+# llvm builds typically without rtti
+# disable it to be consistent with the llvm build
+# this also helps later on when using sanitizers
+build --cxxopt=-fno-rtti
+build --host_cxxopt=-fno-rtti
 # support layering_check similar to Google internal
 # this only works for Clang toolchain AFAIK
 # https://github.com/bazelbuild/bazel/pull/11440
@@ -22,12 +27,44 @@ build --features=layering_check
 # TODO(fzakaria): Make this a toolchain or hermetic somehow
 build --repo_env=CC=clang
 
+# turn on fission https://gcc.gnu.org/wiki/DebugFission
+# this separates the debug information and can improve link times
+build --fission=yes
+
+build:dbg --compilation_mode=dbg
+build:opt --compilation_mode=opt
+
+build:san-common --config=dbg --strip=never --copt=-O0 --copt=-fno-omit-frame-pointer
+
+# Some of this is from "Can I run AddressSanitizer with more aggressive diagnostics enabled?"
+# on https://github.com/google/sanitizers/wiki/AddressSanitizer#faq and some is from
+# https://chromium.googlesource.com/external/github.com/grpc/grpc/+/4e9206f48c91e17f43856b016b12f59dd5118293/tools/bazel.rc
+build:asan --config=san-common 
+build:asan --features=asan
+build:asan --copt=-fsanitize-address-use-after-scope
+# We explicitly disable strict_init_order because LLVM is "hostile to init order"
+# even the google3 monorepo disables it
+build:asan --action_env=ASAN_OPTIONS=detect_odr_violations=2:detect_leaks=1:strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=0
+build:asan --action_env=LSAN_OPTIONS=report_objects=1
+
+build:ubsan --config=san-common 
+build:ubsan --features=ubsan
+# This is needed on account of 
+# https://github.com/bazelbuild/bazel/issues/11122#issuecomment-896613570
+# tl;dr; bazel uses clang and not clang++ to be the driver
+# that discrepenancy causes some issues with ubsan
+build:ubsan --linkopt=-fsanitize-link-c++-runtime
+build:ubsan --copt=-fsanitize-link-c++-runtime
+build:ubsan --linkopt=--driver-mode=g++
+build:ubsan --host_linkopt=-fsanitize-link-c++-runtime
+build:ubsan --action_env=UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
+
 # Disabling runfiles links drastically increases performance in slow disk IO situations
 # Do not build runfile trees by default. If an execution strategy relies on runfile
 # symlink tree, the tree is created on-demand. See: https://github.com/bazelbuild/bazel/issues/6627
 # and https://github.com/bazelbuild/bazel/commit/03246077f948f2790a83520e7dccc2625650e6df
-build --nobuild_runfile_links
-test --nobuild_runfile_links
+#build --nobuild_runfile_links
+#test --nobuild_runfile_links
 
 # https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
 build --nolegacy_external_runfiles

--- a/.bazelrc
+++ b/.bazelrc
@@ -48,7 +48,7 @@ build:asan --copt=-fsanitize-address-use-after-scope
 build:asan --cc_output_directory_tag=asan
 # asan tests tend to take longer, so increase the timeouts
 # defaults are: 60,300,900,3600
-test:asan --test_timeout=120,600,1800,-1
+test:asan --test_timeout=300,600,1800,-1
 
 build:ubsan --config=san-common
 build:ubsan --features=ubsan

--- a/.bazelrc
+++ b/.bazelrc
@@ -32,6 +32,9 @@ build --repo_env=CC=clang
 build --fission=dbg
 
 build:san-common --strip=never --copt=-fno-omit-frame-pointer
+# asan tests tend to take longer, so increase the timeouts
+# defaults are: 60,300,900,3600
+build:san-common --test_timeout=120,600,1800,-1
 
 # Some of this is from "Can I run AddressSanitizer with more aggressive diagnostics enabled?"
 # on https://github.com/google/sanitizers/wiki/AddressSanitizer#faq and some is from

--- a/.bazelrc
+++ b/.bazelrc
@@ -39,7 +39,7 @@ build:san-common --config=dbg --strip=never --copt=-O0 --copt=-fno-omit-frame-po
 # Some of this is from "Can I run AddressSanitizer with more aggressive diagnostics enabled?"
 # on https://github.com/google/sanitizers/wiki/AddressSanitizer#faq and some is from
 # https://chromium.googlesource.com/external/github.com/grpc/grpc/+/4e9206f48c91e17f43856b016b12f59dd5118293/tools/bazel.rc
-build:asan --config=san-common 
+build:asan --config=san-common
 build:asan --features=asan
 build:asan --copt=-fsanitize-address-use-after-scope
 # We explicitly disable strict_init_order because LLVM is "hostile to init order"
@@ -47,9 +47,9 @@ build:asan --copt=-fsanitize-address-use-after-scope
 build:asan --action_env=ASAN_OPTIONS=detect_odr_violations=2:detect_leaks=1:strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=0
 build:asan --action_env=LSAN_OPTIONS=report_objects=1
 
-build:ubsan --config=san-common 
+build:ubsan --config=san-common
 build:ubsan --features=ubsan
-# This is needed on account of 
+# This is needed on account of
 # https://github.com/bazelbuild/bazel/issues/11122#issuecomment-896613570
 # tl;dr; bazel uses clang and not clang++ to be the driver
 # that discrepenancy causes some issues with ubsan

--- a/.bazelrc
+++ b/.bazelrc
@@ -32,9 +32,6 @@ build --repo_env=CC=clang
 build --fission=dbg
 
 build:san-common --strip=never --copt=-fno-omit-frame-pointer
-# asan tests tend to take longer, so increase the timeouts
-# defaults are: 60,300,900,3600
-build:san-common --test_timeout=120,600,1800,-1
 
 # Some of this is from "Can I run AddressSanitizer with more aggressive diagnostics enabled?"
 # on https://github.com/google/sanitizers/wiki/AddressSanitizer#faq and some is from
@@ -44,8 +41,14 @@ build:asan --features=asan
 build:asan --copt=-fsanitize-address-use-after-scope
 # We explicitly disable strict_init_order because LLVM is "hostile to init order"
 # even the google3 monorepo disables it
-build:asan --action_env=ASAN_OPTIONS=detect_odr_violations=2:detect_leaks=1:strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=0
-build:asan --action_env=LSAN_OPTIONS=report_objects=1
+# TODO(fzakaria): disabling due to costs of test execution
+# I don't think internally to Google we use these options
+# build:asan --action_env=ASAN_OPTIONS=detect_odr_violations=2:detect_leaks=1:strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=0
+# build:asan --action_env=LSAN_OPTIONS=report_objects=1
+build:asan --cc_output_directory_tag=asan
+# asan tests tend to take longer, so increase the timeouts
+# defaults are: 60,300,900,3600
+test:asan --test_timeout=120,600,1800,-1
 
 build:ubsan --config=san-common
 build:ubsan --features=ubsan

--- a/build_tools/github_actions/ci_build_bazel.sh
+++ b/build_tools/github_actions/ci_build_bazel.sh
@@ -22,5 +22,5 @@ if [[ $# -ne 0 ]] ; then
 fi
 
 # Build and Test StableHLO
-bazel build --lockfile_mode=error //...
-bazel test //...
+bazel build --lockfile_mode=error //... --config=asan --config=ubsan
+bazel test //... --config=asan --config=ubsan


### PR DESCRIPTION
A prior failure in the google3 internal codebase showed that we were not executing the sanitizers like we thought we were.

This change augments bazelrc to do asan and ubsan via config. It leverages the default feature set offered by bazelrc.

I tested the commit priot to 474caa8370dccc753e4693a2ff4221864b227597 to validate that the bug was exhibited.

I've added the sanitizers to the default Bazel build which also builds debug builds.
This may come at an increase cost. If undesirable we can split the job out.