### PR TITLE
ReverseOp : remove HLO_CompatibleOperandsAndResultType trait

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1743,14 +1743,13 @@ LogicalResult ReverseOp::verify() {
   return hlo::verifyReverseOp(getLoc(), getOperand(), getDimensions());
 }
 
-LogicalResult ReverseOp::inferReturnTypeComponents(
-    MLIRContext* context, std::optional<Location> location,
-    ValueShapeRange operands, DictionaryAttr attributes,
-    OpaqueProperties properties, RegionRange regions,
-    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
+LogicalResult ReverseOp::inferReturnTypes(
+    MLIRContext* /*context*/, std::optional<Location> location,
+    ValueRange operands, DictionaryAttr attributes, OpaqueProperties properties,
+    RegionRange regions, SmallVectorImpl<Type>& inferredReturnTypes) {
   ReverseOp::Adaptor adaptor(operands, attributes, properties, regions);
   return hlo::inferReverseOp(location, adaptor.getOperand().getType(),
-                             inferredReturnShapes);
+                             inferredReturnTypes);
 }
 
 LogicalResult ReverseOp::reifyReturnTypeShapes(

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2810,8 +2810,8 @@ def StableHLO_SortOp : StableHLO_Op<"sort",
 
 def StableHLO_ReverseOp: StableHLO_ShapedInterfaceOp<"reverse",
       [HLO_SpeculatableIfStaticDimInOutputIsStaticInInput, NoMemoryEffect,
-       HLO_CompatibleOperandsAndResultType,
-       SameOperandsAndResultElementType /*reverse_c1*/]> {
+       SameOperandsAndResultElementType /*reverse_c1*/,
+       DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
   let summary = "Reverse operation";
   let description = [{
     Reverses the order of elements in the `operand` along the specified

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2753,11 +2753,11 @@ LogicalResult inferReplicaIdOp(MLIRContext* context, std::optional<Location>,
   return success();
 }
 
-LogicalResult inferReverseOp(
-    std::optional<Location> location, Type operandType,
-    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes) {
-  return hlo::inferMostSpecificTypeComponents(location, operandType,
-                                              inferredReturnShapes);
+LogicalResult inferReverseOp(std::optional<Location> location,
+                             Type operandType,
+                             SmallVectorImpl<Type>& inferredReturnTypes) {
+  inferredReturnTypes.push_back(operandType);
+  return success();
 }
 
 LogicalResult inferRngOp(

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -2753,8 +2753,7 @@ LogicalResult inferReplicaIdOp(MLIRContext* context, std::optional<Location>,
   return success();
 }
 
-LogicalResult inferReverseOp(std::optional<Location> location,
-                             Type operandType,
+LogicalResult inferReverseOp(std::optional<Location> location, Type operandType,
                              SmallVectorImpl<Type>& inferredReturnTypes) {
   inferredReturnTypes.push_back(operandType);
   return success();

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -308,8 +308,7 @@ LogicalResult inferReduceWindowOp(
 LogicalResult inferReplicaIdOp(MLIRContext* context, std::optional<Location>,
                                SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferReverseOp(std::optional<Location> location,
-                             Type operandType,
+LogicalResult inferReverseOp(std::optional<Location> location, Type operandType,
                              SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferRngOp(

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -308,9 +308,9 @@ LogicalResult inferReduceWindowOp(
 LogicalResult inferReplicaIdOp(MLIRContext* context, std::optional<Location>,
                                SmallVectorImpl<Type>& inferredReturnTypes);
 
-LogicalResult inferReverseOp(
-    std::optional<Location> location, Type operandType,
-    SmallVectorImpl<ShapedTypeComponents>& inferredReturnShapes);
+LogicalResult inferReverseOp(std::optional<Location> location,
+                             Type operandType,
+                             SmallVectorImpl<Type>& inferredReturnTypes);
 
 LogicalResult inferRngOp(
     std::optional<Location> location, Value a, Value b, Value shape,


### PR DESCRIPTION
for `reverse`, `HLO_CompatibleOperandsAndResultType` trait is no longer required. `SameOperandsAndResultElementType` is covering (C3) type(result) = type(operand) constraints. Previously `HLO_CompatibleOperandsAndResultType` trait was defining type and shape inference functions. This PR removes `HLO_CompatibleOperandsAndResultType` for the OP and copied-out required type inference function.

`reverse` op is a `StableHLO_ShapedInterfaceOp` so shape inference already handled.

Tested:
existing shape and type inference tests passed

fixes https://github.com/openxla/stablehlo/issues/2145

