### PR TITLE
Include output shape in shape mismatch error message

### DIFF
--- a/stablehlo/dialect/Base.h
+++ b/stablehlo/dialect/Base.h
@@ -86,6 +86,10 @@ bool isCompatibleForHloTypeInference(TypeRange tp1, TypeRange tp2);
 // undefined behavior.
 bool isCompatibleForHloTypeInference(Value shape1, Type tp2);
 
+// Returns true if the given shape, expressed as a slice of integers, is
+// compatible with the given type for the purposes of HLO type inference.
+bool isCompatibleForHloTypeInference(ArrayRef<int64_t> shape1, Type tp2);
+
 // TODO(zhouxin) Move type inference related methods to TypeInference.cpp
 
 std::pair<int64_t, int64_t> inferConcatenatedDimAndBound(int64_t leftSize,

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -3792,10 +3792,18 @@ LogicalResult verifyDynamicReshapeOp(std::optional<Location> location,
     }
   }
 
-  if (!isCompatibleForHloTypeInference(outputShape, resultType))
-    return emitOptionalError(
-        location, "output_shape is incompatible with return type of operation ",
-        resultType, ": ", outputShape);
+  if (SmallVector<int64_t> shape;
+      succeeded(matchInts(outputShape, shape)) &&
+      !isCompatibleForHloTypeInference(shape, resultType)) {
+    std::string str;
+    llvm::raw_string_ostream os(str);
+    os << "[";
+    llvm::interleaveComma(shape, os, [&](int64_t i) { os << i; });
+    os << "]";
+    return emitOptionalError(location, "output_shape ", os.str(),
+                             " is incompatible with return type of operation ",
+                             resultType);
+  }
   return success();
 }
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -3795,7 +3795,7 @@ LogicalResult verifyDynamicReshapeOp(std::optional<Location> location,
   if (!isCompatibleForHloTypeInference(outputShape, resultType))
     return emitOptionalError(
         location, "output_shape is incompatible with return type of operation ",
-        resultType);
+        resultType, ": ", outputShape);
   return success();
 }
 

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -3165,7 +3165,7 @@ func.func @dynamic_reshape_incompatible_shapes(%arg0: tensor<?xf32>, %shape: ten
 // -----
 
 func.func @dynamic_reshape_output_shape_mismatching_size(%arg0: tensor<4xf32>) -> tensor<1x4xf32> {
-  // expected-error@+2 {{output_shape is incompatible with return type of operation 'tensor<1x4xf32>': %0 = "stablehlo.constant"}}
+  // expected-error@+2 {{output_shape [2, 2] is incompatible with return type of operation 'tensor<1x4xf32>'}}
   %0 = stablehlo.constant dense<[2, 2]> : tensor<2xi64>
   %1 = stablehlo.dynamic_reshape %arg0, %0 : (tensor<4xf32>, tensor<2xi64>) -> tensor<1x4xf32>
   return %1 : tensor<1x4xf32>

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -3165,7 +3165,7 @@ func.func @dynamic_reshape_incompatible_shapes(%arg0: tensor<?xf32>, %shape: ten
 // -----
 
 func.func @dynamic_reshape_output_shape_mismatching_size(%arg0: tensor<4xf32>) -> tensor<1x4xf32> {
-  // expected-error@+2 {{output_shape is incompatible with return type of operation 'tensor<1x4xf32>'}}
+  // expected-error@+2 {{output_shape is incompatible with return type of operation 'tensor<1x4xf32>': %0 = "stablehlo.constant"}}
   %0 = stablehlo.constant dense<[2, 2]> : tensor<2xi64>
   %1 = stablehlo.dynamic_reshape %arg0, %0 : (tensor<4xf32>, tensor<2xi64>) -> tensor<1x4xf32>
   return %1 : tensor<1x4xf32>


### PR DESCRIPTION
As discussed in
https://github.com/openxla/stablehlo/pull/2231#discussion_r1571148784, this will likely help with debugging shape mismatches.