### PR TITLE
Add header for M_PI to fix windows build failure on some systems

### DIFF
--- a/stablehlo/transforms/ChloLegalizeToStablehlo.cpp
+++ b/stablehlo/transforms/ChloLegalizeToStablehlo.cpp
@@ -6,6 +6,8 @@
 
 // Implements logic for lowering CHLO ops to StableHLO and Shape dialect ops,
 // taking care of CHLO's broadcasting semantics
+#define _USE_MATH_DEFINES
+#include <cmath>
 
 #include "llvm/ADT/STLExtras.h"
 #include "mlir/Dialect/Complex/IR/Complex.h"


### PR DESCRIPTION
Once we have c++20 support we should flip this to use `std::numbers::pi` from the `<numbers>` header.