### PR TITLE
Implement ConditionallySpeculatable for ConvolutionOp

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -1037,26 +1037,27 @@ mlir::Speculation::Speculatability ConvolutionOp::getSpeculatability() {
   auto featureGroupCount = getFeatureGroupCount();
 
   // input_feature_dimension and kernel_input_feature_dimension must be static
-  // (C14)
+  // (C14).
   if (inputType.isDynamicDim(inputFeatureDim) ||
       kernelType.isDynamicDim(kernelInputFeatureDim))
     return mlir::Speculation::NotSpeculatable;
 
   // input_batch_dimension must be static if batch_group_count > 1 (C10) or if
-  // output_batch_dimension is static (C25, first bullet).
+  // output_batch_dimension is static (C25).
   if (inputType.isDynamicDim(inputBatchDim) &&
       (batchGroupCount > 1 || !resultType.isDynamicDim(outputBatchDim)))
     return mlir::Speculation::NotSpeculatable;
 
   // kernel_output_feature_dimension must be static if batch_group_count > 1
   // (C15) or feature_group_count > 1 (C16) or if output_feature_dimension is
+  // static (C25).
   if (kernelType.isDynamicDim(kernelOutputFeatureDim) &&
       (batchGroupCount > 1 || featureGroupCount > 1 ||
        !resultType.isDynamicDim(outputFeatureDim)))
     return mlir::Speculation::NotSpeculatable;
 
-  // static (C25, second bullet). If a spatial dimension is static in the
-  // output, it must be static in the inputs.
+  // If a spatial dimension is static in the output, it must be static in the
+  // inputs (C25).
   for (auto [inputDim, kernelDim, resultDim] :
        llvm::zip(inputSpatialDims, kernelSpatialDims, outputSpatialDims)) {
     if (!resultType.isDynamicDim(resultDim) &&

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2792,8 +2792,7 @@ def StableHLO_SelectAndScatterOp: StableHLO_Op<"select_and_scatter",
   let hasVerifier = 1;
 }
 
-def StableHLO_SetDimensionSizeOp: StableHLO_Op<"set_dimension_size",
-      [ConditionallySpeculatable, NoMemoryEffect,
+def StableHLO_SetDimensionSizeOp: StableHLO_Op<"set_dimension_size", [Pure,
       InferTensorType]> {
   let summary = "SetDimensionSize operation";
   let description = [{

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2204,7 +2204,8 @@ def StableHLO_CompositeOp : StableHLO_Op<"composite", [DeclareOpInterfaceMethods
   let assemblyFormat = "$name $inputs attr-dict `:` functional-type(operands, results)";
 }
 
-def StableHLO_ConvolutionOp : StableHLO_Op<"convolution", [Pure]> {
+def StableHLO_ConvolutionOp : StableHLO_Op<"convolution",
+    [ConditionallySpeculatable, NoMemoryEffect]> {
   let summary = "Convolution operation";
   let description = [{
     Computes dot products between windows of `lhs` and slices of `rhs` and
@@ -2251,6 +2252,11 @@ def StableHLO_ConvolutionOp : StableHLO_Op<"convolution", [Pure]> {
                                                  $lhs_dilation, $rhs_dilation,
                                                  $window_reversal) `}`
        attr-dict `:` functional-type(operands, results)
+  }];
+
+  let extraClassDeclaration = commonClassDeclaration # [{
+    /// Interface method for ConditionallySpeculatable.
+    mlir::Speculation::Speculatability getSpeculatability();
   }];
 }
 

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2792,7 +2792,8 @@ def StableHLO_SelectAndScatterOp: StableHLO_Op<"select_and_scatter",
   let hasVerifier = 1;
 }
 
-def StableHLO_SetDimensionSizeOp: StableHLO_Op<"set_dimension_size", [Pure,
+def StableHLO_SetDimensionSizeOp: StableHLO_Op<"set_dimension_size",
+      [ConditionallySpeculatable, NoMemoryEffect,
       InferTensorType]> {
   let summary = "SetDimensionSize operation";
   let description = [{


### PR DESCRIPTION
Relevant constraints from the spec:

```
(C10) dim(lhs, input_batch_dimension) % batch_group_count = 0.
(C11) dim(lhs, input_feature_dimension) % feature_group_count = 0.

(C14) dim(rhs, kernel_input_feature_dimension) = dim(lhs, input_feature_dimension) / feature_group_count.
(C15) dim(rhs, kernel_output_feature_dimension) % batch_group_count = 0.
(C16) dim(rhs, kernel_output_feature_dimension) % feature_group_count = 0.

(C25) dim(result, result_dim) is defined as:
* dim(lhs, input_batch_dimension) / batch_group_count if result_dim = output_batch_dimension.
* dim(rhs, kernel_output_feature_dimension) if result_dim = output_feature_dimension.
* num_windows otherwise, where:
* output_spatial_dimensions[spatial_dim] = result_dim.
* lhs_dim = input_spatial_dimensions[spatial_dim].
* rhs_dim = kernel_spatial_dimensions[spatial_dim].
* dilated_input_shape[lhs_dim] = dim(lhs, lhs_dim) = 0 ? 0 : (dim(lhs, lhs_dim) - 1) * lhs_dilation[spatial_dim] + 1.
* padded_input_shape[lhs_dim] = padding[spatial_dim, 0] + dilated_input_shape[lhs_dim] + padding[spatial_dim, 1].
* dilated_window_shape[lhs_dim] = dim(rhs, rhs_dim) = 0 ? 0 : (dim(rhs, rhs_dim) - 1) * rhs_dilation[spatial_dim] + 1.
* is_empty_window[lhs_dim] = padded_input_shape[lhs_dim] = 0 || dilated_window_shape[lhs_dim] > padded_input_shape[lhs_dim].
* num_windows = is_empty_window[lhs_dim] ? 0 : floor((padded_input_shape[lhs_dim] - dilated_window_shape[lhs_dim]) / window_strides[spatial_dim]) + 1.
```

Because of (C14), input_feature_dimension and kernel_input_feature_dimension must be static. input_batch_dimension must be static if batch_group_count > 1 (C10) or if output_batch_dimension is static (C25, first bullet). kernel_output_feature_dimension must be static if batch_group_count > 1 (C15) or feature_group_count > 1 (C16) or if output_feature_dimension is static (C25, second bullet).

Because of (C25), each spatial dimension in the output can depend on the spatial dimensions in the inputs (input + kernel), so if it is static in the output, it must be static in the inputs, otherwise mismatches could occur at runtime.