### PR TITLE
Add prettier printing for constant operations

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -254,6 +254,16 @@ LogicalResult CompositeOp::verifySymbolUses(
 // ConstantOp
 //===----------------------------------------------------------------------===//
 
+void ConstantOp::getAsmResultNames(
+    function_ref<void(Value, StringRef)> setNameFn) {
+  mlir::TensorType type = getType();
+  if (type.getElementType().isa<IntegerType>()) {
+    setNameFn(getResult(), "c");
+  } else {
+    setNameFn(getResult(), "cst");
+  }
+}
+
 OpFoldResult ConstantOp::fold(FoldAdaptor adaptor) {
   assert(adaptor.getOperands().empty() && "constant has no operands");
 

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -66,7 +66,8 @@ class StableHLO_ShapedInterfaceOp<string mnemonic, list<Trait> traits> :
 //===----------------------------------------------------------------------===//
 
 def StableHLO_ConstantOp : StableHLO_Op<"constant",
-    [ConstantLike, Pure, DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+    [ConstantLike, Pure, DeclareOpInterfaceMethods<InferTypeOpInterface>,
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
   let summary = "Constant operation";
   let description = [{
     Produces an `output` tensor from a constant `value`.

--- a/stablehlo/tests/shape_legalize_to_stablehlo.mlir
+++ b/stablehlo/tests/shape_legalize_to_stablehlo.mlir
@@ -14,11 +14,11 @@ func.func @compute_reshape_shape(%arg0: index, %arg1: tensor<2xi32>) -> tensor<2
   // CHECK-NEXT: %[[INPUT_SIZE_PRODUCT:.*]] = stablehlo.multiply %[[TMP1]], %[[INPUT_SIZE1]] : tensor<i32>
   // CHECK-NEXT: %[[COMPUTED_SIZE:.*]] = stablehlo.divide %[[ARG0_I32]], %[[INPUT_SIZE_PRODUCT]] : tensor<i32>
   // CHECK-NEXT: %[[M1:.*]] = stablehlo.constant dense<-1> : tensor<i32>
-  // CHECK-NEXT: %[[INPUT_SIZE0_EQ_M1:.*]] = stablehlo.compare  EQ, %3, %[[M1]],  NOTYPE : (tensor<i32>, tensor<i32>) -> tensor<i1>
-  // CHECK-NEXT: %[[RESULT_SIZE0:.*]] = stablehlo.select %[[INPUT_SIZE0_EQ_M1]], %[[COMPUTED_SIZE]], %3 : tensor<i1>, tensor<i32>
+  // CHECK-NEXT: %[[INPUT_SIZE0_EQ_M1:.*]] = stablehlo.compare  EQ, %[[INPUT_SIZE0]], %[[M1]],  NOTYPE : (tensor<i32>, tensor<i32>) -> tensor<i1>
+  // CHECK-NEXT: %[[RESULT_SIZE0:.*]] = stablehlo.select %[[INPUT_SIZE0_EQ_M1]], %[[COMPUTED_SIZE]], %[[INPUT_SIZE0]] : tensor<i1>, tensor<i32>
   // CHECK-NEXT: %[[RESULT_SIZE0x1:.*]] = stablehlo.reshape %[[RESULT_SIZE0]] : (tensor<i32>) -> tensor<1xi32>
-  // CHECK-NEXT: %[[INPUT_SIZE1_EQ_M1:.*]] = stablehlo.compare  EQ, %6, %[[M1]],  NOTYPE : (tensor<i32>, tensor<i32>) -> tensor<i1>
-  // CHECK-NEXT: %[[RESULT_SIZE1:.*]] = stablehlo.select %[[INPUT_SIZE1_EQ_M1]], %[[COMPUTED_SIZE]], %6 : tensor<i1>, tensor<i32>
+  // CHECK-NEXT: %[[INPUT_SIZE1_EQ_M1:.*]] = stablehlo.compare  EQ, %[[INPUT_SIZE1]], %[[M1]],  NOTYPE : (tensor<i32>, tensor<i32>) -> tensor<i1>
+  // CHECK-NEXT: %[[RESULT_SIZE1:.*]] = stablehlo.select %[[INPUT_SIZE1_EQ_M1]], %[[COMPUTED_SIZE]], %[[INPUT_SIZE1]] : tensor<i1>, tensor<i32>
   // CHECK-NEXT: %[[RESULT_SIZE1x1:.*]] = stablehlo.reshape %[[RESULT_SIZE1]] : (tensor<i32>) -> tensor<1xi32>
   // CHECK-NEXT: %[[RESULT:.*]] = stablehlo.concatenate %[[RESULT_SIZE0x1]], %[[RESULT_SIZE1x1]], dim = 0 : (tensor<1xi32>, tensor<1xi32>) -> tensor<2xi32>
   // CHECK-NEXT: return %[[RESULT]] : tensor<2xi32>

--- a/stablehlo/tests/stablehlo_canonicalize_dynamism.mlir
+++ b/stablehlo/tests/stablehlo_canonicalize_dynamism.mlir
@@ -147,7 +147,7 @@ func.func @custom_call_inapplicable_missing_indices_of_shape_operands(%arg0: ten
 
 // CHECK-LABEL: func @custom_call_inapplicable_dynamic_result_type
 func.func @custom_call_inapplicable_dynamic_result_type(%arg0: tensor<4xf32>) -> tensor<1x?xf32> {
-  // CHECK: stablehlo.custom_call @foo(%arg0, %0)
+  // CHECK: stablehlo.custom_call @foo(%arg0, %c)
   %0 = stablehlo.constant dense<[1, 2]> : tensor<2xi64>
   %1 = stablehlo.custom_call @foo(%arg0, %0) {
     indices_of_shape_operands = dense<[1]> : tensor<1xi64>

--- a/stablehlo/tests/stablehlo_canonicalize_dynamism.mlir
+++ b/stablehlo/tests/stablehlo_canonicalize_dynamism.mlir
@@ -137,7 +137,7 @@ func.func @custom_call_inapplicable_dynamic_shape_operand(%arg0: tensor<4xf32>, 
 
 // CHECK-LABEL: func @custom_call_inapplicable_missing_indices_of_shape_operands
 func.func @custom_call_inapplicable_missing_indices_of_shape_operands(%arg0: tensor<4xf32>) -> tensor<1x2xf32> {
-  // CHECK: stablehlo.custom_call @foo(%arg0, %0)
+  // CHECK: stablehlo.custom_call @foo(%arg0, %c)
   %0 = stablehlo.constant dense<[1, 2]> : tensor<2xi64>
   %1 = stablehlo.custom_call @foo(%arg0, %0) : (tensor<4xf32>, tensor<2xi64>) -> tensor<1x2xf32>
   return %1 : tensor<1x2xf32>


### PR DESCRIPTION
 To make it easier to debug differences is non-constant operations, even if constants are different