### PR TITLE
Migrate StableHLO to use properties

### DIFF
--- a/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
@@ -826,8 +826,10 @@ struct TransposeOpToTransposeConverter final
     Value emptyTensor =
         getEmptyTensorFor(rewriter, loc, resultTy, op, adaptor.getOperands());
 
+    // TODO(#2216) Cleanup Attribute -> DenseArrayAttr
     rewriter.replaceOpWithNewOp<linalg::TransposeOp>(
-        op, adaptor.getOperand(), emptyTensor, op.getPermutationAttr(),
+        op, adaptor.getOperand(), emptyTensor,
+        op.getPermutationAttr().dyn_cast_or_null<DenseI64ArrayAttr>(),
         linalg::getPrunedAttributeList(op));
     return success();
   }

--- a/stablehlo/dialect/AssemblyFormat.h
+++ b/stablehlo/dialect/AssemblyFormat.h
@@ -221,10 +221,8 @@ ParseResult parseWhileOp(OpAsmParser& parser, OperationState& result);
 
 // TODO(#2216) Cleanup Attribute -> DenseArrayAttr for print/parse.
 // SliceRanges - Used to print multi-dimensional ranges for slice.
-void printSliceRanges(OpAsmPrinter& p, Operation* op,
-                      Attribute startIndices,
-                      Attribute limitIndices,
-                      Attribute strides);
+void printSliceRanges(OpAsmPrinter& p, Operation* op, Attribute startIndices,
+                      Attribute limitIndices, Attribute strides);
 
 ParseResult parseSliceRanges(OpAsmParser& parser, Attribute& startIndices,
                              Attribute& limitIndices, Attribute& strides);

--- a/stablehlo/dialect/AssemblyFormat.h
+++ b/stablehlo/dialect/AssemblyFormat.h
@@ -219,16 +219,25 @@ ParseResult parseWhileOp(OpAsmParser& parser, OperationState& result);
 // Attribute Printers and Parsers
 //===----------------------------------------------------------------------===//
 
+// TODO(#2216) Cleanup Attribute -> DenseArrayAttr for print/parse.
 // SliceRanges - Used to print multi-dimensional ranges for slice.
 void printSliceRanges(OpAsmPrinter& p, Operation* op,
-                      ArrayRef<int64_t> startIndices,
-                      ArrayRef<int64_t> limitIndices,
-                      ArrayRef<int64_t> strides);
+                      Attribute startIndices,
+                      Attribute limitIndices,
+                      Attribute strides);
 
-ParseResult parseSliceRanges(OpAsmParser& parser,
-                             DenseI64ArrayAttr& startIndices,
-                             DenseI64ArrayAttr& limitIndices,
-                             DenseI64ArrayAttr& strides);
+ParseResult parseSliceRanges(OpAsmParser& parser, Attribute& startIndices,
+                             Attribute& limitIndices, Attribute& strides);
+
+// GenericI64DenseArray - Used to print an attr that can be either
+//
+//   Dense elements:
+//     { dense<[1, 2]> : tensor<2xi64> }
+//   Array:
+//     { array<i64: 1, 2> }
+void printDenseI64Array(OpAsmPrinter& p, Operation* op, Attribute attr);
+
+ParseResult parseDenseI64Array(OpAsmParser& parser, Attribute& attr);
 
 // DimSizes - Print an array of ints. Dynamic dimensions printed as `?`.
 //

--- a/stablehlo/dialect/StablehloAttrs.td
+++ b/stablehlo/dialect/StablehloAttrs.td
@@ -25,6 +25,24 @@ def StableHLO_Dims : ArrayRefParameter<"int64_t", "Dimension"> {
   let printer = "printDimSizes($_printer, $_self)";
 }
 
+def GenericDenseI64ArrayAttr : Attr<DenseI64ArrayAttr.predicate, "DenseI64ArrayAttr with generic Attribute storage"> {
+  let storageType = "Attribute";
+  let valueType = DenseI64ArrayAttr.valueType;
+  let returnType = "::llvm::ArrayRef<int64_t>";
+  let baseAttr = DenseI64ArrayAttr;
+  let convertFromStorage = "$_self.cast<DenseI64ArrayAttr>().asArrayRef()";
+  let constBuilderCall = "$_builder.getDenseI64ArrayAttr($0)";
+}
+
+def GenericDenseBoolArrayAttr : Attr<DenseBoolArrayAttr.predicate, "DenseBoolArrayAttr with generic Attribute storage"> {
+  let storageType = "Attribute";
+  let valueType = DenseBoolArrayAttr.valueType;
+  let returnType = "::llvm::ArrayRef<bool>";
+  let convertFromStorage = "$_self.cast<DenseBoolArrayAttr>().asArrayRef()";
+  let constBuilderCall = "$_builder.getDenseBoolArrayAttr($0)";
+}
+
+
 def StableHLO_ScatterDimensionNumbers : AttrDef<StableHLO_Dialect, "ScatterDimensionNumbers"> {
   let mnemonic = "scatter";
   let summary = "Attribute that models the dimension information for scatter";
@@ -182,15 +200,15 @@ def StableHLO_ConvDimensionNumbers : AttrDef<StableHLO_Dialect, "ConvDimensionNu
 def StableHLO_ConvolutionAttributes {
   dag attributes = (ins
     // Default value: one for each of the spatial dimension.
-    OptionalAttr<DenseI64ArrayAttr>:$window_strides,
+    OptionalAttr<GenericDenseI64ArrayAttr>:$window_strides,
     // Default value: two zeros for each of the spatial dimension.
     OptionalAttr<I64ElementsAttr>:$padding,
     // Default value: one for each of the spatial dimension.
-    OptionalAttr<DenseI64ArrayAttr>:$lhs_dilation,
+    OptionalAttr<GenericDenseI64ArrayAttr>:$lhs_dilation,
     // Default value: one for each of the spatial dimension.
-    OptionalAttr<DenseI64ArrayAttr>:$rhs_dilation,
+    OptionalAttr<GenericDenseI64ArrayAttr>:$rhs_dilation,
     // Default value: false for each of the spatial dimension.
-    OptionalAttr<DenseBoolArrayAttr>:$window_reversal,
+    OptionalAttr<GenericDenseBoolArrayAttr>:$window_reversal,
     StableHLO_ConvDimensionNumbers:$dimension_numbers,
     I64Attr:$feature_group_count,
     I64Attr:$batch_group_count,

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2346,6 +2346,7 @@ LogicalResult UniformDequantizeOp::inferReturnTypeComponents(
 
 using mlir::hlo::parseComplexOpType;
 using mlir::hlo::parseCustomCallTarget;
+using mlir::hlo::parseDenseI64Array;
 using mlir::hlo::parseDotDimensionNumbers;
 using mlir::hlo::parseExponentMantissa;
 using mlir::hlo::parsePairwiseOpType;
@@ -2357,6 +2358,7 @@ using mlir::hlo::parseVariadicOperandWithAttribute;
 using mlir::hlo::parseVariadicSameOperandsAndResultType;
 using mlir::hlo::printComplexOpType;
 using mlir::hlo::printCustomCallTarget;
+using mlir::hlo::printDenseI64Array;
 using mlir::hlo::printDotDimensionNumbers;
 using mlir::hlo::printExponentMantissa;
 using mlir::hlo::printPairwiseOpType;
@@ -3028,11 +3030,11 @@ void printWindowPadding(OpAsmPrinter& p, DenseElementsAttr padding) {
 }  // namespace
 
 void printWindowAttributes(OpAsmPrinter& p, Operation* /*op*/,
-                           std::optional<DenseI64ArrayAttr> windowStrides,
+                           std::optional<Attribute> windowStrides,
                            std::optional<DenseIntElementsAttr> padding,
-                           std::optional<DenseI64ArrayAttr> lhsDilation,
-                           std::optional<DenseI64ArrayAttr> rhsDilation,
-                           std::optional<DenseBoolArrayAttr> windowReversal) {
+                           std::optional<Attribute> lhsDilation,
+                           std::optional<Attribute> rhsDilation,
+                           std::optional<Attribute> windowReversal) {
   using pair_t = std::pair<Attribute, StringRef>;
   std::array<pair_t, 5> printedAttributes = {{
       {windowStrides ? *windowStrides : nullptr, "stride"},
@@ -3065,11 +3067,11 @@ void printWindowAttributes(OpAsmPrinter& p, Operation* /*op*/,
 }
 
 ParseResult parseWindowAttributes(OpAsmParser& parser,
-                                  DenseI64ArrayAttr& windowStrides,
+                                  Attribute& windowStrides,
                                   DenseIntElementsAttr& padding,
-                                  DenseI64ArrayAttr& lhsDilation,
-                                  DenseI64ArrayAttr& rhsDilation,
-                                  DenseBoolArrayAttr& windowReversal) {
+                                  Attribute& lhsDilation,
+                                  Attribute& rhsDilation,
+                                  Attribute& windowReversal) {
   StringRef attributeName;
 
   llvm::StringSet<> allowedAttributeNames{

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -3066,8 +3066,7 @@ void printWindowAttributes(OpAsmPrinter& p, Operation* /*op*/,
   });
 }
 
-ParseResult parseWindowAttributes(OpAsmParser& parser,
-                                  Attribute& windowStrides,
+ParseResult parseWindowAttributes(OpAsmParser& parser, Attribute& windowStrides,
                                   DenseIntElementsAttr& padding,
                                   Attribute& lhsDilation,
                                   Attribute& rhsDilation,

--- a/stablehlo/dialect/StablehloOps.h
+++ b/stablehlo/dialect/StablehloOps.h
@@ -129,8 +129,7 @@ void printWindowAttributes(OpAsmPrinter &p, Operation *op,
                            std::optional<Attribute> rhsDilation,
                            std::optional<Attribute> windowReversal);
 
-ParseResult parseWindowAttributes(OpAsmParser &parser,
-                                  Attribute &windowStrides,
+ParseResult parseWindowAttributes(OpAsmParser &parser, Attribute &windowStrides,
                                   DenseIntElementsAttr &padding,
                                   Attribute &lhsDilation,
                                   Attribute &rhsDilation,

--- a/stablehlo/dialect/StablehloOps.h
+++ b/stablehlo/dialect/StablehloOps.h
@@ -120,20 +120,21 @@ void printConvolutionDimensions(AsmPrinter &p, Operation *,
 ParseResult parseConvolutionDimensions(AsmParser &parser,
                                        ConvDimensionNumbersAttr &dimNums);
 
+// TODO(#2216) Cleanup Attribute -> DenseArrayAttr for print/parse.
 // Custom formatting for convolution window attributes.
 void printWindowAttributes(OpAsmPrinter &p, Operation *op,
-                           std::optional<DenseI64ArrayAttr> windowStrides,
+                           std::optional<Attribute> windowStrides,
                            std::optional<DenseIntElementsAttr> padding,
-                           std::optional<DenseI64ArrayAttr> lhsDilation,
-                           std::optional<DenseI64ArrayAttr> rhsDilation,
-                           std::optional<DenseBoolArrayAttr> windowReversal);
+                           std::optional<Attribute> lhsDilation,
+                           std::optional<Attribute> rhsDilation,
+                           std::optional<Attribute> windowReversal);
 
 ParseResult parseWindowAttributes(OpAsmParser &parser,
-                                  DenseI64ArrayAttr &windowStrides,
+                                  Attribute &windowStrides,
                                   DenseIntElementsAttr &padding,
-                                  DenseI64ArrayAttr &lhsDilation,
-                                  DenseI64ArrayAttr &rhsDilation,
-                                  DenseBoolArrayAttr &windowReversal);
+                                  Attribute &lhsDilation,
+                                  Attribute &rhsDilation,
+                                  Attribute &windowReversal);
 
 }  // end namespace stablehlo
 }  // end namespace mlir

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -38,7 +38,6 @@ def StableHLO_Dialect : Dialect {
 
   let useDefaultAttributePrinterParser = 0;
   let useDefaultTypePrinterParser = 0;
-  let usePropertiesForAttributes = 0;
 }
 
 class StableHLO_Op<string mnemonic, list<Trait> traits = []> :
@@ -1515,7 +1514,7 @@ def StableHLO_ReduceOp: StableHLO_ShapedInterfaceOp<"reduce", [
   let arguments = (ins
     Variadic<HLO_Tensor>:$inputs, /*reduce_i1*/
     Variadic<HLO_Tensor>:$init_values, /*reduce_i2*/
-    DenseI64ArrayAttr:$dimensions /*reduce_i3*/
+    GenericDenseI64ArrayAttr:$dimensions /*reduce_i3*/
   );
   let regions = (region SizedRegion<1>:$body /*reduce_i4*/);
 
@@ -1665,9 +1664,9 @@ def StableHLO_SliceOp: StableHLO_Op<
 
   let arguments = (ins
     HLO_Tensor:$operand,
-    DenseI64ArrayAttr:$start_indices,
-    DenseI64ArrayAttr:$limit_indices,
-    DenseI64ArrayAttr:$strides
+    GenericDenseI64ArrayAttr:$start_indices,
+    GenericDenseI64ArrayAttr:$limit_indices,
+    GenericDenseI64ArrayAttr:$strides
   );
 
   let assemblyFormat = [{
@@ -1698,14 +1697,14 @@ def StableHLO_DynamicSliceOp: StableHLO_Op<"dynamic_slice",
   let arguments = (ins
     HLO_Tensor:$operand /*dynamic_slice_i1*/,
     Variadic<HLO_ScalarIntTensor>:$start_indices /*dynamic_slice_i2*/,
-    DenseI64ArrayAttr:$slice_sizes /*dynamic_slice_i3*/
+    GenericDenseI64ArrayAttr:$slice_sizes /*dynamic_slice_i3*/
   );
 
   let results = (outs HLO_Tensor:$result);
 
   let assemblyFormat = [{
     $operand `,` custom<VariadicOperandWithAttribute>($start_indices)
-      `sizes` `=` $slice_sizes
+      `sizes` `=` custom<DenseI64Array>($slice_sizes)
       attr-dict `:` functional-type(operands, results)
   }];
 }
@@ -1900,13 +1899,13 @@ def StableHLO_BroadcastOp : StableHLO_ShapedInterfaceOp<"broadcast",
   }];
   let arguments = (ins
     HLO_Tensor:$operand,
-    DenseI64ArrayAttr:$broadcast_sizes
+    GenericDenseI64ArrayAttr:$broadcast_sizes
   );
 
   let results = (outs HLO_TensorOrPerAxisQuantizedTensor);
 
   let assemblyFormat = [{
-    $operand `,` `sizes` `=` $broadcast_sizes
+    $operand `,` `sizes` `=` custom<DenseI64Array>($broadcast_sizes)
       attr-dict `:` functional-type(operands, results)
   }];
 }
@@ -1928,7 +1927,7 @@ def StableHLO_BroadcastInDimOp : StableHLO_Op<"broadcast_in_dim",
   }];
   let arguments = (ins
     HLO_TensorOrPerAxisQuantizedTensor:$operand /*broadcast_in_dim_i1*/,
-    DenseI64ArrayAttr:$broadcast_dimensions /*broadcast_in_dim_i2*/
+    GenericDenseI64ArrayAttr:$broadcast_dimensions /*broadcast_in_dim_i2*/
   );
 
   let results = (outs HLO_StaticShapeTensorOrPerAxisQuantizedTensor);
@@ -1936,7 +1935,7 @@ def StableHLO_BroadcastInDimOp : StableHLO_Op<"broadcast_in_dim",
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    $operand `,` `dims` `=` $broadcast_dimensions
+    $operand `,` `dims` `=` custom<DenseI64Array>($broadcast_dimensions)
       attr-dict `:` functional-type(operands, results)
   }];
 }
@@ -1961,9 +1960,9 @@ def StableHLO_DynamicBroadcastInDimOp : StableHLO_ShapedInterfaceOp<
   let arguments = (ins
     HLO_TensorOrPerAxisQuantizedTensor:$operand,
     HLO_StaticDimensionTensor:$output_dimensions,
-    DenseI64ArrayAttr:$broadcast_dimensions,
-    OptionalAttr<DenseI64ArrayAttr>:$known_expanding_dimensions,
-    OptionalAttr<DenseI64ArrayAttr>:$known_nonexpanding_dimensions
+    GenericDenseI64ArrayAttr:$broadcast_dimensions,
+    OptionalAttr<GenericDenseI64ArrayAttr>:$known_expanding_dimensions,
+    OptionalAttr<GenericDenseI64ArrayAttr>:$known_nonexpanding_dimensions
   );
 
   let results = (outs HLO_TensorOrPerAxisQuantizedTensor);
@@ -1981,7 +1980,7 @@ def StableHLO_DynamicBroadcastInDimOp : StableHLO_ShapedInterfaceOp<
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    $operand `,` $output_dimensions `,` `dims` `=` $broadcast_dimensions
+    $operand `,` $output_dimensions `,` `dims` `=` custom<DenseI64Array>($broadcast_dimensions)
       attr-dict `:` functional-type(operands, results)
   }];
 }
@@ -2239,8 +2238,8 @@ def StableHLO_ConvolutionOp : StableHLO_Op<"convolution", [Pure]> {
 
   let extraClassDeclaration = [{
     bool hasWindowReversal() {
-      auto reversal = getWindowReversalAttr();
-      return reversal && llvm::any_of(reversal.asArrayRef(), [](bool v) { return v; });
+      auto reversal = getWindowReversal();
+      return reversal.has_value() && llvm::any_of(reversal.value(), [](bool v) { return v; });
     }
   }];
 
@@ -2472,13 +2471,13 @@ def StableHLO_FftOp: StableHLO_Op<"fft", [InferTensorType, Pure]> {
   let arguments = (ins
     HLO_FpOrComplexTensor:$operand,
     StableHLO_FftTypeAttr:$fft_type,
-    DenseI64ArrayAttr:$fft_length
+    GenericDenseI64ArrayAttr:$fft_length
   );
 
   let results = (outs HLO_FpOrComplexTensor);
 
   let assemblyFormat = [{
-    $operand `,` `type` `=` $fft_type `,` `length` `=` $fft_length
+    $operand `,` `type` `=` $fft_type `,` `length` `=` custom<DenseI64Array>($fft_length)
       attr-dict `:` functional-type(operands, results)
   }];
 }
@@ -2513,7 +2512,7 @@ def StableHLO_GatherOp: StableHLO_Op<"gather",
     HLO_Tensor:$operand /*gather_i1*/,
     HLO_IntTensor:$start_indices /*gather_i2*/,
     StableHLO_GatherDimensionNumbers:$dimension_numbers /*gather_i3, gather_i4, gather_i5, gather_i6*/,
-    DenseI64ArrayAttr:$slice_sizes /*gather_i7*/,
+    GenericDenseI64ArrayAttr:$slice_sizes /*gather_i7*/,
     DefaultValuedOptionalAttr<BoolAttr, "false">:$indices_are_sorted /*gather_i8*/
   );
 
@@ -2578,7 +2577,7 @@ def StableHLO_MapOp: StableHLO_ShapedInterfaceOp<"map",
   }];
   let arguments = (ins
     Variadic<HLO_Tensor>:$inputs /*map_i1*/,
-    DenseI64ArrayAttr:$dimensions /*map_i2*/
+    GenericDenseI64ArrayAttr:$dimensions /*map_i2*/
   );
   let regions = (region SizedRegion<1>:$computation /*map_i3*/);
   let results = (outs HLO_Tensor);
@@ -2758,8 +2757,8 @@ def StableHLO_SelectAndScatterOp: StableHLO_Op<"select_and_scatter",
     HLO_Tensor:$operand, /*select_and_scatter_i1*/
     HLO_Tensor:$source, /*select_and_scatter_i2*/
     HLO_Tensor:$init_value, /*select_and_scatter_i3*/
-    OptionalAttr<DenseI64ArrayAttr>:$window_dimensions, /*select_and_scatter_i4*/
-    OptionalAttr<DenseI64ArrayAttr>:$window_strides, /*select_and_scatter_i5*/
+    OptionalAttr<GenericDenseI64ArrayAttr>:$window_dimensions, /*select_and_scatter_i4*/
+    OptionalAttr<GenericDenseI64ArrayAttr>:$window_strides, /*select_and_scatter_i5*/
     OptionalAttr<I64ElementsAttr>:$padding /*select_and_scatter_i6*/
   );
 
@@ -2861,7 +2860,7 @@ def StableHLO_ReverseOp: StableHLO_ShapedInterfaceOp<"reverse",
   }];
   let arguments = (ins
     HLO_Tensor:$operand,
-    DenseI64ArrayAttr:$dimensions
+    GenericDenseI64ArrayAttr:$dimensions
   );
 
   let hasVerifier = 1;
@@ -2869,7 +2868,7 @@ def StableHLO_ReverseOp: StableHLO_ShapedInterfaceOp<"reverse",
   let results = (outs HLO_Tensor:$result);
 
   let assemblyFormat = [{
-    $operand `,` `dims` `=` $dimensions
+    $operand `,` `dims` `=` custom<DenseI64Array>($dimensions)
       attr-dict `:` custom<SameOperandsAndResultType>(type($operand), type($result))
   }];
 }
@@ -2897,18 +2896,18 @@ def StableHLO_PadOp: StableHLO_ShapedInterfaceOp<"pad",
   let arguments = (ins
     HLO_Tensor:$operand /*pad_i1*/,
     HLO_Tensor:$padding_value /*pad_i2*/,
-    DenseI64ArrayAttr:$edge_padding_low /*pad_i3*/,
-    DenseI64ArrayAttr:$edge_padding_high /*pad_i4*/,
-    DenseI64ArrayAttr:$interior_padding /*pad_i5*/
+    GenericDenseI64ArrayAttr:$edge_padding_low /*pad_i3*/,
+    GenericDenseI64ArrayAttr:$edge_padding_high /*pad_i4*/,
+    GenericDenseI64ArrayAttr:$interior_padding /*pad_i5*/
   );
 
   let results = (outs HLO_Tensor);
 
   let assemblyFormat = [{
     $operand `,` $padding_value `,`
-      `low` `=` $edge_padding_low `,`
-      `high` `=` $edge_padding_high `,`
-      `interior` `=` $interior_padding
+      `low` `=` custom<DenseI64Array>($edge_padding_low) `,`
+      `high` `=` custom<DenseI64Array>($edge_padding_high) `,`
+      `interior` `=` custom<DenseI64Array>($interior_padding)
       attr-dict `:` functional-type(operands, results)
   }];
 }
@@ -2954,14 +2953,14 @@ def StableHLO_TransposeOp: StableHLO_ShapedInterfaceOp<"transpose",
   }];
   let arguments = (ins
     HLO_TensorOrPerAxisQuantizedTensor:$operand,
-    DenseI64ArrayAttr:$permutation
+    GenericDenseI64ArrayAttr:$permutation
   );
   let results = (outs HLO_TensorOrPerAxisQuantizedTensor:$result);
 
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    $operand `,` `dims` `=` $permutation
+    $operand `,` `dims` `=` custom<DenseI64Array>($permutation)
       attr-dict `:` functional-type(operands, results)
   }];
 
@@ -3041,13 +3040,13 @@ def StableHLO_ReduceWindowOp: StableHLO_Op<"reduce_window", [
   let arguments = (ins
     Variadic<HLO_Tensor>:$inputs /*reduce_window_i1*/,
     Variadic<HLO_Tensor>:$init_values /*reduce_window_i2*/,
-    DenseI64ArrayAttr:$window_dimensions /*reduce_window_i3*/,
+    GenericDenseI64ArrayAttr:$window_dimensions /*reduce_window_i3*/,
     // If strides or dilations attributes are missing then the default value is
     // one for each of the operand dimensions. Similarly, padding values are zero
     // for both low and high in each of the dimensions, if not specified.
-    OptionalAttr<DenseI64ArrayAttr>:$window_strides /*reduce_window_i4*/,
-    OptionalAttr<DenseI64ArrayAttr>:$base_dilations /*reduce_window_i5*/,
-    OptionalAttr<DenseI64ArrayAttr>:$window_dilations /*reduce_window_i6*/,
+    OptionalAttr<GenericDenseI64ArrayAttr>:$window_strides /*reduce_window_i4*/,
+    OptionalAttr<GenericDenseI64ArrayAttr>:$base_dilations /*reduce_window_i5*/,
+    OptionalAttr<GenericDenseI64ArrayAttr>:$window_dilations /*reduce_window_i6*/,
     OptionalAttr<I64ElementsAttr>:$padding /*reduce_window_i7*/
   );
 

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -517,8 +517,8 @@ SmallVector<InterpreterValue> eval(Region &region,
       auto rank = lhs.getRank();
 
       SmallVector<int64_t> windowStrides(rank - 2, 1);
-      if (auto windowStridesAttr = convolutionOp.getWindowStridesAttr())
-        windowStrides = SmallVector<int64_t>(windowStridesAttr.asArrayRef());
+      if (auto windowStridesAttr = convolutionOp.getWindowStrides())
+        windowStrides = SmallVector<int64_t>(windowStridesAttr.value());
 
       SmallVector<std::pair<int64_t, int64_t>> padding(rank - 2, {0, 0});
       if (auto paddingAttr = convolutionOp.getPaddingAttr()) {
@@ -529,16 +529,16 @@ SmallVector<InterpreterValue> eval(Region &region,
       }
 
       SmallVector<int64_t> lhsDilation(rank - 2, 1);
-      if (auto lhsDilationAttr = convolutionOp.getLhsDilationAttr())
-        lhsDilation = SmallVector<int64_t>(lhsDilationAttr.asArrayRef());
+      if (auto lhsDilationAttr = convolutionOp.getLhsDilation())
+        lhsDilation = SmallVector<int64_t>(lhsDilationAttr.value());
 
       SmallVector<int64_t> rhsDilation(rank - 2, 1);
-      if (auto rhsDilationAttr = convolutionOp.getRhsDilationAttr())
-        rhsDilation = SmallVector<int64_t>(rhsDilationAttr.asArrayRef());
+      if (auto rhsDilationAttr = convolutionOp.getRhsDilation())
+        rhsDilation = SmallVector<int64_t>(rhsDilationAttr.value());
 
       SmallVector<bool> windowReversal(rank - 2, false);
-      if (auto windowReversalAttr = convolutionOp.getWindowReversalAttr())
-        windowReversal = SmallVector<bool>(windowReversalAttr.asArrayRef());
+      if (auto windowReversalAttr = convolutionOp.getWindowReversal())
+        windowReversal = SmallVector<bool>(windowReversalAttr.value());
 
       auto dimensionNumbers = convolutionOp.getDimensionNumbers();
       auto result = evalConvolutionOp(

--- a/stablehlo/tests/chlo/chlo_legalize_to_stablehlo.mlir
+++ b/stablehlo/tests/chlo/chlo_legalize_to_stablehlo.mlir
@@ -1317,8 +1317,8 @@ func.func @zeta_f16(%arg0: tensor<f16>, %arg1: tensor<f16>) -> tensor<f16> {
   // CHECK: %[[TMP_33:.*]] = stablehlo.add %[[TMP_30]], %[[TMP_3]]
   // CHECK: %[[TMP_34:.*]] = stablehlo.power %[[TMP_33]], %[[TMP_4]]
   // CHECK: %[[TMP_35:.*]] = stablehlo.constant dense<1.000000e+00>
-  // CHECK: %[[TMP_36:.*]] = stablehlo.multiply %[[TMP_34]], %[[TMP_33]]
-  // CHECK: %[[TMP_37:.*]] = stablehlo.subtract %[[TMP_0]], %[[TMP_35]]
+  // CHECK-DAG: %[[TMP_36:.*]] = stablehlo.multiply %[[TMP_34]], %[[TMP_33]]
+  // CHECK-DAG: %[[TMP_37:.*]] = stablehlo.subtract %[[TMP_0]], %[[TMP_35]]
   // CHECK: %[[TMP_38:.*]] = stablehlo.divide %[[TMP_36]], %[[TMP_37]]
   // CHECK: %[[TMP_39:.*]] = stablehlo.multiply %[[TMP_33]], %[[TMP_33]]
   // CHECK: %[[TMP_40:.*]] = stablehlo.divide %[[TMP_3]], %[[TMP_39]]
@@ -1465,7 +1465,7 @@ func.func @zeta_f16(%arg0: tensor<f16>, %arg1: tensor<f16>) -> tensor<f16> {
 
 // -----
 
-// CHECK: @polygamma_f32
+// CHECK-LABEL: @polygamma_f32
 // CHECK-SAME: (%[[ARG0:.*]]: tensor<f32>, %[[ARG1:.*]]: tensor<f32>)
 func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> {
   // CHECK-DAG: %[[TMP_0:.*]] = stablehlo.constant dense<1.000000e+00>
@@ -1592,8 +1592,8 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_121:.*]] = stablehlo.add %[[TMP_118]], %[[TMP_91]]
   // CHECK: %[[TMP_122:.*]] = stablehlo.power %[[TMP_121]], %[[TMP_92]]
   // CHECK: %[[TMP_123:.*]] = stablehlo.constant dense<1.000000e+00>
-  // CHECK: %[[TMP_124:.*]] = stablehlo.multiply %[[TMP_122]], %[[TMP_121]]
-  // CHECK: %[[TMP_125:.*]] = stablehlo.subtract %[[TMP_5]], %[[TMP_123]]
+  // CHECK-DAG: %[[TMP_124:.*]] = stablehlo.multiply %[[TMP_122]], %[[TMP_121]]
+  // CHECK-DAG: %[[TMP_125:.*]] = stablehlo.subtract %[[TMP_5]], %[[TMP_123]]
   // CHECK: %[[TMP_126:.*]] = stablehlo.divide %[[TMP_124]], %[[TMP_125]]
   // CHECK: %[[TMP_127:.*]] = stablehlo.multiply %[[TMP_121]], %[[TMP_121]]
   // CHECK: %[[TMP_128:.*]] = stablehlo.divide %[[TMP_91]], %[[TMP_127]]
@@ -1602,7 +1602,7 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_131:.*]] = stablehlo.constant dense<2.100000e+01>
   // CHECK: %[[TMP_132:.*]] = stablehlo.add %[[TMP_5]], %[[TMP_131]]
   // CHECK: %[[TMP_133:.*]] = stablehlo.multiply %[[TMP_130]], %[[TMP_132]]
-  // CHECK: %[[TMP_134:.*]] = stablehlo.constant dense<-1.39544646E-19>
+  // CHECK: %[[TMP_134:.*]] = stablehlo.constant
   // CHECK: %[[TMP_135:.*]] = stablehlo.add %[[TMP_90]], %[[TMP_134]]
   // CHECK: %[[TMP_136:.*]] = stablehlo.multiply %[[TMP_128]], %[[TMP_135]]
   // CHECK: %[[TMP_137:.*]] = stablehlo.multiply %[[TMP_133]], %[[TMP_136]]
@@ -1611,7 +1611,7 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_140:.*]] = stablehlo.constant dense<1.900000e+01>
   // CHECK: %[[TMP_141:.*]] = stablehlo.add %[[TMP_5]], %[[TMP_140]]
   // CHECK: %[[TMP_142:.*]] = stablehlo.multiply %[[TMP_139]], %[[TMP_141]]
-  // CHECK: %[[TMP_143:.*]] = stablehlo.constant dense<5.50900303E-18>
+  // CHECK: %[[TMP_143:.*]] = stablehlo.constant
   // CHECK: %[[TMP_144:.*]] = stablehlo.add %[[TMP_137]], %[[TMP_143]]
   // CHECK: %[[TMP_145:.*]] = stablehlo.multiply %[[TMP_128]], %[[TMP_144]]
   // CHECK: %[[TMP_146:.*]] = stablehlo.multiply %[[TMP_142]], %[[TMP_145]]
@@ -1620,7 +1620,7 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_149:.*]] = stablehlo.constant dense<1.700000e+01>
   // CHECK: %[[TMP_150:.*]] = stablehlo.add %[[TMP_5]], %[[TMP_149]]
   // CHECK: %[[TMP_151:.*]] = stablehlo.multiply %[[TMP_148]], %[[TMP_150]]
-  // CHECK: %[[TMP_152:.*]] = stablehlo.constant dense<-2.17486866E-16>
+  // CHECK: %[[TMP_152:.*]] = stablehlo.constant
   // CHECK: %[[TMP_153:.*]] = stablehlo.add %[[TMP_146]], %[[TMP_152]]
   // CHECK: %[[TMP_154:.*]] = stablehlo.multiply %[[TMP_128]], %[[TMP_153]]
   // CHECK: %[[TMP_155:.*]] = stablehlo.multiply %[[TMP_151]], %[[TMP_154]]
@@ -1629,7 +1629,7 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_158:.*]] = stablehlo.constant dense<1.500000e+01>
   // CHECK: %[[TMP_159:.*]] = stablehlo.add %[[TMP_5]], %[[TMP_158]]
   // CHECK: %[[TMP_160:.*]] = stablehlo.multiply %[[TMP_157]], %[[TMP_159]]
-  // CHECK: %[[TMP_161:.*]] = stablehlo.constant dense<8.58606213E-15>
+  // CHECK: %[[TMP_161:.*]] = stablehlo.constant
   // CHECK: %[[TMP_162:.*]] = stablehlo.add %[[TMP_155]], %[[TMP_161]]
   // CHECK: %[[TMP_163:.*]] = stablehlo.multiply %[[TMP_128]], %[[TMP_162]]
   // CHECK: %[[TMP_164:.*]] = stablehlo.multiply %[[TMP_160]], %[[TMP_163]]
@@ -1638,7 +1638,7 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_167:.*]] = stablehlo.constant dense<1.300000e+01>
   // CHECK: %[[TMP_168:.*]] = stablehlo.add %[[TMP_5]], %[[TMP_167]]
   // CHECK: %[[TMP_169:.*]] = stablehlo.multiply %[[TMP_166]], %[[TMP_168]]
-  // CHECK: %[[TMP_170:.*]] = stablehlo.constant dense<-3.3896803E-13>
+  // CHECK: %[[TMP_170:.*]] = stablehlo.constant
   // CHECK: %[[TMP_171:.*]] = stablehlo.add %[[TMP_164]], %[[TMP_170]]
   // CHECK: %[[TMP_172:.*]] = stablehlo.multiply %[[TMP_128]], %[[TMP_171]]
   // CHECK: %[[TMP_173:.*]] = stablehlo.multiply %[[TMP_169]], %[[TMP_172]]
@@ -1647,7 +1647,7 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_176:.*]] = stablehlo.constant dense<1.100000e+01>
   // CHECK: %[[TMP_177:.*]] = stablehlo.add %[[TMP_5]], %[[TMP_176]]
   // CHECK: %[[TMP_178:.*]] = stablehlo.multiply %[[TMP_175]], %[[TMP_177]]
-  // CHECK: %[[TMP_179:.*]] = stablehlo.constant dense<1.33825364E-11>
+  // CHECK: %[[TMP_179:.*]] = stablehlo.constant
   // CHECK: %[[TMP_180:.*]] = stablehlo.add %[[TMP_173]], %[[TMP_179]]
   // CHECK: %[[TMP_181:.*]] = stablehlo.multiply %[[TMP_128]], %[[TMP_180]]
   // CHECK: %[[TMP_182:.*]] = stablehlo.multiply %[[TMP_178]], %[[TMP_181]]
@@ -1656,7 +1656,7 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_185:.*]] = stablehlo.constant dense<9.000000e+00>
   // CHECK: %[[TMP_186:.*]] = stablehlo.add %[[TMP_5]], %[[TMP_185]]
   // CHECK: %[[TMP_187:.*]] = stablehlo.multiply %[[TMP_184]], %[[TMP_186]]
-  // CHECK: %[[TMP_188:.*]] = stablehlo.constant dense<-5.28419031E-10>
+  // CHECK: %[[TMP_188:.*]] = stablehlo.constant
   // CHECK: %[[TMP_189:.*]] = stablehlo.add %[[TMP_182]], %[[TMP_188]]
   // CHECK: %[[TMP_190:.*]] = stablehlo.multiply %[[TMP_128]], %[[TMP_189]]
   // CHECK: %[[TMP_191:.*]] = stablehlo.multiply %[[TMP_187]], %[[TMP_190]]
@@ -1665,7 +1665,7 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_194:.*]] = stablehlo.constant dense<7.000000e+00>
   // CHECK: %[[TMP_195:.*]] = stablehlo.add %[[TMP_5]], %[[TMP_194]]
   // CHECK: %[[TMP_196:.*]] = stablehlo.multiply %[[TMP_193]], %[[TMP_195]]
-  // CHECK: %[[TMP_197:.*]] = stablehlo.constant dense<2.08767563E-8>
+  // CHECK: %[[TMP_197:.*]] = stablehlo.constant
   // CHECK: %[[TMP_198:.*]] = stablehlo.add %[[TMP_191]], %[[TMP_197]]
   // CHECK: %[[TMP_199:.*]] = stablehlo.multiply %[[TMP_128]], %[[TMP_198]]
   // CHECK: %[[TMP_200:.*]] = stablehlo.multiply %[[TMP_196]], %[[TMP_199]]
@@ -1674,7 +1674,7 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_203:.*]] = stablehlo.constant dense<5.000000e+00>
   // CHECK: %[[TMP_204:.*]] = stablehlo.add %[[TMP_5]], %[[TMP_203]]
   // CHECK: %[[TMP_205:.*]] = stablehlo.multiply %[[TMP_202]], %[[TMP_204]]
-  // CHECK: %[[TMP_206:.*]] = stablehlo.constant dense<-8.26719599E-7>
+  // CHECK: %[[TMP_206:.*]] = stablehlo.constant
   // CHECK: %[[TMP_207:.*]] = stablehlo.add %[[TMP_200]], %[[TMP_206]]
   // CHECK: %[[TMP_208:.*]] = stablehlo.multiply %[[TMP_128]], %[[TMP_207]]
   // CHECK: %[[TMP_209:.*]] = stablehlo.multiply %[[TMP_205]], %[[TMP_208]]
@@ -1683,7 +1683,7 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_212:.*]] = stablehlo.constant dense<3.000000e+00>
   // CHECK: %[[TMP_213:.*]] = stablehlo.add %[[TMP_5]], %[[TMP_212]]
   // CHECK: %[[TMP_214:.*]] = stablehlo.multiply %[[TMP_211]], %[[TMP_213]]
-  // CHECK: %[[TMP_215:.*]] = stablehlo.constant dense<3.30687835E-5>
+  // CHECK: %[[TMP_215:.*]] = stablehlo.constant
   // CHECK: %[[TMP_216:.*]] = stablehlo.add %[[TMP_209]], %[[TMP_215]]
   // CHECK: %[[TMP_217:.*]] = stablehlo.multiply %[[TMP_128]], %[[TMP_216]]
   // CHECK: %[[TMP_218:.*]] = stablehlo.multiply %[[TMP_214]], %[[TMP_217]]
@@ -1692,13 +1692,13 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_221:.*]] = stablehlo.constant dense<1.000000e+00>
   // CHECK: %[[TMP_222:.*]] = stablehlo.add %[[TMP_5]], %[[TMP_221]]
   // CHECK: %[[TMP_223:.*]] = stablehlo.multiply %[[TMP_220]], %[[TMP_222]]
-  // CHECK: %[[TMP_224:.*]] = stablehlo.constant dense<-0.00138888892>
+  // CHECK: %[[TMP_224:.*]] = stablehlo.constant
   // CHECK: %[[TMP_225:.*]] = stablehlo.add %[[TMP_218]], %[[TMP_224]]
   // CHECK: %[[TMP_226:.*]] = stablehlo.multiply %[[TMP_128]], %[[TMP_225]]
   // CHECK: %[[TMP_227:.*]] = stablehlo.multiply %[[TMP_223]], %[[TMP_226]]
   // CHECK: %[[TMP_228:.*]] = stablehlo.constant dense<5.000000e-01>
   // CHECK: %[[TMP_229:.*]] = stablehlo.divide %[[TMP_5]], %[[TMP_121]]
-  // CHECK: %[[TMP_230:.*]] = stablehlo.constant dense<0.0833333358>
+  // CHECK: %[[TMP_230:.*]] = stablehlo.constant
   // CHECK: %[[TMP_231:.*]] = stablehlo.add %[[TMP_230]], %[[TMP_227]]
   // CHECK: %[[TMP_232:.*]] = stablehlo.multiply %[[TMP_229]], %[[TMP_231]]
   // CHECK: %[[TMP_233:.*]] = stablehlo.add %[[TMP_228]], %[[TMP_232]]
@@ -1707,11 +1707,11 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_236:.*]] = stablehlo.add %[[TMP_235]], %[[TMP_234]]
   // CHECK: %[[TMP_237:.*]] = stablehlo.abs %[[TMP_122]]
   // CHECK: %[[TMP_238:.*]] = stablehlo.abs %[[TMP_120]]
-  // CHECK: %[[TMP_239:.*]] = stablehlo.constant dense<1.401300e-45>
+  // CHECK: %[[TMP_239:.*]] = stablehlo.constant
   // CHECK: %[[TMP_240:.*]] = stablehlo.multiply %[[TMP_238]], %[[TMP_239]]
   // CHECK: %[[TMP_241:.*]] = stablehlo.compare LT, %[[TMP_237]], %[[TMP_240]], NOTYPE
   // CHECK: %[[TMP_242:.*]] = stablehlo.select %[[TMP_241]], %[[TMP_120]], %[[TMP_236]]
-  // CHECK: %[[TMP_243:.*]] = stablehlo.constant dense<0x7FC00000>
+  // CHECK: %[[TMP_243:.*]] = stablehlo.constant
   // CHECK: %[[TMP_244:.*]] = stablehlo.compare LT, %[[TMP_5]], %[[TMP_123]], NOTYPE
   // CHECK: %[[TMP_245:.*]] = stablehlo.select %[[TMP_244]], %[[TMP_243]], %[[TMP_242]]
   // CHECK: %[[TMP_246:.*]] = stablehlo.compare LE, %[[ARG1]], %[[TMP_90]], NOTYPE
@@ -1719,7 +1719,7 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_248:.*]] = stablehlo.compare NE, %[[TMP_5]], %[[TMP_247]], NOTYPE
   // CHECK: %[[TMP_249:.*]] = stablehlo.and %[[TMP_246]], %[[TMP_248]]
   // CHECK: %[[TMP_250:.*]] = stablehlo.select %[[TMP_249]], %[[TMP_243]], %[[TMP_245]]
-  // CHECK: %[[TMP_251:.*]] = stablehlo.constant dense<0x7F800000>
+  // CHECK: %[[TMP_251:.*]] = stablehlo.constant
   // CHECK: %[[TMP_252:.*]] = stablehlo.floor %[[ARG1]]
   // CHECK: %[[TMP_253:.*]] = stablehlo.compare EQ, %[[ARG1]], %[[TMP_252]], NOTYPE
   // CHECK: %[[TMP_254:.*]] = stablehlo.and %[[TMP_246]], %[[TMP_253]]
@@ -1744,8 +1744,8 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_273:.*]] = stablehlo.subtract %[[ARG1]], %[[TMP_272]]
   // CHECK: %[[TMP_274:.*]] = stablehlo.select %[[TMP_270]], %[[TMP_271]], %[[TMP_273]]
   // CHECK-DAG: %[[TMP_275:.*]] = stablehlo.constant dense<0.000000e+00>
-  // CHECK-DAG: %[[TMP_276:.*]] = stablehlo.constant dense<1.000000e+00>
-  // CHECK-DAG: %[[TMP_277:.*]] = stablehlo.constant dense<676.520386>
+  // CHECK-DAG: %[[TMP_276:.*]] = stablehlo.constant
+  // CHECK-DAG: %[[TMP_277:.*]] = stablehlo.constant
   // CHECK-DAG: %[[TMP_278:.*]] = stablehlo.constant dense<1.000000e+00>
   // CHECK: %[[TMP_279:.*]] = stablehlo.add %[[TMP_274]], %[[TMP_278]]
   // CHECK: %[[TMP_280:.*]] = stablehlo.multiply %[[TMP_279]], %[[TMP_279]]
@@ -1753,7 +1753,7 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_282:.*]] = stablehlo.subtract %[[TMP_275]], %[[TMP_281]]
   // CHECK: %[[TMP_283:.*]] = stablehlo.divide %[[TMP_277]], %[[TMP_279]]
   // CHECK: %[[TMP_284:.*]] = stablehlo.add %[[TMP_276]], %[[TMP_283]]
-  // CHECK-DAG: %[[TMP_285:.*]] = stablehlo.constant dense<-1259.13916>
+  // CHECK-DAG: %[[TMP_285:.*]] = stablehlo.constant
   // CHECK-DAG: %[[TMP_286:.*]] = stablehlo.constant dense<2.000000e+00>
   // CHECK: %[[TMP_287:.*]] = stablehlo.add %[[TMP_274]], %[[TMP_286]]
   // CHECK: %[[TMP_288:.*]] = stablehlo.multiply %[[TMP_287]], %[[TMP_287]]
@@ -1761,7 +1761,7 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_290:.*]] = stablehlo.subtract %[[TMP_282]], %[[TMP_289]]
   // CHECK: %[[TMP_291:.*]] = stablehlo.divide %[[TMP_285]], %[[TMP_287]]
   // CHECK: %[[TMP_292:.*]] = stablehlo.add %[[TMP_284]], %[[TMP_291]]
-  // CHECK-DAG: %[[TMP_293:.*]] = stablehlo.constant dense<771.323425>
+  // CHECK-DAG: %[[TMP_293:.*]] = stablehlo.constant
   // CHECK-DAG: %[[TMP_294:.*]] = stablehlo.constant dense<3.000000e+00>
   // CHECK: %[[TMP_295:.*]] = stablehlo.add %[[TMP_274]], %[[TMP_294]]
   // CHECK: %[[TMP_296:.*]] = stablehlo.multiply %[[TMP_295]], %[[TMP_295]]
@@ -1769,15 +1769,15 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_298:.*]] = stablehlo.subtract %[[TMP_290]], %[[TMP_297]]
   // CHECK: %[[TMP_299:.*]] = stablehlo.divide %[[TMP_293]], %[[TMP_295]]
   // CHECK: %[[TMP_300:.*]] = stablehlo.add %[[TMP_292]], %[[TMP_299]]
-  // CHECK-DAG: %[[TMP_301:.*]] = stablehlo.constant dense<-176.615036>
-  // CHECK-DAG: %[[TMP_302:.*]] = stablehlo.constant dense<4.000000e+00>
+  // CHECK-DAG: %[[TMP_301:.*]] = stablehlo.constant
+  // CHECK-DAG: %[[TMP_302:.*]] = stablehlo.constant
   // CHECK: %[[TMP_303:.*]] = stablehlo.add %[[TMP_274]], %[[TMP_302]]
   // CHECK: %[[TMP_304:.*]] = stablehlo.multiply %[[TMP_303]], %[[TMP_303]]
   // CHECK: %[[TMP_305:.*]] = stablehlo.divide %[[TMP_301]], %[[TMP_304]]
   // CHECK: %[[TMP_306:.*]] = stablehlo.subtract %[[TMP_298]], %[[TMP_305]]
   // CHECK: %[[TMP_307:.*]] = stablehlo.divide %[[TMP_301]], %[[TMP_303]]
   // CHECK: %[[TMP_308:.*]] = stablehlo.add %[[TMP_300]], %[[TMP_307]]
-  // CHECK-DAG: %[[TMP_309:.*]] = stablehlo.constant dense<12.5073433>
+  // CHECK-DAG: %[[TMP_309:.*]] = stablehlo.constant
   // CHECK-DAG: %[[TMP_310:.*]] = stablehlo.constant dense<5.000000e+00>
   // CHECK: %[[TMP_311:.*]] = stablehlo.add %[[TMP_274]], %[[TMP_310]]
   // CHECK: %[[TMP_312:.*]] = stablehlo.multiply %[[TMP_311]], %[[TMP_311]]
@@ -1785,7 +1785,7 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_314:.*]] = stablehlo.subtract %[[TMP_306]], %[[TMP_313]]
   // CHECK: %[[TMP_315:.*]] = stablehlo.divide %[[TMP_309]], %[[TMP_311]]
   // CHECK: %[[TMP_316:.*]] = stablehlo.add %[[TMP_308]], %[[TMP_315]]
-  // CHECK-DAG: %[[TMP_317:.*]] = stablehlo.constant dense<-0.138571098>
+  // CHECK-DAG: %[[TMP_317:.*]] = stablehlo.constant
   // CHECK-DAG: %[[TMP_318:.*]] = stablehlo.constant dense<6.000000e+00>
   // CHECK: %[[TMP_319:.*]] = stablehlo.add %[[TMP_274]], %[[TMP_318]]
   // CHECK: %[[TMP_320:.*]] = stablehlo.multiply %[[TMP_319]], %[[TMP_319]]
@@ -1793,7 +1793,7 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_322:.*]] = stablehlo.subtract %[[TMP_314]], %[[TMP_321]]
   // CHECK: %[[TMP_323:.*]] = stablehlo.divide %[[TMP_317]], %[[TMP_319]]
   // CHECK: %[[TMP_324:.*]] = stablehlo.add %[[TMP_316]], %[[TMP_323]]
-  // CHECK-DAG: %[[TMP_325:.*]] = stablehlo.constant dense<9.98436917E-6>
+  // CHECK-DAG: %[[TMP_325:.*]] = stablehlo.constant
   // CHECK-DAG: %[[TMP_326:.*]] = stablehlo.constant dense<7.000000e+00>
   // CHECK: %[[TMP_327:.*]] = stablehlo.add %[[TMP_274]], %[[TMP_326]]
   // CHECK: %[[TMP_328:.*]] = stablehlo.multiply %[[TMP_327]], %[[TMP_327]]
@@ -1801,7 +1801,7 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_330:.*]] = stablehlo.subtract %[[TMP_322]], %[[TMP_329]]
   // CHECK: %[[TMP_331:.*]] = stablehlo.divide %[[TMP_325]], %[[TMP_327]]
   // CHECK: %[[TMP_332:.*]] = stablehlo.add %[[TMP_324]], %[[TMP_331]]
-  // CHECK-DAG: %[[TMP_333:.*]] = stablehlo.constant dense<1.50563267E-7>
+  // CHECK-DAG: %[[TMP_333:.*]] = stablehlo.constant
   // CHECK-DAG: %[[TMP_334:.*]] = stablehlo.constant dense<8.000000e+00>
   // CHECK: %[[TMP_335:.*]] = stablehlo.add %[[TMP_274]], %[[TMP_334]]
   // CHECK: %[[TMP_336:.*]] = stablehlo.multiply %[[TMP_335]], %[[TMP_335]]
@@ -1811,7 +1811,7 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_340:.*]] = stablehlo.add %[[TMP_332]], %[[TMP_339]]
   // CHECK: %[[TMP_341:.*]] = stablehlo.constant dense<7.500000e+00>
   // CHECK: %[[TMP_342:.*]] = stablehlo.add %[[TMP_341]], %[[TMP_274]]
-  // CHECK: %[[TMP_343:.*]] = stablehlo.constant dense<2.01490307>
+  // CHECK: %[[TMP_343:.*]] = stablehlo.constant
   // CHECK: %[[TMP_344:.*]] = stablehlo.divide %[[TMP_274]], %[[TMP_341]]
   // CHECK: %[[TMP_345:.*]] = stablehlo.log_plus_one %[[TMP_344]]
   // CHECK: %[[TMP_346:.*]] = stablehlo.add %[[TMP_343]], %[[TMP_345]]
@@ -1825,7 +1825,7 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_354:.*]] = stablehlo.floor %[[TMP_353]]
   // CHECK: %[[TMP_355:.*]] = stablehlo.abs %[[TMP_354]]
   // CHECK: %[[TMP_356:.*]] = stablehlo.add %[[ARG1]], %[[TMP_355]]
-  // CHECK: %[[TMP_357:.*]] = stablehlo.constant dense<3.14159274>
+  // CHECK: %[[TMP_357:.*]] = stablehlo.constant
   // CHECK: %[[TMP_358:.*]] = stablehlo.multiply %[[TMP_357]], %[[TMP_356]]
   // CHECK: %[[TMP_359:.*]] = stablehlo.cosine %[[TMP_358]]
   // CHECK: %[[TMP_360:.*]] = stablehlo.sine %[[TMP_358]]
@@ -1837,14 +1837,14 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
   // CHECK: %[[TMP_366:.*]] = stablehlo.floor %[[ARG1]]
   // CHECK: %[[TMP_367:.*]] = stablehlo.compare EQ, %[[ARG1]], %[[TMP_366]], NOTYPE
   // CHECK: %[[TMP_368:.*]] = stablehlo.and %[[TMP_365]], %[[TMP_367]]
-  // CHECK: %[[TMP_369:.*]] = stablehlo.constant dense<0x7FC00000>
+  // CHECK: %[[TMP_369:.*]] = stablehlo.constant
   // CHECK: %[[TMP_370:.*]] = stablehlo.select %[[TMP_368]], %[[TMP_369]], %[[TMP_364]]
   // CHECK: %[[TMP_371:.*]] = stablehlo.select %[[TMP_268]], %[[TMP_370]], %[[TMP_266]]
   // CHECK: %[[TMP_372:.*]] = stablehlo.floor %[[ARG0]]
   // CHECK: %[[TMP_373:.*]] = stablehlo.compare NE, %[[ARG0]], %[[TMP_372]], NOTYPE
   // CHECK: %[[TMP_374:.*]] = stablehlo.compare LT, %[[ARG0]], %[[TMP_267]], NOTYPE
   // CHECK: %[[TMP_375:.*]] = stablehlo.or %[[TMP_373]], %[[TMP_374]]
-  // CHECK: %[[TMP_376:.*]] = stablehlo.constant dense<0x7FC00000>
+  // CHECK: %[[TMP_376:.*]] = stablehlo.constant
   // CHECK: %[[TMP_377:.*]] = stablehlo.select %[[TMP_375]], %[[TMP_376]], %[[TMP_371]]
   %1 = chlo.polygamma %lhs, %rhs : tensor<f32>, tensor<f32> -> tensor<f32>
   func.return %1 : tensor<f32>
@@ -1852,7 +1852,7 @@ func.func @polygamma_f32(%lhs : tensor<f32>, %rhs : tensor<f32>) -> tensor<f32> 
 
 // -----
 
-// CHECK: @polygamma_f64
+// CHECK-LABEL: @polygamma_f64
 // CHECK-SAME: (%[[ARG0:.*]]: tensor<f64>, %[[ARG1:.*]]: tensor<f64>)
 func.func @polygamma_f64(%lhs : tensor<f64>, %rhs : tensor<f64>) -> tensor<f64> {
   // CHECK-DAG: %[[TMP_0:.*]] = stablehlo.constant dense<1.000000e+00>
@@ -1979,8 +1979,8 @@ func.func @polygamma_f64(%lhs : tensor<f64>, %rhs : tensor<f64>) -> tensor<f64> 
   // CHECK: %[[TMP_121:.*]] = stablehlo.add %[[TMP_118]], %[[TMP_91]]
   // CHECK: %[[TMP_122:.*]] = stablehlo.power %[[TMP_121]], %[[TMP_92]]
   // CHECK: %[[TMP_123:.*]] = stablehlo.constant dense<1.000000e+00>
-  // CHECK: %[[TMP_124:.*]] = stablehlo.multiply %[[TMP_122]], %[[TMP_121]]
-  // CHECK: %[[TMP_125:.*]] = stablehlo.subtract %[[TMP_5]], %[[TMP_123]]
+  // CHECK-DAG: %[[TMP_124:.*]] = stablehlo.multiply %[[TMP_122]], %[[TMP_121]]
+  // CHECK-DAG: %[[TMP_125:.*]] = stablehlo.subtract %[[TMP_5]], %[[TMP_123]]
   // CHECK: %[[TMP_126:.*]] = stablehlo.divide %[[TMP_124]], %[[TMP_125]]
   // CHECK: %[[TMP_127:.*]] = stablehlo.multiply %[[TMP_121]], %[[TMP_121]]
   // CHECK: %[[TMP_128:.*]] = stablehlo.divide %[[TMP_91]], %[[TMP_127]]
@@ -2492,11 +2492,11 @@ func.func @tan_complexf32(%arg0 : tensor<1xf32>, %arg1 : tensor<1xf32>) -> (tens
 // CHECK-SAME: (%[[ARG:.*]]: tensor<16x16xf32>)
 func.func @top_k(%arg : tensor<16x16xf32>) -> (tensor<16x8xf32>, tensor<16x8xi32>) {
   // CHECK:      %[[IOTA:.*]] = stablehlo.iota dim = 1 : tensor<16x16xi32>
-  // CHECK-NEXT: %[[SORT:.*]]:2 = "stablehlo.sort"(%[[ARG]], %[[IOTA]]) ({
+  // CHECK-NEXT: %[[SORT:.*]]:2 = "stablehlo.sort"(%[[ARG]], %[[IOTA]]) <{dimension = 1 : i64, is_stable = true}> ({
   // CHECK-NEXT: ^{{.*}}(%[[LHS:.*]]: tensor<f32>, %[[RHS:.*]]: tensor<f32>, %{{.*}}: tensor<i32>, %{{.*}}: tensor<i32>):
   // CHECK-NEXT:   %[[CMP:.*]] = stablehlo.compare GT, %[[LHS]], %[[RHS]], TOTALORDER
   // CHECK-NEXT:   stablehlo.return %[[CMP]]
-  // CHECK-NEXT: }) {dimension = 1 : i64, is_stable = true} : (tensor<16x16xf32>, tensor<16x16xi32>) -> (tensor<16x16xf32>, tensor<16x16xi32>)
+  // CHECK-NEXT: }) : (tensor<16x16xf32>, tensor<16x16xi32>) -> (tensor<16x16xf32>, tensor<16x16xi32>)
   // CHECK-NEXT: %[[VAL:.*]] = stablehlo.slice %[[SORT]]#0 [0:16, 0:8] : (tensor<16x16xf32>) -> tensor<16x8xf32>
   // CHECK-NEXT: %[[IDX:.*]] = stablehlo.slice %[[SORT]]#1 [0:16, 0:8] : (tensor<16x16xi32>) -> tensor<16x8xi32>
   // CHECK-NEXT: return %[[VAL]], %[[IDX]]
@@ -2521,11 +2521,11 @@ func.func @dyn_top_k(%arg0: tensor<?x5x?xi1>) -> (tensor<?x5x2xi1>, tensor<?x5x2
   // CHECK-NEXT: [[K_I32x1:%.*]] = stablehlo.reshape [[K_I32]] : (tensor<i32>) -> tensor<1xi32>
   // CHECK-NEXT: [[RESULT_SHAPE:%.*]] = stablehlo.concatenate [[DIM_0_I32x1]], [[DIM_1_I32x1]], [[K_I32x1]], dim = 0 : (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<3xi32>
   // CHECK-NEXT: [[IOTA:%.*]] = stablehlo.dynamic_iota [[IOTA_SHAPE]], dim = 2 : (tensor<3xi32>) -> tensor<?x5x?xi32>
-  // CHECK-NEXT: [[SORT:%.*]]:2 = "stablehlo.sort"([[ARG]], [[IOTA]]) ({
+  // CHECK-NEXT: [[SORT:%.*]]:2 = "stablehlo.sort"([[ARG]], [[IOTA]]) <{dimension = 2 : i64, is_stable = true}> ({
   // CHECK-NEXT: ^bb0([[ARG_1:%.*]]: tensor<i1>, [[ARG_2:%.*]]: tensor<i1>, [[ARG_3:%.*]]: tensor<i32>, [[ARG_4:%.*]]: tensor<i32>):
   // CHECK-NEXT:   [[CMP:%.*]] = stablehlo.compare  GT, [[ARG_1]], [[ARG_2]],  NOTYPE : (tensor<i1>, tensor<i1>) -> tensor<i1>
   // CHECK-NEXT:   stablehlo.return [[CMP]] : tensor<i1>
-  // CHECK-NEXT: }) {dimension = 2 : i64, is_stable = true} : (tensor<?x5x?xi1>, tensor<?x5x?xi32>) -> (tensor<?x5x?xi1>, tensor<?x5x?xi32>)
+  // CHECK-NEXT: }) : (tensor<?x5x?xi1>, tensor<?x5x?xi32>) -> (tensor<?x5x?xi1>, tensor<?x5x?xi32>)
   // CHECK-NEXT: [[STARTS:%.*]] = stablehlo.constant dense<0> : tensor<3xi64>
   // CHECK-NEXT: [[LIMITS:%.*]] = stablehlo.convert [[RESULT_SHAPE]] : (tensor<3xi32>) -> tensor<3xi64>
   // CHECK-NEXT: [[STRIDES:%.*]] = stablehlo.constant dense<1> : tensor<3xi64>

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -2014,7 +2014,7 @@ func.func @rng_bit_generator_dynamic(%arg0: tensor<?xui64>) -> (tensor<?xui64>, 
 
 // CHECK-LABEL: func @rng_normal
 func.func @rng_normal(%arg0: tensor<f32>, %arg1: tensor<f32>) -> tensor<2x3x5xf32> {
-  %cst = "stablehlo.constant"() {value = dense<[2, 3, 5]> : tensor<3xi64>} : () -> tensor<3xi64>
+  %cst = stablehlo.constant dense<[2, 3, 5]> : tensor<3xi64>
   %0 = "stablehlo.rng"(%arg0, %arg1, %cst) {rng_distribution = #stablehlo<rng_distribution NORMAL>}: (tensor<f32>, tensor<f32>, tensor<3xi64>) -> tensor<2x3x5xf32>
   func.return %0 : tensor<2x3x5xf32>
 }
@@ -2030,7 +2030,7 @@ func.func @rng_normal_no_constant(%a: tensor<f32>, %b: tensor<f32>, %shape: tens
 // -----
 
 func.func @rng_normal_invalid_shape(%arg0: tensor<f32>, %arg1: tensor<f32>) {
-  %cst = "stablehlo.constant"() {value = dense<7> : tensor<1xi64>} : () -> tensor<1xi64>
+  %cst = stablehlo.constant dense<7> : tensor<1xi64>
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error @+1 {{inferred type(s) 'tensor<7xf32>' are incompatible with return type(s) of operation 'tensor<12xf32>'}}
   %0 = "stablehlo.rng"(%arg0, %arg1, %cst) {rng_distribution = #stablehlo<rng_distribution NORMAL>}: (tensor<f32>, tensor<f32>, tensor<1xi64>) -> tensor<12xf32>
@@ -2067,7 +2067,7 @@ func.func @rng_normal_invalid_shape_rank(%mu: tensor<f32>, %sigma: tensor<f32>) 
 // -----
 
 func.func @rng_normal_invalid_type(%arg0: tensor<complex<f32>>, %arg1: tensor<f32>) {
-  %cst = "stablehlo.constant"() {value = dense<7> : tensor<1xi64>} : () -> tensor<1xi64>
+  %cst = stablehlo.constant dense<7> : tensor<1xi64>
   // expected-error @+1 {{#0 must be 0D tensor of pred (AKA boolean or 1-bit integer) or 4/8/16/32/64-bit signless integer or 4/8/16/32/64-bit unsigned integer or f8E4M3B11FNUZ type or f8E4M3FN type or f8E4M3FNUZ type or f8E5M2 type or f8E5M2FNUZ type or 16-bit float or 32-bit float or 64-bit float or bfloat16 type values, but got 'tensor<complex<f32>>'}}
   %0 = "stablehlo.rng"(%arg0, %arg1, %cst) {rng_distribution = #stablehlo<rng_distribution NORMAL>}: (tensor<complex<f32>>, tensor<f32>, tensor<1xi64>) -> tensor<7xf32>
   func.return
@@ -2691,7 +2691,7 @@ func.func @floor_invalid_i32_type(%arg0: tensor<4xi32>) -> tensor<4xi32> {
 // CHECK-LABEL: func @constants
 func.func @constants() -> () {
   // CHECK: stablehlo.constant dense<0> : tensor<i32>
-  %0 = "stablehlo.constant"() {value = dense<0> : tensor<i32>} : () -> (tensor<i32>)
+  %0 = "stablehlo.constant"() <{value = dense<0> : tensor<i32>}> : () -> (tensor<i32>)
 
   // CHECK: stablehlo.constant {extra_attr = 3 : i32} dense<0> : tensor<i32>
   %1 = "stablehlo.constant"() {extra_attr = 3 : i32, value = dense<0> : tensor<i32>} : () -> (tensor<i32>)
@@ -2703,7 +2703,7 @@ func.func @constants() -> () {
 func.func @constant_invalid() -> () {
   // expected-error@+2 {{failed to infer returned types}}
   // expected-error@+1 {{'stablehlo.constant' op inferred type(s) 'tensor<i32>' are incompatible with return type(s) of operation 'tensor<3xi32>'}}
-  %0 = "stablehlo.constant"() {value = dense<0> : tensor<i32>} : () -> (tensor<3xi32>)
+  %0 = "stablehlo.constant"() <{value = dense<0> : tensor<i32>}> : () -> (tensor<3xi32>)
   func.return
 }
 
@@ -2711,7 +2711,7 @@ func.func @constant_invalid() -> () {
 
 func.func @constant_invalid() -> () {
   // expected-error@+1 {{op result #0 must be statically shaped tensor}}
-  %0 = "stablehlo.constant"() {value = dense<1> : tensor<i32>} : () -> tensor<?xi32>
+  %0 = "stablehlo.constant"() <{value = dense<1> : tensor<i32>}> : () -> tensor<?xi32>
   func.return
 }
 
@@ -2719,7 +2719,7 @@ func.func @constant_invalid() -> () {
 
 func.func @constant_invalid() -> () {
   // expected-error@+1 {{elements literal type must have static shape}}
-  %0 = "stablehlo.constant"() {value = dense<1> : tensor<?xi32>} : () -> tensor<?xi32>
+  %0 = "stablehlo.constant"() <{value = dense<1> : tensor<?xi32>}> : () -> tensor<?xi32>
   func.return
 }
 
@@ -4872,7 +4872,7 @@ func.func @quantized_constants() -> (tensor<2x!quant.uniform<i8:f32, 2.0:15>>, t
   %3 = stablehlo.uniform_quantize %2 : (tensor<2xf32>) -> tensor<2x!quant.uniform<i8:f32, 2.0:15>>
   %4 = stablehlo.uniform_quantize %1 : (tensor<2xf32>) -> tensor<2x!quant.uniform<ui8:f32, 34.0:16>>
   func.return %0, %4, %3 : tensor<2x!quant.uniform<i8:f32, 2.0:15>>, tensor<2x!quant.uniform<ui8:f32, 34.0:16>>, tensor<2x!quant.uniform<i8:f32, 2.0:15>>
-  // CHECK: stablehlo.constant() {value = dense<[1, 2]> : tensor<2xi8>} : () -> tensor<2x!quant.uniform<i8:f32, 2.000000e+00:15>>
+  // CHECK: stablehlo.constant() <{value = dense<[1, 2]> : tensor<2xi8>}> : () -> tensor<2x!quant.uniform<i8:f32, 2.000000e+00:15>>
   // CHECK-NEXT: stablehlo.constant dense<[1.000000e+01, 1.200000e+01]> : tensor<2xf32>
   // CHECK-NEXT: stablehlo.constant dense<[3.000000e+00, 1.000000e+02]> : tensor<2xf32>
 }

--- a/stablehlo/tests/print_stablehlo.mlir
+++ b/stablehlo/tests/print_stablehlo.mlir
@@ -61,6 +61,20 @@ func.func @zero_output_ret0(%arg0 : tensor<3xi64>) -> () {
   "stablehlo.return"() : () -> ()
 }
 
+func.func @constants() -> () {
+  // CHECK:      %c = stablehlo.constant dense<-1> : tensor<1xi64>
+  // CHECK-NEXT: %c_0 = stablehlo.constant {attr = 1 : i32} dense<[-2, 4]> : tensor<2xi64>
+  // CHECK-NEXT: %cst = stablehlo.constant() <{value = dense<[1, 2]> : tensor<2xi8>}> : () -> tensor<2x!quant.uniform<i8:f32, 2.000000e+00:15>>
+  // CHECK-NEXT: %cst_1 = stablehlo.constant() <{value = dense<3> : tensor<1xi8>}> : () -> tensor<1x!quant.uniform<i8:f32, 2.000000e+00:15>>
+  // CHECK-NEXT: %cst_2 = stablehlo.constant() <{value = dense<4> : tensor<1xi8>}> {attr = 1 : i32} : () -> tensor<1x!quant.uniform<i8:f32, 2.000000e+00:15>>
+  %cst = "stablehlo.constant"() <{value = dense<[-1]> : tensor<1xi64>}> : () -> tensor<1xi64>
+  %cst_attrs = "stablehlo.constant"() <{value = dense<[-2, 4]> : tensor<2xi64>}> {attr = 1 : i32} : () -> tensor<2xi64>
+  %cst_q = "stablehlo.constant"() {value = dense<[1, 2]> : tensor<2xi8>} : () -> tensor<2x!quant.uniform<i8:f32, 2.000000e+00:15>>
+  %cst_q_attr = stablehlo.constant() {value = dense<[3]> : tensor<1xi8>} : () -> tensor<1x!quant.uniform<i8:f32, 2.000000e+00:15>>
+  %cst_q_attrs = stablehlo.constant() {value = dense<[4]> : tensor<1xi8>, attr = 1 : i32} : () -> tensor<1x!quant.uniform<i8:f32, 2.000000e+00:15>>
+  return
+}
+
 // CHECK-LABEL: func @unary_ops
 func.func @unary_ops(%arg0 : tensor<2xi32>, %arg1 : tensor<2xf32>) -> () {
   // CHECK:      %0 = stablehlo.abs %arg0 : tensor<2xi32>

--- a/stablehlo/tests/stablehlo_canonicalize_dynamism.mlir
+++ b/stablehlo/tests/stablehlo_canonicalize_dynamism.mlir
@@ -272,7 +272,7 @@ func.func @dynamic_conv_inapplicable_dynamic_padding(%arg0: tensor<100x26x26x32x
 // CHECK-LABEL: @dynamic_gather_success_static_result_type
 func.func @dynamic_gather_success_static_result_type(%arg0 : tensor<2x4x9xi32>, %arg1 : tensor<1x5x2xi32>) -> tensor<1x5x8xi32> {
   //  CHECK-NOT: stablehlo.dynamic_gather
-  //      CHECK: "stablehlo.gather"(%arg0, %arg1) {
+  //      CHECK: "stablehlo.gather"(%arg0, %arg1) <{
   // CHECK-SAME:   dimension_numbers = #stablehlo.gather<
   // CHECK-SAME:     offset_dims = [2],
   // CHECK-SAME:     collapsed_slice_dims = [0, 1],
@@ -280,7 +280,7 @@ func.func @dynamic_gather_success_static_result_type(%arg0 : tensor<2x4x9xi32>, 
   // CHECK-SAME:     index_vector_dim = 2
   // CHECK-SAME:   >,
   // CHECK-SAME:   slice_sizes = array<i64: 1, 1, 8>
-  // CHECK-SAME: } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
+  // CHECK-SAME: }> : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x8xi32>
   %0 = stablehlo.constant dense<[1, 1, 8]> : tensor<3xi32>
   %1 = "stablehlo.dynamic_gather"(%arg0, %arg1, %0) {
     dimension_numbers = #stablehlo.gather<
@@ -298,7 +298,7 @@ func.func @dynamic_gather_success_static_result_type(%arg0 : tensor<2x4x9xi32>, 
 // CHECK-LABEL: @dynamic_gather_success_dynamic_result_type
 func.func @dynamic_gather_success_dynamic_result_type(%arg0 : tensor<2x4x9xi32>, %arg1 : tensor<1x5x2xi32>) -> tensor<1x5x?xi32> {
   //  CHECK-NOT: stablehlo.dynamic_gather
-  //      CHECK: "stablehlo.gather"(%arg0, %arg1) {
+  //      CHECK: "stablehlo.gather"(%arg0, %arg1) <{
   // CHECK-SAME:   dimension_numbers = #stablehlo.gather<
   // CHECK-SAME:     offset_dims = [2],
   // CHECK-SAME:     collapsed_slice_dims = [0, 1],
@@ -306,16 +306,16 @@ func.func @dynamic_gather_success_dynamic_result_type(%arg0 : tensor<2x4x9xi32>,
   // CHECK-SAME:     index_vector_dim = 2
   // CHECK-SAME:   >,
   // CHECK-SAME:   slice_sizes = array<i64: 1, 1, 8>
-  // CHECK-SAME: } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x?xi32>
+  // CHECK-SAME: }> : (tensor<2x4x9xi32>, tensor<1x5x2xi32>) -> tensor<1x5x?xi32>
   %0 = stablehlo.constant dense<[1, 1, 8]> : tensor<3xi32>
-  %1 = "stablehlo.dynamic_gather"(%arg0, %arg1, %0) {
+  %1 = "stablehlo.dynamic_gather"(%arg0, %arg1, %0) <{
     dimension_numbers = #stablehlo.gather<
       collapsed_slice_dims = [0, 1],
       index_vector_dim = 2,
       offset_dims = [2],
       start_index_map = [0, 1]
     >
-  } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>, tensor<3xi32>) -> tensor<1x5x?xi32>
+  }> : (tensor<2x4x9xi32>, tensor<1x5x2xi32>, tensor<3xi32>) -> tensor<1x5x?xi32>
   return %1 : tensor<1x5x?xi32>
 }
 
@@ -324,14 +324,14 @@ func.func @dynamic_gather_success_dynamic_result_type(%arg0 : tensor<2x4x9xi32>,
 // CHECK-LABEL: @dynamic_gather_inapplicable_dynamic_slice_sizes
 func.func @dynamic_gather_inapplicable_dynamic_slice_sizes(%arg0 : tensor<2x4x9xi32>, %arg1 : tensor<1x5x2xi32>, %arg2 : tensor<3xi32>) -> tensor<1x5x8xi32> {
   // CHECK: stablehlo.dynamic_gather
-  %0 = "stablehlo.dynamic_gather"(%arg0, %arg1, %arg2) {
+  %0 = "stablehlo.dynamic_gather"(%arg0, %arg1, %arg2) <{
     dimension_numbers = #stablehlo.gather<
       collapsed_slice_dims = [0, 1],
       index_vector_dim = 2,
       offset_dims = [2],
       start_index_map = [0, 1]
     >
-  } : (tensor<2x4x9xi32>, tensor<1x5x2xi32>, tensor<3xi32>) -> tensor<1x5x8xi32>
+  }> : (tensor<2x4x9xi32>, tensor<1x5x2xi32>, tensor<3xi32>) -> tensor<1x5x8xi32>
   return %0 : tensor<1x5x8xi32>
 }
 

--- a/stablehlo/transforms/StablehloAggressiveSimplification.cpp
+++ b/stablehlo/transforms/StablehloAggressiveSimplification.cpp
@@ -110,8 +110,9 @@ struct AddOpCanon final : OpRewritePattern<mlir::stablehlo::AddOp> {
 
     // The canonical form has the constant operand as the RHS.
     if (isa<IntegerType>(elemType) && lhsAttr && !rhsAttr) {
-      rewriter.modifyOpInPlace(
-          op, [op, lhs, rhs] { op->setOperands(ValueRange{rhs, lhs}); });
+      rewriter.modifyOpInPlace(op, [op, lhs, rhs] {
+        op->setOperands(ValueRange{rhs, lhs});
+      });
       return success();
     }
 
@@ -198,8 +199,9 @@ struct MulOpCanon final : OpRewritePattern<mlir::stablehlo::MulOp> {
 
     // The canonical form has the constant operand as the RHS.
     if (isa<IntegerType>(elemType) && lhsAttr && !rhsAttr) {
-      rewriter.modifyOpInPlace(
-          op, [op, lhs, rhs] { op->setOperands(ValueRange{rhs, lhs}); });
+      rewriter.modifyOpInPlace(op, [op, lhs, rhs] {
+        op->setOperands(ValueRange{rhs, lhs});
+      });
       return success();
     }
 

--- a/stablehlo/transforms/StablehloAggressiveSimplification.cpp
+++ b/stablehlo/transforms/StablehloAggressiveSimplification.cpp
@@ -110,9 +110,8 @@ struct AddOpCanon final : OpRewritePattern<mlir::stablehlo::AddOp> {
 
     // The canonical form has the constant operand as the RHS.
     if (isa<IntegerType>(elemType) && lhsAttr && !rhsAttr) {
-      rewriter.modifyOpInPlace(op, [op, lhs, rhs] {
-        op->setOperands(ValueRange{rhs, lhs});
-      });
+      rewriter.modifyOpInPlace(
+          op, [op, lhs, rhs] { op->setOperands(ValueRange{rhs, lhs}); });
       return success();
     }
 
@@ -199,9 +198,8 @@ struct MulOpCanon final : OpRewritePattern<mlir::stablehlo::MulOp> {
 
     // The canonical form has the constant operand as the RHS.
     if (isa<IntegerType>(elemType) && lhsAttr && !rhsAttr) {
-      rewriter.modifyOpInPlace(op, [op, lhs, rhs] {
-        op->setOperands(ValueRange{rhs, lhs});
-      });
+      rewriter.modifyOpInPlace(
+          op, [op, lhs, rhs] { op->setOperands(ValueRange{rhs, lhs}); });
       return success();
     }
 

--- a/stablehlo/transforms/StablehloAggressiveSimplification.cpp
+++ b/stablehlo/transforms/StablehloAggressiveSimplification.cpp
@@ -771,9 +771,9 @@ struct UnusedResultReduceOpCanon final
       newInitVals.push_back(op.getOperand(i + numOperandPairs));
     }
 
-    auto newOp =
-        rewriter.create<ReduceOp>(op.getLoc(), newInputs, newInitVals,
-                                  op.getDimensionsAttr(), newElementTypes);
+    auto newOp = rewriter.create<ReduceOp>(
+        op.getLoc(), newInputs, newInitVals,
+        op.getDimensionsAttr().cast<DenseI64ArrayAttr>(), newElementTypes);
     Block *newReducerBlock = rewriter.createBlock(&newOp.getBody());
 
     IRMapping mapper;


### PR DESCRIPTION
Migrate StableHLO to use properties with a few additional changes:

- Constant op's custom fallback parsing needs to be updated to handle properties _or_ attributes.
- There are PjRT who require handling version skew, and are yet to migrate to VHLO (in progress, est ~Jun next release), in the meantime we require inherent IR attribute downgrades (DenseArray->DenseElements in [openxla/xla/pjrt/mlir_to_hlo.cc]( https://github.com/openxla/xla/blob/aefa3ab3a0613b538e14b449817dce986a765e84/xla/pjrt/mlir_to_hlo.cc#L180)). This isn't possible in a dialect that is using properties since properties require that property types are never invalid, so this PR introduces a DenseArray backed by generic Attribute storage. Cleanup tasks for this are tracked by #2216

Closes #1584
