### PR TITLE
Add compile_commands flag to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Here's how to build the StableHLO repo on Linux or macOS:
      -DSTABLEHLO_ENABLE_SPLIT_DWARF=ON \
      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
      -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
      -DSTABLEHLO_ENABLE_SANITIZER=address \
      -DMLIR_DIR=${PWD}/../llvm-build/lib/cmake/mlir
 


### PR DESCRIPTION
We don't provide documentation on how to generate compile_commands.json and this could be a useful start. I left this flag out of CI since the CI doesn't need to generate this.