### PR TITLE
Remove extra quotes in getMaxVersion template

### DIFF
--- a/stablehlo/dialect/VhloOps.td
+++ b/stablehlo/dialect/VhloOps.td
@@ -57,7 +57,7 @@ class VHLO_Op<string mnemonic, string minVersion, string maxVersion, list<Trait>
       }] # !if(
         !eq(maxVersion, "current"),
         [{ return mlir::vhlo::Version::getCurrentVersion(); }],
-        [{ return mlir::vhlo::Version("}] # !subst(".", ", ", maxVersion) # [{"); }]
+        [{ return mlir::vhlo::Version(}] # !subst(".", ", ", maxVersion) # [{); }]
       ) # [{
     }
   }];


### PR DESCRIPTION
We haven't needed to use this yet, but without this change it would create invalid code like `return mlir::vhlo::Version("0, 10, 0");`.