### PR TITLE
Add TF dependency to wheel build action

### DIFF
--- a/.github/workflows/publishWheelRelease.yml
+++ b/.github/workflows/publishWheelRelease.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
   schedule:
     # Runs at 6:00 AM UTC, which is 10:00 PM previous day PST (UTC-8)
-    - cron: '0 6 * * *' 
+    - cron: '0 6 * * *'
 
 # Ensure that only a single job or workflow using the same
 # concurrency group will run at a time. This would cancel
@@ -93,7 +93,7 @@ jobs:
       shell: bash
       run: |
         ./build_tools/github_actions/ci_build_python_wheel.sh "$GITHUB_WORKSPACE/${{ github.sha }}"
-    
+
     - name: Upload an artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/publishWheelRelease.yml
+++ b/.github/workflows/publishWheelRelease.yml
@@ -83,6 +83,7 @@ jobs:
     - name: Build and Test StableHLO with Python
       shell: bash
       run: |
+        pip install tensorflow-cpu
         ./build_tools/github_actions/ci_build_cmake.sh "$LLVM_BUILD_DIR" "$STABLEHLO_BUILD_DIR"
       env:
           CMAKE_BUILD_TYPE: Release


### PR DESCRIPTION
We want to run all python tests before publishing a wheel. Running all tests has a TF dependency to run savedmodel tests.

See:
https://github.com/openxla/stablehlo/actions/runs/8807435054/job/24174472438