### PR TITLE
Include command to build StableHLO with python bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ pip install  install -r ./llvm-project/mlir/python/requirements.txt
 ```
 
 Then build StableHLO with python bindings enabled:
+
 ```sh
 STABLEHLO_ENABLE_BINDINGS_PYTHON=ON ./build_tools/github_actions/ci_build_cmake.sh ${PWD}/llvm-build ${PWD}/build
 ```

--- a/README.md
+++ b/README.md
@@ -143,8 +143,10 @@ additional dependencies.
 pip install  install -r ./llvm-project/mlir/python/requirements.txt
 ```
 
-If you've built MLIR & StableHLO using the script above, the Python bindings
-for MLIR may already built.
+Then build StableHLO with python bindings enabled:
+```sh
+STABLEHLO_ENABLE_BINDINGS_PYTHON=ON ./build_tools/github_actions/ci_build_cmake.sh ${PWD}/llvm-build ${PWD}/build
+```
 
 After you have built the project you can import the Python bindings to begin
 by modifying your Python path variable


### PR DESCRIPTION
The doc originally stated that the script preceding the instruction may have already built MLIR with python bindings, but that isn't true. I've included the actual command that builds with python bindings.