### PR TITLE
Add spec and verifier for quantized dot_general op

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2200,33 +2200,33 @@ For hybrid quantized types, performs `hybrid_dequantize_then_op(
 
 #### Inputs
 
-| Label | Name                              | Type                                                         | Constraints                             |
-|-------|-----------------------------------|--------------------------------------------------------------|-----------------------------------------|
-| (I1)  | `lhs`                             | tensor or per-tensor quantized tensor                        | (C1), (C10-C11), (C14) (C25), (C27-C30) |
-| (I2)  | `rhs`                             | tensor or quantized tensor                                   | (C1), (C14-C16), (C25), (C27-C32)       |
-| (I3)  | `window_strides`                  | 1-dimensional tensor constant of type `si64`                 | (C2-C3), (C25)                          |
-| (I4)  | `padding`                         | 2-dimensional tensor constant of type `si64`                 | (C4), (C25)                             |
-| (I5)  | `lhs_dilation`                    | 1-dimensional tensor constant of type `si64`                 | (C5-C6), (C25)                          |
-| (I6)  | `rhs_dilation`                    | 1-dimensional tensor constant of type `si64`                 | (C7-C8), (C25)                          |
-| (I7)  | `window_reversal`                 | 1-dimensional tensor constant of type `i1`                   | (C9)                                    |
-| (I8)  | `input_batch_dimension`           | constant of type `si64`                                      | (C10), (C13), (C25)                     |
-| (I9)  | `input_feature_dimension`         | constant of type `si64`                                      | (C11), (C13-C14)                        |
-| (I10) | `input_spatial_dimensions`        | 1-dimensional tensor constant of type `si64`                 | (C12), (C13), (C25)                     |
-| (I11) | `kernel_input_feature_dimension`  | constant of type `si64`                                      | (C14), (C18)                            |
-| (I12) | `kernel_output_feature_dimension` | constant of type `si64`                                      | (C15-C16), (C18), (C25), (C32)          |
-| (I13) | `kernel_spatial_dimensions`       | 1-dimensional tensor constant of type `si64`                 | (C17-C18), (C25)                        |
-| (I14) | `output_batch_dimension`          | constant of type `si64`                                      | (C20), (C25)                            |
-| (I15) | `output_feature_dimension`        | constant of type `si64`                                      | (C20), (C25), (C33)                     |
-| (I16) | `output_spatial_dimensions`       | 1-dimensional tensor constant of type `si64`                 | (C19-C20), (C25)                        |
-| (I17) | `feature_group_count`             | constant of type `si64`                                      | (C11), (C14), (C16), (C21), (C23)       |
-| (I18) | `batch_group_count`               | constant of type `si64`                                      | (C10), (C15), (C22), (C23), (C25)       |
-| (I19) | `precision_config`                | variadic number of enums of `DEFAULT`, `HIGH`, and `HIGHEST` | (C24)                                   |
+| Label | Name                              | Type                                                         | Constraints                                               |
+|-------|-----------------------------------|--------------------------------------------------------------|-----------------------------------------------------------|
+| (I1)  | `lhs`                             | tensor or per-tensor quantized tensor                        | (C1), (C10-C11), (C14) (C25), (C27-C28), (C31-C32), (C34) |
+| (I2)  | `rhs`                             | tensor or quantized tensor                                   | (C1), (C14-C16), (C25), (C27-C29), (C31-C34)              |
+| (I3)  | `window_strides`                  | 1-dimensional tensor constant of type `si64`                 | (C2-C3), (C25)                                            |
+| (I4)  | `padding`                         | 2-dimensional tensor constant of type `si64`                 | (C4), (C25)                                               |
+| (I5)  | `lhs_dilation`                    | 1-dimensional tensor constant of type `si64`                 | (C5-C6), (C25)                                            |
+| (I6)  | `rhs_dilation`                    | 1-dimensional tensor constant of type `si64`                 | (C7-C8), (C25)                                            |
+| (I7)  | `window_reversal`                 | 1-dimensional tensor constant of type `i1`                   | (C9)                                                      |
+| (I8)  | `input_batch_dimension`           | constant of type `si64`                                      | (C10), (C13), (C25)                                       |
+| (I9)  | `input_feature_dimension`         | constant of type `si64`                                      | (C11), (C13-C14)                                          |
+| (I10) | `input_spatial_dimensions`        | 1-dimensional tensor constant of type `si64`                 | (C12), (C13), (C25)                                       |
+| (I11) | `kernel_input_feature_dimension`  | constant of type `si64`                                      | (C14), (C18)                                              |
+| (I12) | `kernel_output_feature_dimension` | constant of type `si64`                                      | (C15-C16), (C18), (C25), (C29)                            |
+| (I13) | `kernel_spatial_dimensions`       | 1-dimensional tensor constant of type `si64`                 | (C17-C18), (C25)                                          |
+| (I14) | `output_batch_dimension`          | constant of type `si64`                                      | (C20), (C25)                                              |
+| (I15) | `output_feature_dimension`        | constant of type `si64`                                      | (C20), (C25), (C30)                                       |
+| (I16) | `output_spatial_dimensions`       | 1-dimensional tensor constant of type `si64`                 | (C19-C20), (C25)                                          |
+| (I17) | `feature_group_count`             | constant of type `si64`                                      | (C11), (C14), (C16), (C21), (C23)                         |
+| (I18) | `batch_group_count`               | constant of type `si64`                                      | (C10), (C15), (C22), (C23), (C25)                         |
+| (I19) | `precision_config`                | variadic number of enums of `DEFAULT`, `HIGH`, and `HIGHEST` | (C24)                                                     |
 
 #### Outputs
 
 | Name     | Type                       | Constraints                 |
 |----------|----------------------------|-----------------------------|
-| `result` | tensor or quantized tensor | (C25-C28), (C30-C31), (C33) |
+| `result` | tensor or quantized tensor | (C25-C28), (C30), (C32-34)  |
 
 #### Constraints
 
@@ -2553,21 +2553,21 @@ planning to address this in
 
 #### Inputs
 
-| Label | Name                         | Type                                                         | Constraints                    |
-|-------|------------------------------|--------------------------------------------------------------|--------------------------------|
-| (I1)  | `lhs`                        | tensor or per-tensor quantized tensor                        | (C5-C6), (C9-C10), (C12-C16)   |
-| (I2)  | `rhs`                        | tensor or quantized tensor                                   | (C7-C10), (C12), (C18-C19)     |
-| (I3)  | `lhs_batching_dimensions`    | 1-dimensional tensor constant of type `si64`                 | (C1), (C3), (C5), (C9), (C12)  |
-| (I4)  | `rhs_batching_dimensions`    | 1-dimensional tensor constant of type `si64`                 | (C1), (C4), (C7), (C9)         |
-| (I5)  | `lhs_contracting_dimensions` | 1-dimensional tensor constant of type `si64`                 | (C2), (C3), (C6), (C10)        |
-| (I6)  | `rhs_contracting_dimensions` | 1-dimensional tensor constant of type `si64`                 | (C2), (C4), (C8), (C10), (C19) |
-| (I7)  | `precision_config`           | variadic number of enums of `DEFAULT`, `HIGH`, and `HIGHEST` | (C11)                          |
+| Label | Name                         | Type                                                         | Constraints                                    |
+|-------|------------------------------|--------------------------------------------------------------|------------------------------------------------|
+| (I1)  | `lhs`                        | tensor or per-tensor quantized tensor                        | (C5-C6), (C9-C10), (C12-C14), (C17-C18), (C20) |
+| (I2)  | `rhs`                        | tensor or quantized tensor                                   | (C7-C10), (C12-C20)                            |
+| (I3)  | `lhs_batching_dimensions`    | 1-dimensional tensor constant of type `si64`                 | (C1), (C3), (C5), (C9), (C12)                  |
+| (I4)  | `rhs_batching_dimensions`    | 1-dimensional tensor constant of type `si64`                 | (C1), (C4), (C7), (C9)                         |
+| (I5)  | `lhs_contracting_dimensions` | 1-dimensional tensor constant of type `si64`                 | (C2), (C3), (C6), (C10)                        |
+| (I6)  | `rhs_contracting_dimensions` | 1-dimensional tensor constant of type `si64`                 | (C2), (C4), (C8), (C10), (C16)                 |
+| (I7)  | `precision_config`           | variadic number of enums of `DEFAULT`, `HIGH`, and `HIGHEST` | (C11)                                          |
 
 #### Outputs
 
 | Name     | Type                       | Constraints                |
 |----------|----------------------------|----------------------------|
-| `result` | tensor or quantized tensor | (C12), (C14), (C16), (C18) |
+| `result` | tensor or quantized tensor | (C12), (C14), (C18-C20)    |
 
 #### Constraints
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2602,7 +2602,6 @@ planning to address this in
   * If `!is_quantized(lhs)`:
     * (C20) `element_type(lhs) = expressed_type(rhs) = element_type(result)`.
 
-
 #### Examples
 
 ```mlir

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2191,12 +2191,12 @@ For quantized types, performs `dequantize_op_quantize(
     type(result))`.
 
 For hybrid quantized types, performs `hybrid_dequantize_then_op(
-  lambda lhs, rhs: convolution(lhs, rhs, window_strides, padding, lhs_dilation, rhs_dilation,
-window_reversal, input_batch_dimension, input_feature_dimension,
-input_spatial_dimensions, kernel_input_feature_dimension,
-kernel_output_feature_dimension, kernel_spatial_dimensions,
-output_batch_dimension, output_feature_dimension, output_spatial_dimensions,
-feature_group_count, batch_group_count, precision_config), lhs, rhs)`.
+    lambda lhs, rhs: convolution(lhs, rhs, window_strides, padding, lhs_dilation,
+        rhs_dilation, window_reversal, input_batch_dimension, input_feature_dimension,
+        input_spatial_dimensions, kernel_input_feature_dimension,
+        kernel_output_feature_dimension, kernel_spatial_dimensions,
+        output_batch_dimension, output_feature_dimension, output_spatial_dimensions,
+        feature_group_count, batch_group_count, precision_config), lhs, rhs)`.
 
 #### Inputs
 
@@ -2533,10 +2533,10 @@ For quantized types, performs `dequantize_op_quantize(
         rhs_batching_dimensions, lhs_contracting_dimensions,
         rhs_contracting_dimensions, precision_config), lhs, rhs, type(result))`.
 
-This only specifies semantics for per-tensor quantization. Per-axis quantization
-is work in progress ([#1574](https://github.com/openxla/stablehlo/issues/1574)).
-Also, in the future we may consider adding support for hybrid quantization
- ([#1575](https://github.com/openxla/stablehlo/issues/1575)).
+For hybrid quantized types, performs `hybrid_dequantize_then_op(
+    lambda lhs, rhs: dot_general(lhs, rhs, lhs_batching_dimensions,
+        rhs_batching_dimensions, lhs_contracting_dimensions,
+        rhs_contracting_dimensions, precision_config), lhs, rhs)`.
 
 `precision_config` controls the tradeoff between speed and accuracy for
 computations on accelerator backends. This can be one of the following (at the
@@ -2590,14 +2590,18 @@ planning to address this in
 * If the operation uses non-quantized tensors:
   * (C13) `element_type(lhs) = element_type(rhs)`.
 * If the operation uses quantized tensors:
-  * (C14) `is_quantized(lhs) and is_quantized(rhs) and is_quantized(result)`.
-  * (C15) `storage_type(lhs) = storage_type(rhs)`.
-  * (C16) `expressed_type(lhs) = expressed_type(rhs) = expressed_type(result)`.
-  * (C17) `zero_points(rhs) = 0`.
-  * (C18) If `is_per_tensor_quantized(rhs)`, then
-    `is_per_tensor_quantized(result)`.
-  * (C19) If `is_per_axis_quantized(rhs)`, then
+  * (C14) `is_quantized(lhs) = is_quantized(result) and is_quantized(rhs)`.
+  * (C15) `zero_points(rhs) = 0`.
+  * (C16) If `is_per_axis_quantized(rhs)`, then
     `quantization_dimension(rhs)` not in `rhs_contracting_dimensions`.
+  * If `is_quantized(lhs)`:
+    * (C17) `storage_type(lhs) = storage_type(rhs)`.
+    * (C18) `expressed_type(lhs) = expressed_type(rhs) = expressed_type(result)`.
+    * (C19) If `is_per_tensor_quantized(rhs)`, then
+      `is_per_tensor_quantized(result)`.
+  * If `!is_quantized(lhs)`:
+    * (C20) `element_type(lhs) = expressed_type(rhs) = element_type(result)`.
+
 
 #### Examples
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -3638,7 +3638,7 @@ LogicalResult verifyDotGeneralOpQuantizationConstraints(
 
     // dot_general_c16
     if (llvm::find(rhsContractingDimensions,
-                   rhsPerAxisType.getQuantizedDimension()) !=
+                   rhsPerAxisQuantType.getQuantizedDimension()) !=
         rhsContractingDimensions.end()) {
       return emitOptionalError(location,
                                "Quantization dimension should not be a "

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -168,7 +168,7 @@ LogicalResult verifyBinaryOpQuantizationConstraints(
 LogicalResult verifyConvolutionDotGeneralCommonQuantizationConstraints(
     std::optional<Location> location, Type lhsElementType, Type rhsElementType,
     Type resultElementType) {
-  // convolution_c28
+  // convolution_c28 and dot_general_c14
   if (!isa<quant::QuantizedType>(rhsElementType) ||
       (isa<quant::QuantizedType>(lhsElementType) !=
        isa<quant::QuantizedType>(resultElementType))) {
@@ -181,19 +181,19 @@ LogicalResult verifyConvolutionDotGeneralCommonQuantizationConstraints(
   auto rhsQuantType = cast<quant::QuantizedType>(rhsElementType);
   if (auto lhsQuantType = dyn_cast<quant::QuantizedType>(lhsElementType)) {
     auto resultQuantType = cast<quant::QuantizedType>(resultElementType);
-    // convolution_c31
+    // convolution_c31 and dot_general_c17
     if (lhsQuantType.getStorageType() != rhsQuantType.getStorageType()) {
       return emitOptionalError(
           location, "mismatched lhs and rhs quantization storage types");
     }
-    // convolution_c32
+    // convolution_c32 and dot_general_c18
     if (lhsQuantType.getExpressedType() != rhsQuantType.getExpressedType() ||
         lhsQuantType.getExpressedType() != resultQuantType.getExpressedType()) {
       return emitOptionalError(
           location,
           "mismatched lhs, rhs and result quantization expressed types");
     }
-    // convolution_c33
+    // convolution_c33 and dot_general_c19
     if (isa<quant::UniformQuantizedType>(rhsQuantType) &&
         !isa<quant::UniformQuantizedType>(resultQuantType)) {
       return emitOptionalError(
@@ -201,7 +201,7 @@ LogicalResult verifyConvolutionDotGeneralCommonQuantizationConstraints(
     }
   } else {
     Type rhsExpressedType = rhsQuantType.getExpressedType();
-    // convolution_c34
+    // convolution_c34 and dot_general_c20
     if (lhsElementType != rhsExpressedType ||
         lhsElementType != resultElementType) {
       return emitOptionalError(location,
@@ -3549,7 +3549,7 @@ LogicalResult verifyConvolutionOpQuantizationConstraints(
     }
   }
 
-  // convolution_c31 - convolution_c34
+  // convolution_c28, convolution_c31 - convolution_c34
   return verifyConvolutionDotGeneralCommonQuantizationConstraints(
       location, lhsElementType, rhsElementType, resultElementType);
 }
@@ -3614,6 +3614,46 @@ LogicalResult verifyDotOp(std::optional<Location> location,
   return success();
 }
 
+LogicalResult verifyDotGeneralOpQuantizationConstraints(
+    std::optional<Location> location, Type lhsType, Type rhsType,
+    Type resultType, ArrayRef<int64_t> rhsContractingDimensions) {
+  Type lhsElementType = getElementTypeOrSelf(lhsType);
+  Type rhsElementType = getElementTypeOrSelf(rhsType);
+  Type resultElementType = getElementTypeOrSelf(resultType);
+
+  // dot_general_c15
+  if (auto rhsPerTensorQuantType =
+          dyn_cast<quant::UniformQuantizedType>(rhsElementType)) {
+    if (rhsPerTensorQuantType.getZeroPoint() != 0) {
+      return emitOptionalError(location,
+                               "Zero point of rhs of dot_general should be 0");
+    }
+  } else if (auto rhsPerAxisQuantType =
+                 dyn_cast<quant::UniformQuantizedPerAxisType>(rhsElementType)) {
+    if (llvm::any_of(rhsPerAxisQuantType.getZeroPoints(),
+                     [](int64_t zero_point) { return zero_point != 0; })) {
+      return emitOptionalError(location,
+                               "Zero points of rhs of dot_general should be 0");
+    }
+  }
+
+  // dot_general_c16
+  if (auto rhsPerAxisType =
+          dyn_cast<quant::UniformQuantizedPerAxisType>(rhsElementType)) {
+    if (llvm::find(rhsContractingDimensions,
+                   rhsPerAxisType.getQuantizedDimension()) !=
+        rhsContractingDimensions.end()) {
+      return emitOptionalError(location,
+                               "Quantization dimension should not be a "
+                               "contracting dimension of rhs");
+    }
+  }
+
+  // dot_general_c14, dot_general_c17 - dot_general_c20
+  return verifyConvolutionDotGeneralCommonQuantizationConstraints(
+      location, lhsElementType, rhsElementType, resultElementType);
+}
+
 LogicalResult verifyDotGeneralOp(std::optional<Location> location, Value lhs,
                                  Value rhs,
                                  ArrayRef<int64_t> lhsBatchingDimensions,
@@ -3636,6 +3676,13 @@ LogicalResult verifyDotGeneralOp(std::optional<Location> location, Value lhs,
     return emitOptionalError(
         location, "inferred shape '", dimSizesToString(inferredShape.getDims()),
         "' ", "is incompatible with return type of operation ", resultType, "");
+
+  Type lhsType = lhs.getType();
+  Type rhsType = rhs.getType();
+  if (anyQuantized<quant::QuantizedType>({lhsType, rhsType, resultType})) {
+    return verifyDotGeneralOpQuantizationConstraints(
+        location, lhsType, rhsType, resultType, rhsContractingDimensions);
+  }
   return success();
 }
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -3625,24 +3625,22 @@ LogicalResult verifyDotGeneralOpQuantizationConstraints(
   if (auto rhsPerTensorQuantType =
           dyn_cast<quant::UniformQuantizedType>(rhsElementType)) {
     if (rhsPerTensorQuantType.getZeroPoint() != 0) {
-      return emitOptionalError(location,
-                               "Zero point of rhs of dot_general should be 0");
+      return emitOptionalError(location, "Zero point of rhs should be 0");
     }
   } else if (auto rhsPerAxisQuantType =
                  dyn_cast<quant::UniformQuantizedPerAxisType>(rhsElementType)) {
     if (llvm::any_of(rhsPerAxisQuantType.getZeroPoints(),
                      [](int64_t zero_point) { return zero_point != 0; })) {
-      return emitOptionalError(location,
-                               "Zero points of rhs of dot_general should be 0");
+      return emitOptionalError(location, "Zero points of rhs should be 0");
     }
 
     // dot_general_c16
-    if (llvm::find(rhsContractingDimensions,
-                   rhsPerAxisQuantType.getQuantizedDimension()) !=
-        rhsContractingDimensions.end()) {
-      return emitOptionalError(location,
-                               "Quantization dimension should not be a "
-                               "contracting dimension of rhs");
+    if (llvm::is_contained(rhsContractingDimensions,
+                           rhsPerAxisQuantType.getQuantizedDimension())) {
+      return emitOptionalError(
+          location,
+          "Quantization dimension of rhs should not be in the "
+          "contracting dimension of rhs");
     }
   }
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -3635,11 +3635,8 @@ LogicalResult verifyDotGeneralOpQuantizationConstraints(
       return emitOptionalError(location,
                                "Zero points of rhs of dot_general should be 0");
     }
-  }
 
-  // dot_general_c16
-  if (auto rhsPerAxisType =
-          dyn_cast<quant::UniformQuantizedPerAxisType>(rhsElementType)) {
+    // dot_general_c16
     if (llvm::find(rhsContractingDimensions,
                    rhsPerAxisType.getQuantizedDimension()) !=
         rhsContractingDimensions.end()) {

--- a/stablehlo/tests/ops_stablehlo_quantized.mlir
+++ b/stablehlo/tests/ops_stablehlo_quantized.mlir
@@ -1095,7 +1095,7 @@ func.func @dot_general_c14(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5x!quant.
 // -----
 
 func.func @dot_general_c15_per_tensor(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5x!quant.uniform<i8:f32, 1.0:30>>) -> tensor<2x4x5xf32> {
-  // expected-error@+1 {{Zero point of rhs of dot_general should be 0}}
+  // expected-error@+1 {{Zero point of rhs should be 0}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
       lhs_batching_dimensions = [0],
@@ -1112,7 +1112,7 @@ func.func @dot_general_c15_per_tensor(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x
 func.func @dot_general_c15_per_axis(
   %arg0: tensor<2x3x4x!quant.uniform<i8:f32, 1.0:17>>,
   %arg1: tensor<2x3x5x!quant.uniform<i8:f32:0, {0.1:10}>>) -> tensor<2x4x5x!quant.uniform<i8:f32:0, {0.1:-30}>> {
-  // expected-error@+1 {{Zero points of rhs of dot_general should be 0}}
+  // expected-error@+1 {{Zero points of rhs should be 0}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
       lhs_batching_dimensions = [0],
@@ -1130,7 +1130,7 @@ func.func @dot_general_c15_per_axis(
 func.func @dot_general_c16(
   %arg0: tensor<2x3x4x!quant.uniform<i8:f32, 1.0:17>>,
   %arg1: tensor<2x3x5x!quant.uniform<i8:f32:0, {0.1:0}>>) -> tensor<2x4x5x!quant.uniform<i8:f32:0, {0.1:-30}>> {
-  // expected-error@+1 {{Quantization dimension should not be a contracting dimension of rhs}}
+  // expected-error@+1 {{Quantization dimension of rhs should not be in the contracting dimension of rhs}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {
     dot_dimension_numbers = #stablehlo.dot<
       lhs_batching_dimensions = [1],


### PR DESCRIPTION
This PR adds spec for hybrid quantized op discussed in the [RFC](https://github.com/openxla/stablehlo/pull/1792) and implements verifier accordingly.
Please feel free to take a look. Thank you!

cc @sdasgup3 @loganchien @abhigunj 