### PR TITLE
Tutorial: JAX Export to StableHLO

### DIFF
--- a/build_tools/github_actions/lint_check_license.sh
+++ b/build_tools/github_actions/lint_check_license.sh
@@ -51,6 +51,7 @@ echo
 SKIPPED_SUFFIXES=(
   .clang-format
   .gitignore
+  .ipynb
   .json
   .md
   .mlir

--- a/build_tools/github_actions/lint_whitespace_checks.sh
+++ b/build_tools/github_actions/lint_whitespace_checks.sh
@@ -40,7 +40,7 @@ if [[ $# -ne 0 ]] ; then
 fi
 
 echo "Gathering changed files..."
-mapfile -t CHANGED_FILES < <(git diff "$BASE_BRANCH" HEAD --name-only --diff-filter=d | grep -Ev '.*\.(bc|png|svg)$')
+mapfile -t CHANGED_FILES < <(git diff "$BASE_BRANCH" HEAD --name-only --diff-filter=d | grep -Ev '.*\.(bc|png|svg|ipynb)$')
 if (( ${#CHANGED_FILES[@]} == 0 )); then
   echo "No files to check."
   exit 0

--- a/docs/_toc.yaml
+++ b/docs/_toc.yaml
@@ -25,6 +25,10 @@ toc:
     path: /stablehlo/reference
   - title: Roadmap
     path: /stablehlo/roadmap
+- title: Tutorials
+  section:
+  - title: JAX Export to StableHLO
+    path: /stablehlo/tutorials/jax-export
 - title: Contributing
   section:
   - title: Governance

--- a/docs/tutorials/jax-export.ipynb
+++ b/docs/tutorials/jax-export.ipynb
@@ -1,0 +1,453 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Example: JAX Export to StableHLO\n",
+        "\n",
+        "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/openxla/stablehlo/blob/main/docs/examples/jax-export.ipynb) [![Open in Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/openxla/stablehlo/blob/main/docs/examples/jax-export.ipynb)\n",
+        "\n",
+        "## Example Setup\n",
+        "\n",
+        "### Install required dependencies\n",
+        "\n",
+        "We'll be using `jax` and `jaxlib` (JAX's XLA package), along with `flax` and `transformers` for some models to export."
+      ],
+      "metadata": {
+        "id": "_TuAgGNKt5HO"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "ENUcO6aML-Nq",
+        "collapsed": true
+      },
+      "outputs": [],
+      "source": [
+        "!pip install -U jax jaxlib flax transformers"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#@title Define `prettyprint_stablehlo` to help with MLIR printing\n",
+        "from jax._src.interpreters import mlir as jax_mlir\n",
+        "from jax._src.lib.mlir import ir\n",
+        "\n",
+        "# Prettyprint without large constants\n",
+        "def prettyprint_stablehlo(module_str):\n",
+        "  with jax_mlir.make_ir_context():\n",
+        "    stablehlo_module = ir.Module.parse(module_str, context=jax_mlir.make_ir_context())\n",
+        "    return stablehlo_module.operation.get_asm(large_elements_limit=20)"
+      ],
+      "metadata": {
+        "cellView": "form",
+        "id": "HqjeC_QSugYj"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "_Note: This helper uses a JAX internal API that may break at any time, but it serves no functional purpose in the tutorial aside from readability._"
+      ],
+      "metadata": {
+        "id": "LNlFj80UwX0D"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Export JAX model to StableHLO using `jax.export`\n",
+        "\n",
+        "In this section we'll export a very basic JAX function to StableHLO.\n",
+        "\n",
+        "The preferred API for export is `jax.experimental.export`, which uses `jax.jit` under the hood. As a rule-of-thumb, a function must be `jit`-able to be exported to StableHLO."
+      ],
+      "metadata": {
+        "id": "TEfsW69IBp_V"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Export basic JAX model to StableHLO\n",
+        "\n",
+        "Let's start by exporting a basic `plus` function to StableHLO, using `np.int32` argument types to trace the function.\n",
+        "\n",
+        "Export requires specifying shapes using `jax.ShapeDtypeStruct`, which are trivial to construct from numpy values."
+      ],
+      "metadata": {
+        "id": "3MzMjjf2iIk2"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import jax\n",
+        "from jax.experimental import export\n",
+        "import jax.numpy as jnp\n",
+        "import numpy as np\n",
+        "\n",
+        "def plus(x,y):\n",
+        "  return jnp.add(x,y)\n",
+        "\n",
+        "# Create abstract input shapes:\n",
+        "inputs = (np.int32(1), np.int32(1),)\n",
+        "input_shapes = [jax.ShapeDtypeStruct(input.shape, input.dtype) for input in inputs]\n",
+        "stablehlo_add_str = export.export(plus)(*input_shapes).mlir_module()\n",
+        "print(prettyprint_stablehlo(stablehlo_add_str))"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "v-GN3vPbvFoa",
+        "outputId": "02315a19-0fe2-496a-b6f2-5f665acca2c5"
+      },
+      "execution_count": 11,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "module @jit_plus attributes {jax.uses_shape_polymorphism = false, mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {\n",
+            "  func.func public @main(%arg0: tensor<i32> {mhlo.layout_mode = \"default\"}, %arg1: tensor<i32> {mhlo.layout_mode = \"default\"}) -> (tensor<i32> {jax.result_info = \"\", mhlo.layout_mode = \"default\"}) {\n",
+            "    %0 = stablehlo.add %arg0, %arg1 : tensor<i32>\n",
+            "    return %0 : tensor<i32>\n",
+            "  }\n",
+            "}\n",
+            "\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Export Huggingface FlaxResNet18 to StableHLO\n",
+        "\n",
+        "Now let's look at a simple model that appears in the wild, `resnet18`.\n",
+        "\n",
+        "This example will export a `flax` model from the huggingface `transformers` ResNet page, [FlaxResNetModel](https://huggingface.co/docs/transformers/en/model_doc/resnet#transformers.FlaxResNetModel). Much of this steps setup was copied from the huggingface documentation.\n",
+        "\n",
+        "The documentation also states: _\"Finally, this model supports inherent JAX features such as: **Just-In-Time (JIT) compilation** ...\"_ which means it is perfect for export.\n",
+        "\n",
+        "Similar to our very basic example, our steps for export are:\n",
+        "1. Instantiate a callable (model/function) that can be JIT'ed.\n",
+        "2. Specify shapes for export using `jax.ShapeDtypeStruct` on numpy values\n",
+        "3. Use the JAX `export` API to get a StableHLO module"
+      ],
+      "metadata": {
+        "id": "xZWVAHQzBsEM"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from transformers import AutoImageProcessor, FlaxResNetModel\n",
+        "import jax\n",
+        "import numpy as np\n",
+        "\n",
+        "# Construct flax model with sample inputs\n",
+        "resnet18 = FlaxResNetModel.from_pretrained(\"microsoft/resnet-18\", return_dict=False)\n",
+        "sample_input = np.random.randn(1, 3, 224, 224)\n",
+        "input_shape = jax.ShapeDtypeStruct(sample_input.shape, sample_input.dtype)\n",
+        "\n",
+        "# Export to StableHLO\n",
+        "stablehlo_resnet18_export = export.export(resnet18)(input_shape)\n",
+        "resnet18_stablehlo = prettyprint_stablehlo(stablehlo_resnet18_export.mlir_module())\n",
+        "print(resnet18_stablehlo[:600], \"\\n...\\n\", resnet18_stablehlo[-345:])"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "53T7jO-v_6PC",
+        "outputId": "85f4d042-0baa-48ca-be8b-5cf4c4175863"
+      },
+      "execution_count": 19,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "Some weights of the model checkpoint at microsoft/resnet-18 were not used when initializing FlaxResNetModel: {('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', '0', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', '1', 'normalization', 'bias'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', '1', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '1', 'layer', '1', 'normalization', 'mean'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', '0', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', '1', 'normalization', 'kernel'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '0', 'layer', '1', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '0', 'layer', '1', 'normalization', 'mean'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '0', 'layer', '0', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '1', 'layer', '1', 'normalization', 'mean'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '1', 'layer', '1', 'normalization', 'mean'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', '1', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', '0', 'normalization', 'kernel'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '1', 'layer', '0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', '0', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', '0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', '0', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '1', 'layer', '0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', '0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', '1', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', '1', 'normalization', 'bias'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', '1', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', '0', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', '0', 'normalization', 'bias'), ('params', 'classifier', '1', 'kernel'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', '0', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', '1', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', '0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', '0', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '1', 'layer', '1', 'normalization', 'var'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', '1', 'normalization', 'bias'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '0', 'layer', '1', 'normalization', 'var'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', '0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', '1', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', '1', 'normalization', 'kernel'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '1', 'layer', '1', 'normalization', 'mean'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '1', 'layer', '0', 'normalization', 'mean'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '1', 'layer', '0', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '0', 'layer', '1', 'normalization', 'mean'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '0', 'layer', '0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', '0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', '0', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '0', 'layer', '1', 'normalization', 'mean'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '0', 'layer', '0', 'normalization', 'mean'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '1', 'layer', '0', 'normalization', 'var'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', '0', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', '1', 'normalization', 'bias'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '0', 'layer', '0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', '1', 'normalization', 'bias'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', '1', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', '1', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', '1', 'normalization', 'bias'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', '1', 'normalization', 'bias'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', '1', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '0', 'layer', '0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', '0', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '1', 'layer', '1', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '1', 'layer', '1', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '1', 'layer', '1', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '1', 'layer', '0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', '0', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', '1', 'normalization', 'bias'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', '1', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '1', 'layer', '0', 'normalization', 'var'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', '0', 'normalization', 'kernel'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '0', 'layer', '1', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '0', 'layer', '0', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '0', 'layer', '0', 'normalization', 'var'), ('params', 'classifier', '1', 'bias'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '0', 'layer', '1', 'normalization', 'var'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', '1', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', '0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', '0', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', '1', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '0', 'layer', '1', 'normalization', 'mean'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', '0', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', '1', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', '1', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', '0', 'normalization', 'bias'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '0', 'layer', '0', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '1', 'layer', '0', 'normalization', 'var'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', '0', 'normalization', 'kernel')}\n",
+            "- This IS expected if you are initializing FlaxResNetModel from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
+            "- This IS NOT expected if you are initializing FlaxResNetModel from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n",
+            "Some weights of FlaxResNetModel were not initialized from the model checkpoint at microsoft/resnet-18 and are newly initialized: {('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', 'layer_0', 'normalization', 'bias'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '1', 'layer', 'layer_0', 'normalization', 'var'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', 'layer_0', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '0', 'layer', 'layer_0', 'normalization', 'var'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', 'layer_1', 'normalization', 'bias'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', 'layer_1', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '1', 'layer', 'layer_1', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '1', 'layer', 'layer_1', 'normalization', 'var'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', 'layer_1', 'normalization', 'bias'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', 'layer_0', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', 'layer_0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', 'layer_0', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', 'layer_1', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', 'layer_1', 'normalization', 'scale'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '1', 'layer', 'layer_1', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '1', 'layer', 'layer_1', 'normalization', 'mean'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', 'layer_0', 'normalization', 'scale'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', 'layer_0', 'normalization', 'scale'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '0', 'layer', 'layer_1', 'normalization', 'mean'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', 'layer_1', 'normalization', 'scale'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '1', 'layer', 'layer_0', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '1', 'layer', 'layer_0', 'normalization', 'var'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', 'layer_1', 'normalization', 'scale'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', 'layer_1', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', 'layer_0', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '0', 'layer', 'layer_0', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '0', 'layer', 'layer_1', 'normalization', 'mean'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', 'layer_1', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', 'layer_1', 'normalization', 'scale'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', 'layer_0', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '0', 'layer', 'layer_0', 'normalization', 'mean'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '1', 'layer', 'layer_0', 'normalization', 'var'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', 'layer_1', 'normalization', 'bias'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '1', 'layer', 'layer_1', 'normalization', 'var'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', 'layer_0', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', 'layer_0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', 'layer_1', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', 'layer_0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', 'layer_0', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '0', 'layer', 'layer_1', 'normalization', 'var'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', 'layer_1', 'normalization', 'bias'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '0', 'layer', 'layer_1', 'normalization', 'mean'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', 'layer_0', 'normalization', 'scale'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', 'layer_0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', 'layer_1', 'normalization', 'bias'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', 'layer_0', 'normalization', 'scale'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '0', 'layer', 'layer_0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', 'layer_0', 'normalization', 'scale'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '0', 'layer', 'layer_1', 'normalization', 'var'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', 'layer_1', 'normalization', 'scale'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', 'layer_1', 'normalization', 'bias'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '1', 'layer', 'layer_1', 'normalization', 'mean'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '0', 'layer', 'layer_1', 'normalization', 'mean'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '1', 'layer', 'layer_0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', 'layer_1', 'normalization', 'scale'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', 'layer_0', 'normalization', 'scale'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '1', 'layer', 'layer_0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', 'layer_0', 'normalization', 'scale'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '0', 'layer', 'layer_0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', 'layer_0', 'normalization', 'bias'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '0', 'layer', 'layer_0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', 'layer_1', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', 'layer_1', 'normalization', 'scale'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '0', 'layer', 'layer_1', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '1', 'layer', 'layer_1', 'normalization', 'mean'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', 'layer_0', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '1', 'layer', 'layer_1', 'normalization', 'mean'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', 'layer_1', 'normalization', 'scale'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', 'layer_1', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', 'layer_0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', 'layer_0', 'normalization', 'scale'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '0', 'layer', 'layer_0', 'normalization', 'var'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', 'layer_0', 'normalization', 'bias'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '1', 'layer', 'layer_0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', 'layer_1', 'normalization', 'bias'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', 'layer_1', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '0', 'layer', 'layer_0', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '0', 'layer', 'layer_1', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '1', 'layer', 'layer_0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', 'layer_1', 'normalization', 'bias')}\n",
+            "You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "module @jit__unnamed_wrapped_function_ attributes {jax.uses_shape_polymorphism = false, mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {\n",
+            "  func.func public @main(%arg0: tensor<1x3x224x224xf32> {mhlo.layout_mode = \"default\"}) -> (tensor<1x512x7x7xf32> {mhlo.layout_mode = \"default\"}, tensor<1x512x1x1xf32> {mhlo.layout_mode = \"default\"}) {\n",
+            "    %0 = stablehlo.constant dense_resource<__elided__> : tensor<7x7x3x64xf32>\n",
+            "    %1 = stablehlo.constant dense_resource<__elided__> : tensor<64xf32>\n",
+            "    %2 = stablehlo.constant dense_resource<__elided__> : tensor<64xf32>\n",
+            "    %3 = stablehlo.constan \n",
+            "...\n",
+            " }\n",
+            "  func.func private @relu_3(%arg0: tensor<1x7x7x512xf32>) -> tensor<1x7x7x512xf32> {\n",
+            "    %0 = stablehlo.constant dense<0.000000e+00> : tensor<f32>\n",
+            "    %1 = stablehlo.broadcast_in_dim %0, dims = [] : (tensor<f32>) -> tensor<1x7x7x512xf32>\n",
+            "    %2 = stablehlo.maximum %arg0, %1 : tensor<1x7x7x512xf32>\n",
+            "    return %2 : tensor<1x7x7x512xf32>\n",
+            "  }\n",
+            "}\n",
+            "\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Export with dynamic batch size\n",
+        "\n",
+        "Not let's export that same model with a dynamic batch size!\n",
+        "\n",
+        "In the first example we used an input shape of `tensor<1x3x224x224xf32>`, specifying strict constraints on the input shape. If we wanted to defer the concerete shapes used in compilation until a later point, we can specify a `symbolic_shape`, in this case we'll export using `tensor<?x3x224x224xf32>`.\n",
+        "\n",
+        "Symbolic shapes are specified using `export.symbolic_shape`, with letters representing symint dimensions. For example, a valid 2-d matrix multiplication could use symbolic constraints of: `2,a * a,5` to ensure the refined program will have valid shapes. Symbolic integer names are kept track of by an `export.SymbolicScope` to avoid unintentional name clashes."
+      ],
+      "metadata": {
+        "id": "X2MC9F7Zlx6E"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "dyn_scope = export.SymbolicScope()\n",
+        "dyn_input_shape = jax.ShapeDtypeStruct(export.symbolic_shape(\"a,3,224,224\", scope=dyn_scope), np.float32)\n",
+        "dyn_resnet18_export = export.export(resnet18)(dyn_input_shape)\n",
+        "dyn_resnet18_stablehlo = prettyprint_stablehlo(dyn_resnet18_export.mlir_module())\n",
+        "print(dyn_resnet18_stablehlo[:1900], \"\\n...\\n\", dyn_resnet18_stablehlo[-1000:])"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "sIkbtViEMJ3T",
+        "outputId": "4c45fe23-4565-4810-b28c-b32924ac7a74"
+      },
+      "execution_count": 25,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "module @jit__unnamed_wrapped_function_ attributes {jax.uses_shape_polymorphism = true, mhlo.num_partitions = 1 : i32, mhlo.num_replicas = 1 : i32} {\n",
+            "  func.func public @main(%arg0: tensor<?x3x224x224xf32> {mhlo.layout_mode = \"default\"}) -> (tensor<?x512x7x7xf32> {mhlo.layout_mode = \"default\"}, tensor<?x512x1x1xf32> {mhlo.layout_mode = \"default\"}) {\n",
+            "    %0 = stablehlo.get_dimension_size %arg0, dim = 0 : (tensor<?x3x224x224xf32>) -> tensor<i32>\n",
+            "    %1 = stablehlo.constant dense<1> : tensor<i32>\n",
+            "    %2 = stablehlo.compare  GE, %0, %1,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>\n",
+            "    stablehlo.custom_call @shape_assertion(%2, %0) {api_version = 2 : i32, error_message = \"Input shapes do not match the polymorphic shapes specification. Expected value >= 1 for dimension variable 'a'. Using the following polymorphic shapes specifications: args[0].shape = (a, 3, 224, 224). Obtained dimension variables: 'a' = {0} from specification 'a' for dimension args[0].shape[0] (= {0}), . Please see https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#shape-assertion-errors for more details.\", has_side_effect = true} : (tensor<i1>, tensor<i32>) -> ()\n",
+            "    %3:2 = call @_wrapped_jax_export_main(%0, %arg0) : (tensor<i32>, tensor<?x3x224x224xf32>) -> (tensor<?x512x7x7xf32>, tensor<?x512x1x1xf32>)\n",
+            "    return %3#0, %3#1 : tensor<?x512x7x7xf32>, tensor<?x512x1x1xf32>\n",
+            "  }\n",
+            "  func.func private @_wrapped_jax_export_main(%arg0: tensor<i32> {jax.global_constant = \"a\"}, %arg1: tensor<?x3x224x224xf32> {mhlo.layout_mode = \"default\"}) -> (tensor<?x512x7x7xf32> {mhlo.layout_mode = \"default\"}, tensor<?x512x1x1xf32> {mhlo.layout_mode = \"default\"}) {\n",
+            "    %0 = stablehlo.constant dense_resource<__elided__> : tensor<7x7x3x64xf32>\n",
+            "    %1 = stablehlo.constant dense_resource<__elided__> : tensor<64xf32>\n",
+            "    %2 = stablehlo.constant dense_resource<__elided__> : tensor<64xf32>\n",
+            "    %3 = stablehl \n",
+            "...\n",
+            " <?x14x14x256xf32>\n",
+            "    return %10 : tensor<?x14x14x256xf32>\n",
+            "  }\n",
+            "  func.func private @relu_3(%arg0: tensor<i32> {jax.global_constant = \"a\"}, %arg1: tensor<?x7x7x512xf32>) -> tensor<?x7x7x512xf32> {\n",
+            "    %0 = stablehlo.constant dense<0.000000e+00> : tensor<f32>\n",
+            "    %1 = stablehlo.constant dense<7> : tensor<i32>\n",
+            "    %2 = stablehlo.constant dense<7> : tensor<i32>\n",
+            "    %3 = stablehlo.constant dense<512> : tensor<i32>\n",
+            "    %4 = stablehlo.reshape %arg0 : (tensor<i32>) -> tensor<1xi32>\n",
+            "    %5 = stablehlo.constant dense<7> : tensor<1xi32>\n",
+            "    %6 = stablehlo.constant dense<7> : tensor<1xi32>\n",
+            "    %7 = stablehlo.constant dense<512> : tensor<1xi32>\n",
+            "    %8 = stablehlo.concatenate %4, %5, %6, %7, dim = 0 : (tensor<1xi32>, tensor<1xi32>, tensor<1xi32>, tensor<1xi32>) -> tensor<4xi32>\n",
+            "    %9 = stablehlo.dynamic_broadcast_in_dim %0, %8, dims = [] : (tensor<f32>, tensor<4xi32>) -> tensor<?x7x7x512xf32>\n",
+            "    %10 = stablehlo.maximum %arg1, %9 : tensor<?x7x7x512xf32>\n",
+            "    return %10 : tensor<?x7x7x512xf32>\n",
+            "  }\n",
+            "}\n",
+            "\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "A few things to note in the exported StableHLO:\n",
+        "\n",
+        "1. The exported program now has `tensor<?x3x224x224xf32>`. These input types can be refined in many ways: SavedModel execution takes care of refinement which we'll see in the next example, but StableHLO also has APIs to [refine shapes](https://github.com/openxla/stablehlo/blob/541db997e449dcfee8536043dfdd49bb13f9ed1a/stablehlo/transforms/Passes.td#L69-L99) and [canonicalize dynamic programs](https://github.com/openxla/stablehlo/blob/541db997e449dcfee8536043dfdd49bb13f9ed1a/stablehlo/transforms/Passes.td#L18-L28) to static programs.\n",
+        "2. JAX will generated guards to ensure the values of `a` are valid, in this case `a > 1` is checked. These can be washed away at compile time once refined."
+      ],
+      "metadata": {
+        "id": "dRIu7xlSoDUK"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Export to SavedModel\n",
+        "\n",
+        "It is common to want to export a StableHLO model to SavedModel for interop with existing compilation pipelines, existing TF tooling, or serving via [TF Serving](https://github.com/tensorflow/serving).\n",
+        "\n",
+        "It is easy to pack StableHLO into a SavedModel, and load that SavedModel in the future. For this section we'll be using our dynamic model from the previous section."
+      ],
+      "metadata": {
+        "id": "xFU5M6Xm1U8_"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Install latest TF\n",
+        "\n",
+        "SavedModel definition lives in TF, so we need to install the dependency. We recommend using `tensorflow-cpu` or `tf-nightly`."
+      ],
+      "metadata": {
+        "id": "Gt_bIJaSpsYf"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install tensorflow-cpu"
+      ],
+      "metadata": {
+        "id": "KZEd7NavBoem",
+        "collapsed": true
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Export to SavedModel using `jax2tf`\n",
+        "\n",
+        "JAX provides a simple API for exporting StableHLO into a format that can be packaged in SavedModel in `jax.experimental.jax2tf`. This uses the `export` function under the hood, so the same `jit` requirements apply.\n",
+        "\n",
+        "Full details on `jax2tf` can be found in the [README](https://github.com/google/jax/blob/main/jax/experimental/jax2tf/README.md#jax-and-tensorflow-interoperation-jax2tfcall_tf), for this example we'll only need to know the `polymorphic_shapes` option to specify our dynamic batch dimension."
+      ],
+      "metadata": {
+        "id": "lf7Fnsrop7BD"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from jax.experimental import jax2tf\n",
+        "import tensorflow as tf\n",
+        "\n",
+        "exported_f = jax2tf.convert(resnet18, polymorphic_shapes=[\"(a,3,224,224)\"])\n",
+        "\n",
+        "# Copied from the jax2tf README.md > Usage: saved model\n",
+        "my_model = tf.Module()\n",
+        "my_model.f = tf.function(exported_f, autograph=False).get_concrete_function(tf.TensorSpec([None, 3, 224, 224], tf.float32))\n",
+        "tf.saved_model.save(my_model, '/tmp/resnet18_tf', options=tf.saved_model.SaveOptions(experimental_custom_gradients=True))\n",
+        "\n",
+        "!ls /tmp/resnet18_tf"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "GXkgtX7QEiWa",
+        "outputId": "07272608-d48b-4336-9e70-c2efde472b20",
+        "collapsed": true
+      },
+      "execution_count": 27,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "assets\tfingerprint.pb\tsaved_model.pb\tvariables\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### Reload and call the SavedModel\n",
+        "\n",
+        "Now we can load that SavedModel and compile using our `sample_input` from a previous example.\n",
+        "\n",
+        "_Note: the restored model does *not* require JAX to run, just XLA._"
+      ],
+      "metadata": {
+        "id": "CmKABmLdrS3C"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "restored_model = tf.saved_model.load('/tmp/resnet18_tf')\n",
+        "print(\"Result shape:\", restored_model.f(tf.constant(sample_input, tf.float32))[0].shape)"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "9Az3dXXWrVDM",
+        "outputId": "cef15475-e1f2-40a6-cfd8-afa07ca07097"
+      },
+      "execution_count": 28,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "WARNING:absl:Importing a function (__inference_internal_grad_fn_605) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Result shape: (1, 512, 7, 7)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Common Troubleshooting\n",
+        "\n",
+        "If the function can be JIT'ed, then it can be exported. Focus on making `jax.jit` work first, or look in desired project for uses of JIT already (ex: [AlphaFold's `apply`](https://github.com/google-deepmind/alphafold/blob/dbe2a438ebfc6289f960292f15dbf421a05e563d/alphafold/model/model.py#L89) can be exported easily).\n",
+        "\n",
+        "See [JAX JIT Examples](https://jax.readthedocs.io/en/latest/_autosummary/jax.jit.html#Examples) for troubleshooting. The most common issue is control flow, which can often be resolved with `static_argnums` / `static_argnames` as in the linked example.\n",
+        "\n",
+        "For opening a ticket for help, include a repo using one of the above APIs, this will help get the issue resolved much quicker!"
+      ],
+      "metadata": {
+        "id": "a2Dsm2oF5jn4"
+      }
+    }
+  ]
+}

--- a/docs/tutorials/jax-export.ipynb
+++ b/docs/tutorials/jax-export.ipynb
@@ -56,11 +56,11 @@
         "    stablehlo_module = ir.Module.parse(module_str, context=jax_mlir.make_ir_context())\n",
         "    return stablehlo_module.operation.get_asm(large_elements_limit=20)\n",
         "\n",
+        "# Disable logging for better tutorial rendering\n",
         "import logging\n",
         "logging.disable(logging.WARNING)"
       ],
       "metadata": {
-        "cellView": "form",
         "id": "HqjeC_QSugYj"
       },
       "execution_count": 4,
@@ -400,7 +400,8 @@
       "cell_type": "code",
       "source": [
         "restored_model = tf.saved_model.load('/tmp/resnet18_tf')\n",
-        "print(\"Result shape:\", restored_model.f(tf.constant(sample_input, tf.float32))[0].shape)"
+        "restored_result = restored_model.f(tf.constant(sample_input, tf.float32))\n",
+        "print(\"Result shape:\", restored_result[0].shape)"
       ],
       "metadata": {
         "colab": {

--- a/docs/tutorials/jax-export.ipynb
+++ b/docs/tutorials/jax-export.ipynb
@@ -17,11 +17,11 @@
     {
       "cell_type": "markdown",
       "source": [
-        "# Example: JAX Export to StableHLO\n",
+        "# Tutorial: JAX Export to StableHLO\n",
         "\n",
         "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/openxla/stablehlo/blob/main/docs/examples/jax-export.ipynb) [![Open in Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/openxla/stablehlo/blob/main/docs/examples/jax-export.ipynb)\n",
         "\n",
-        "## Example Setup\n",
+        "## Tutorial Setup\n",
         "\n",
         "### Install required dependencies\n",
         "\n",
@@ -54,13 +54,16 @@
         "def prettyprint_stablehlo(module_str):\n",
         "  with jax_mlir.make_ir_context():\n",
         "    stablehlo_module = ir.Module.parse(module_str, context=jax_mlir.make_ir_context())\n",
-        "    return stablehlo_module.operation.get_asm(large_elements_limit=20)"
+        "    return stablehlo_module.operation.get_asm(large_elements_limit=20)\n",
+        "\n",
+        "import logging\n",
+        "logging.disable(logging.WARNING)"
       ],
       "metadata": {
         "cellView": "form",
         "id": "HqjeC_QSugYj"
       },
-      "execution_count": null,
+      "execution_count": 4,
       "outputs": []
     },
     {
@@ -120,9 +123,9 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "v-GN3vPbvFoa",
-        "outputId": "02315a19-0fe2-496a-b6f2-5f665acca2c5"
+        "outputId": "0d434553-6332-4e9e-fb1b-5cd07db5dab0"
       },
-      "execution_count": 11,
+      "execution_count": 2,
       "outputs": [
         {
           "output_type": "stream",
@@ -167,6 +170,7 @@
         "import numpy as np\n",
         "\n",
         "# Construct flax model with sample inputs\n",
+        "\n",
         "resnet18 = FlaxResNetModel.from_pretrained(\"microsoft/resnet-18\", return_dict=False)\n",
         "sample_input = np.random.randn(1, 3, 224, 224)\n",
         "input_shape = jax.ShapeDtypeStruct(sample_input.shape, sample_input.dtype)\n",
@@ -181,21 +185,10 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "53T7jO-v_6PC",
-        "outputId": "85f4d042-0baa-48ca-be8b-5cf4c4175863"
+        "outputId": "4567e611-f02d-4121-fd82-3fd66e6bec75"
       },
-      "execution_count": 19,
+      "execution_count": 5,
       "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Some weights of the model checkpoint at microsoft/resnet-18 were not used when initializing FlaxResNetModel: {('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', '0', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', '1', 'normalization', 'bias'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', '1', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '1', 'layer', '1', 'normalization', 'mean'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', '0', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', '1', 'normalization', 'kernel'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '0', 'layer', '1', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '0', 'layer', '1', 'normalization', 'mean'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '0', 'layer', '0', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '1', 'layer', '1', 'normalization', 'mean'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '1', 'layer', '1', 'normalization', 'mean'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', '1', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', '0', 'normalization', 'kernel'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '1', 'layer', '0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', '0', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', '0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', '0', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '1', 'layer', '0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', '0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', '1', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', '1', 'normalization', 'bias'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', '1', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', '0', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', '0', 'normalization', 'bias'), ('params', 'classifier', '1', 'kernel'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', '0', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', '1', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', '0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', '0', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '1', 'layer', '1', 'normalization', 'var'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', '1', 'normalization', 'bias'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '0', 'layer', '1', 'normalization', 'var'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', '0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', '1', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', '1', 'normalization', 'kernel'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '1', 'layer', '1', 'normalization', 'mean'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '1', 'layer', '0', 'normalization', 'mean'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '1', 'layer', '0', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '0', 'layer', '1', 'normalization', 'mean'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '0', 'layer', '0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', '0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', '0', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '0', 'layer', '1', 'normalization', 'mean'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '0', 'layer', '0', 'normalization', 'mean'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '1', 'layer', '0', 'normalization', 'var'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', '0', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', '1', 'normalization', 'bias'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '0', 'layer', '0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', '1', 'normalization', 'bias'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', '1', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', '1', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', '1', 'normalization', 'bias'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', '1', 'normalization', 'bias'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', '1', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '0', 'layer', '0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', '0', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '1', 'layer', '1', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '1', 'layer', '1', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '1', 'layer', '1', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '1', 'layer', '0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', '0', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', '1', 'normalization', 'bias'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', '1', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '1', 'layer', '0', 'normalization', 'var'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', '0', 'normalization', 'kernel'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '0', 'layer', '1', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '0', 'layer', '0', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '0', 'layer', '0', 'normalization', 'var'), ('params', 'classifier', '1', 'bias'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '0', 'layer', '1', 'normalization', 'var'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', '1', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', '0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', '0', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', '1', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '0', 'layer', '1', 'normalization', 'mean'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', '0', 'normalization', 'kernel'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', '1', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', '1', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', '0', 'normalization', 'bias'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '0', 'layer', '0', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '1', 'layer', '0', 'normalization', 'var'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', '0', 'normalization', 'kernel')}\n",
-            "- This IS expected if you are initializing FlaxResNetModel from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
-            "- This IS NOT expected if you are initializing FlaxResNetModel from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n",
-            "Some weights of FlaxResNetModel were not initialized from the model checkpoint at microsoft/resnet-18 and are newly initialized: {('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', 'layer_0', 'normalization', 'bias'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '1', 'layer', 'layer_0', 'normalization', 'var'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', 'layer_0', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '0', 'layer', 'layer_0', 'normalization', 'var'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', 'layer_1', 'normalization', 'bias'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', 'layer_1', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '1', 'layer', 'layer_1', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '1', 'layer', 'layer_1', 'normalization', 'var'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', 'layer_1', 'normalization', 'bias'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', 'layer_0', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', 'layer_0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', 'layer_0', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', 'layer_1', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', 'layer_1', 'normalization', 'scale'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '1', 'layer', 'layer_1', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '1', 'layer', 'layer_1', 'normalization', 'mean'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', 'layer_0', 'normalization', 'scale'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', 'layer_0', 'normalization', 'scale'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '0', 'layer', 'layer_1', 'normalization', 'mean'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', 'layer_1', 'normalization', 'scale'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '1', 'layer', 'layer_0', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '1', 'layer', 'layer_0', 'normalization', 'var'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', 'layer_1', 'normalization', 'scale'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', 'layer_1', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', 'layer_0', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '0', 'layer', 'layer_0', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '0', 'layer', 'layer_1', 'normalization', 'mean'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', 'layer_1', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', 'layer_1', 'normalization', 'scale'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', 'layer_0', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '0', 'layer', 'layer_0', 'normalization', 'mean'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '1', 'layer', 'layer_0', 'normalization', 'var'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', 'layer_1', 'normalization', 'bias'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '1', 'layer', 'layer_1', 'normalization', 'var'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', 'layer_0', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', 'layer_0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', 'layer_1', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', 'layer_0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', 'layer_0', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '0', 'layer', 'layer_1', 'normalization', 'var'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', 'layer_1', 'normalization', 'bias'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '0', 'layer', 'layer_1', 'normalization', 'mean'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', 'layer_0', 'normalization', 'scale'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', 'layer_0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', 'layer_1', 'normalization', 'bias'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', 'layer_0', 'normalization', 'scale'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '0', 'layer', 'layer_0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', 'layer_0', 'normalization', 'scale'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '0', 'layer', 'layer_1', 'normalization', 'var'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', 'layer_1', 'normalization', 'scale'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', 'layer_1', 'normalization', 'bias'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '1', 'layer', 'layer_1', 'normalization', 'mean'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '0', 'layer', 'layer_1', 'normalization', 'mean'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '1', 'layer', 'layer_0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', 'layer_1', 'normalization', 'scale'), ('params', 'encoder', 'stages', '3', 'layers', '1', 'layer', 'layer_0', 'normalization', 'scale'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '1', 'layer', 'layer_0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', 'layer_0', 'normalization', 'scale'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '0', 'layer', 'layer_0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', 'layer_0', 'normalization', 'bias'), ('batch_stats', 'encoder', 'stages', '2', 'layers', '0', 'layer', 'layer_0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', 'layer_1', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '0', 'layers', '1', 'layer', 'layer_1', 'normalization', 'scale'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '0', 'layer', 'layer_1', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '1', 'layer', 'layer_1', 'normalization', 'mean'), ('params', 'encoder', 'stages', '2', 'layers', '0', 'layer', 'layer_0', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '3', 'layers', '1', 'layer', 'layer_1', 'normalization', 'mean'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', 'layer_1', 'normalization', 'scale'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', 'layer_1', 'convolution', 'kernel'), ('params', 'encoder', 'stages', '3', 'layers', '0', 'layer', 'layer_0', 'normalization', 'bias'), ('params', 'encoder', 'stages', '2', 'layers', '1', 'layer', 'layer_0', 'normalization', 'scale'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '0', 'layer', 'layer_0', 'normalization', 'var'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', 'layer_0', 'normalization', 'bias'), ('batch_stats', 'encoder', 'stages', '0', 'layers', '1', 'layer', 'layer_0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '1', 'layers', '0', 'layer', 'layer_1', 'normalization', 'bias'), ('params', 'encoder', 'stages', '0', 'layers', '0', 'layer', 'layer_1', 'convolution', 'kernel'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '0', 'layer', 'layer_0', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '0', 'layer', 'layer_1', 'normalization', 'var'), ('batch_stats', 'encoder', 'stages', '1', 'layers', '1', 'layer', 'layer_0', 'normalization', 'mean'), ('params', 'encoder', 'stages', '1', 'layers', '1', 'layer', 'layer_1', 'normalization', 'bias')}\n",
-            "You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.\n"
-          ]
-        },
         {
           "output_type": "stream",
           "name": "stdout",
@@ -249,9 +242,9 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "sIkbtViEMJ3T",
-        "outputId": "4c45fe23-4565-4810-b28c-b32924ac7a74"
+        "outputId": "a1da7467-4adb-44cf-f861-c482bbc7fc82"
       },
-      "execution_count": 25,
+      "execution_count": 6,
       "outputs": [
         {
           "output_type": "stream",
@@ -376,10 +369,10 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "GXkgtX7QEiWa",
-        "outputId": "07272608-d48b-4336-9e70-c2efde472b20",
+        "outputId": "930b87c6-d0cb-4363-ccce-5510543ee7d9",
         "collapsed": true
       },
-      "execution_count": 27,
+      "execution_count": 7,
       "outputs": [
         {
           "output_type": "stream",
@@ -414,17 +407,10 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "9Az3dXXWrVDM",
-        "outputId": "cef15475-e1f2-40a6-cfd8-afa07ca07097"
+        "outputId": "c3f4fd83-8461-4386-8907-dd91942312bb"
       },
-      "execution_count": 28,
+      "execution_count": 8,
       "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "WARNING:absl:Importing a function (__inference_internal_grad_fn_605) with ops with unsaved custom gradients. Will likely fail if a gradient is requested.\n"
-          ]
-        },
         {
           "output_type": "stream",
           "name": "stdout",

--- a/docs/tutorials/jax-export.ipynb
+++ b/docs/tutorials/jax-export.ipynb
@@ -17,7 +17,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "# Tutorial: JAX Export to StableHLO\n",
+        "# Tutorial: Exporting StableHLO from JAX\n",
         "\n",
         "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/openxla/stablehlo/blob/main/docs/examples/jax-export.ipynb) [![Open in Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://kaggle.com/kernels/welcome?src=https://github.com/openxla/stablehlo/blob/main/docs/examples/jax-export.ipynb)\n",
         "\n",
@@ -46,12 +46,12 @@
     {
       "cell_type": "code",
       "source": [
-        "#@title Define `prettyprint_stablehlo` to help with MLIR printing\n",
+        "#@title Define `get_stablehlo_asm` to help with MLIR printing\n",
         "from jax._src.interpreters import mlir as jax_mlir\n",
         "from jax._src.lib.mlir import ir\n",
         "\n",
-        "# Prettyprint without large constants\n",
-        "def prettyprint_stablehlo(module_str):\n",
+        "# Returns prettyprint of StableHLO module without large constants\n",
+        "def get_stablehlo_asm(module_str):\n",
         "  with jax_mlir.make_ir_context():\n",
         "    stablehlo_module = ir.Module.parse(module_str, context=jax_mlir.make_ir_context())\n",
         "    return stablehlo_module.operation.get_asm(large_elements_limit=20)\n",
@@ -61,9 +61,10 @@
         "logging.disable(logging.WARNING)"
       ],
       "metadata": {
-        "id": "HqjeC_QSugYj"
+        "id": "HqjeC_QSugYj",
+        "cellView": "form"
       },
-      "execution_count": 4,
+      "execution_count": 2,
       "outputs": []
     },
     {
@@ -115,17 +116,17 @@
         "# Create abstract input shapes:\n",
         "inputs = (np.int32(1), np.int32(1),)\n",
         "input_shapes = [jax.ShapeDtypeStruct(input.shape, input.dtype) for input in inputs]\n",
-        "stablehlo_add_str = export.export(plus)(*input_shapes).mlir_module()\n",
-        "print(prettyprint_stablehlo(stablehlo_add_str))"
+        "stablehlo_add = export.export(plus)(*input_shapes).mlir_module()\n",
+        "print(get_stablehlo_asm(stablehlo_add))"
       ],
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "v-GN3vPbvFoa",
-        "outputId": "0d434553-6332-4e9e-fb1b-5cd07db5dab0"
+        "outputId": "b128c08f-3591-4142-fd67-561812bb3d4e"
       },
-      "execution_count": 2,
+      "execution_count": 3,
       "outputs": [
         {
           "output_type": "stream",
@@ -177,7 +178,7 @@
         "\n",
         "# Export to StableHLO\n",
         "stablehlo_resnet18_export = export.export(resnet18)(input_shape)\n",
-        "resnet18_stablehlo = prettyprint_stablehlo(stablehlo_resnet18_export.mlir_module())\n",
+        "resnet18_stablehlo = get_stablehlo_asm(stablehlo_resnet18_export.mlir_module())\n",
         "print(resnet18_stablehlo[:600], \"\\n...\\n\", resnet18_stablehlo[-345:])"
       ],
       "metadata": {
@@ -185,7 +186,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "53T7jO-v_6PC",
-        "outputId": "4567e611-f02d-4121-fd82-3fd66e6bec75"
+        "outputId": "0536386d-09d2-49a3-b51c-951c20f6e49b"
       },
       "execution_count": 5,
       "outputs": [
@@ -234,7 +235,7 @@
         "dyn_scope = export.SymbolicScope()\n",
         "dyn_input_shape = jax.ShapeDtypeStruct(export.symbolic_shape(\"a,3,224,224\", scope=dyn_scope), np.float32)\n",
         "dyn_resnet18_export = export.export(resnet18)(dyn_input_shape)\n",
-        "dyn_resnet18_stablehlo = prettyprint_stablehlo(dyn_resnet18_export.mlir_module())\n",
+        "dyn_resnet18_stablehlo = get_stablehlo_asm(dyn_resnet18_export.mlir_module())\n",
         "print(dyn_resnet18_stablehlo[:1900], \"\\n...\\n\", dyn_resnet18_stablehlo[-1000:])"
       ],
       "metadata": {
@@ -242,7 +243,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "sIkbtViEMJ3T",
-        "outputId": "a1da7467-4adb-44cf-f861-c482bbc7fc82"
+        "outputId": "165019c7-e771-43d6-c324-6bb4222798ec"
       },
       "execution_count": 6,
       "outputs": [
@@ -294,7 +295,7 @@
         "A few things to note in the exported StableHLO:\n",
         "\n",
         "1. The exported program now has `tensor<?x3x224x224xf32>`. These input types can be refined in many ways: SavedModel execution takes care of refinement which we'll see in the next example, but StableHLO also has APIs to [refine shapes](https://github.com/openxla/stablehlo/blob/541db997e449dcfee8536043dfdd49bb13f9ed1a/stablehlo/transforms/Passes.td#L69-L99) and [canonicalize dynamic programs](https://github.com/openxla/stablehlo/blob/541db997e449dcfee8536043dfdd49bb13f9ed1a/stablehlo/transforms/Passes.td#L18-L28) to static programs.\n",
-        "2. JAX will generated guards to ensure the values of `a` are valid, in this case `a > 1` is checked. These can be washed away at compile time once refined."
+        "2. JAX will generate guards to ensure the values of `a` are valid, in this case `a > 1` is checked. These can be washed away at compile time once refined."
       ],
       "metadata": {
         "id": "dRIu7xlSoDUK"
@@ -369,7 +370,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "GXkgtX7QEiWa",
-        "outputId": "930b87c6-d0cb-4363-ccce-5510543ee7d9",
+        "outputId": "9034836e-4ba1-4210-c2c1-316777d4ad89",
         "collapsed": true
       },
       "execution_count": 7,
@@ -408,7 +409,7 @@
           "base_uri": "https://localhost:8080/"
         },
         "id": "9Az3dXXWrVDM",
-        "outputId": "c3f4fd83-8461-4386-8907-dd91942312bb"
+        "outputId": "cac6d3b1-126e-4e66-dc4d-f2a798ede463"
       },
       "execution_count": 8,
       "outputs": [


### PR DESCRIPTION
See tutorial rendering using "View File" ([example](https://github.com/openxla/stablehlo/blob/f85d9fffc3d4e0fe4f09bfadd4739d09baaf60c1/docs/tutorials/jax-export.ipynb)).

Once merged the "Open in Colab" button should work. Also once integrated this should appear on the openxla.org documentation as well.