### PR TITLE
Clean up op speculatability tests

### DIFF
--- a/stablehlo/tests/ops_speculatability.mlir
+++ b/stablehlo/tests/ops_speculatability.mlir
@@ -9,8 +9,8 @@
 // CHECK-LABEL: func @abs_multidim
 // CHECK-NEXT:  return
 func.func @abs_multidim(%dynamic_arg: tensor<?x?xf64>) {
-  %not_speculatable = stablehlo.abs %dynamic_arg : (tensor<?x?xf64>) -> tensor<?x2xf64>
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable) : (tensor<?x2xf64>) -> ()
+  %0 = stablehlo.abs %dynamic_arg : (tensor<?x?xf64>) -> tensor<?x2xf64>
+  "hlo_test_speculatability.is_not_speculatable"(%0) : (tensor<?x2xf64>) -> ()
   return
 }
 
@@ -19,14 +19,14 @@ func.func @abs_multidim(%dynamic_arg: tensor<?x?xf64>) {
 // CHECK-LABEL: func @abs
 // CHECK-NEXT:  return
 func.func @abs(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.abs %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.abs %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.abs %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.abs %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.abs %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.abs %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.abs %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.abs %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -35,14 +35,14 @@ func.func @abs(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @cbrt
 // CHECK-NEXT:  return
 func.func @cbrt(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.cbrt %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.cbrt %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.cbrt %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.cbrt %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.cbrt %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.cbrt %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.cbrt %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.cbrt %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -51,14 +51,14 @@ func.func @cbrt(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @ceil
 // CHECK-NEXT:  return
 func.func @ceil(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.ceil %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.ceil %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.ceil %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.ceil %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.ceil %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.ceil %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.ceil %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.ceil %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -67,14 +67,14 @@ func.func @ceil(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @convert
 // CHECK-NEXT:  return
 func.func @convert(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.convert %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.convert %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.convert %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.convert %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.convert %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.convert %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.convert %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.convert %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -83,14 +83,14 @@ func.func @convert(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @count_leading_zeros
 // CHECK-NEXT:  return
 func.func @count_leading_zeros(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
-  %speculatable_0 = stablehlo.count_leading_zeros %static_arg : (tensor<2xi64>) -> tensor<2xi64>
-  %speculatable_1 = stablehlo.count_leading_zeros %static_arg : (tensor<2xi64>) -> tensor<?xi64>
-  %not_speculatable_0 = stablehlo.count_leading_zeros %dynamic_arg : (tensor<?xi64>) -> tensor<2xi64>
-  %speculatable_2 = stablehlo.count_leading_zeros %dynamic_arg : (tensor<?xi64>) -> tensor<?xi64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xi64>) -> ()
+  %0 = stablehlo.count_leading_zeros %static_arg : (tensor<2xi64>) -> tensor<2xi64>
+  %1 = stablehlo.count_leading_zeros %static_arg : (tensor<2xi64>) -> tensor<?xi64>
+  %2 = stablehlo.count_leading_zeros %dynamic_arg : (tensor<?xi64>) -> tensor<2xi64>
+  %3 = stablehlo.count_leading_zeros %dynamic_arg : (tensor<?xi64>) -> tensor<?xi64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xi64>) -> ()
   return
 }
 
@@ -99,14 +99,14 @@ func.func @count_leading_zeros(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<
 // CHECK-LABEL: func @cosine
 // CHECK-NEXT:  return
 func.func @cosine(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.cosine %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.cosine %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.cosine %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.cosine %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.cosine %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.cosine %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.cosine %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.cosine %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -115,14 +115,14 @@ func.func @cosine(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @exponential
 // CHECK-NEXT:  return
 func.func @exponential(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.exponential %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.exponential %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.exponential %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.exponential %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.exponential %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.exponential %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.exponential %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.exponential %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -131,14 +131,14 @@ func.func @exponential(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) 
 // CHECK-LABEL: func @exponential_minus_one
 // CHECK-NEXT:  return
 func.func @exponential_minus_one(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.exponential_minus_one %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.exponential_minus_one %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.exponential_minus_one %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.exponential_minus_one %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.exponential_minus_one %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.exponential_minus_one %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.exponential_minus_one %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.exponential_minus_one %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -147,14 +147,14 @@ func.func @exponential_minus_one(%static_arg: tensor<2xf64>, %dynamic_arg: tenso
 // CHECK-LABEL: func @floor
 // CHECK-NEXT:  return
 func.func @floor(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.floor %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.floor %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.floor %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.floor %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.floor %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.floor %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.floor %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.floor %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -163,14 +163,14 @@ func.func @floor(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @imag
 // CHECK-NEXT:  return
 func.func @imag(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.imag %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.imag %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.imag %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.imag %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.imag %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.imag %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.imag %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.imag %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -179,14 +179,14 @@ func.func @imag(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @is_finite
 // CHECK-NEXT:  return
 func.func @is_finite(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.is_finite %static_arg : (tensor<2xf64>) -> tensor<2xi1>
-  %speculatable_1 = stablehlo.is_finite %static_arg : (tensor<2xf64>) -> tensor<?xi1>
-  %not_speculatable_0 = stablehlo.is_finite %dynamic_arg : (tensor<?xf64>) -> tensor<2xi1>
-  %speculatable_2 = stablehlo.is_finite %dynamic_arg : (tensor<?xf64>) -> tensor<?xi1>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xi1>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xi1>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xi1>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xi1>) -> ()
+  %0 = stablehlo.is_finite %static_arg : (tensor<2xf64>) -> tensor<2xi1>
+  %1 = stablehlo.is_finite %static_arg : (tensor<2xf64>) -> tensor<?xi1>
+  %2 = stablehlo.is_finite %dynamic_arg : (tensor<?xf64>) -> tensor<2xi1>
+  %3 = stablehlo.is_finite %dynamic_arg : (tensor<?xf64>) -> tensor<?xi1>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xi1>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xi1>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xi1>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xi1>) -> ()
   return
 }
 
@@ -195,14 +195,14 @@ func.func @is_finite(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @log
 // CHECK-NEXT:  return
 func.func @log(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.log %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.log %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.log %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.log %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.log %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.log %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.log %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.log %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -211,14 +211,14 @@ func.func @log(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @log_plus_one
 // CHECK-NEXT:  return
 func.func @log_plus_one(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.log_plus_one %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.log_plus_one %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.log_plus_one %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.log_plus_one %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.log_plus_one %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.log_plus_one %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.log_plus_one %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.log_plus_one %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -227,14 +227,14 @@ func.func @log_plus_one(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>)
 // CHECK-LABEL: func @logistic
 // CHECK-NEXT:  return
 func.func @logistic(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.logistic %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.logistic %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.logistic %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.logistic %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.logistic %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.logistic %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.logistic %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.logistic %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -243,14 +243,14 @@ func.func @logistic(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @not
 // CHECK-NEXT:  return
 func.func @not(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
-  %speculatable_0 = stablehlo.not %static_arg : (tensor<2xi64>) -> tensor<2xi64>
-  %speculatable_1 = stablehlo.not %static_arg : (tensor<2xi64>) -> tensor<?xi64>
-  %not_speculatable_0 = stablehlo.not %dynamic_arg : (tensor<?xi64>) -> tensor<2xi64>
-  %speculatable_2 = stablehlo.not %dynamic_arg : (tensor<?xi64>) -> tensor<?xi64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xi64>) -> ()
+  %0 = stablehlo.not %static_arg : (tensor<2xi64>) -> tensor<2xi64>
+  %1 = stablehlo.not %static_arg : (tensor<2xi64>) -> tensor<?xi64>
+  %2 = stablehlo.not %dynamic_arg : (tensor<?xi64>) -> tensor<2xi64>
+  %3 = stablehlo.not %dynamic_arg : (tensor<?xi64>) -> tensor<?xi64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xi64>) -> ()
   return
 }
 
@@ -259,14 +259,14 @@ func.func @not(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
 // CHECK-LABEL: func @negate
 // CHECK-NEXT:  return
 func.func @negate(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.negate %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.negate %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.negate %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.negate %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.negate %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.negate %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.negate %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.negate %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -275,14 +275,14 @@ func.func @negate(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @popcnt
 // CHECK-NEXT:  return
 func.func @popcnt(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
-  %speculatable_0 = stablehlo.popcnt %static_arg : (tensor<2xi64>) -> tensor<2xi64>
-  %speculatable_1 = stablehlo.popcnt %static_arg : (tensor<2xi64>) -> tensor<?xi64>
-  %not_speculatable_0 = stablehlo.popcnt %dynamic_arg : (tensor<?xi64>) -> tensor<2xi64>
-  %speculatable_2 = stablehlo.popcnt %dynamic_arg : (tensor<?xi64>) -> tensor<?xi64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xi64>) -> ()
+  %0 = stablehlo.popcnt %static_arg : (tensor<2xi64>) -> tensor<2xi64>
+  %1 = stablehlo.popcnt %static_arg : (tensor<2xi64>) -> tensor<?xi64>
+  %2 = stablehlo.popcnt %dynamic_arg : (tensor<?xi64>) -> tensor<2xi64>
+  %3 = stablehlo.popcnt %dynamic_arg : (tensor<?xi64>) -> tensor<?xi64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xi64>) -> ()
   return
 }
 
@@ -291,14 +291,14 @@ func.func @popcnt(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
 // CHECK-LABEL: func @real
 // CHECK-NEXT:  return
 func.func @real(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.real %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.real %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.real %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.real %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.real %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.real %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.real %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.real %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -307,14 +307,14 @@ func.func @real(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @round_nearest_afz
 // CHECK-NEXT:  return
 func.func @round_nearest_afz(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.round_nearest_afz %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.round_nearest_afz %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.round_nearest_afz %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.round_nearest_afz %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.round_nearest_afz %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.round_nearest_afz %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.round_nearest_afz %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.round_nearest_afz %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -323,14 +323,14 @@ func.func @round_nearest_afz(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?x
 // CHECK-LABEL: func @round_nearest_even
 // CHECK-NEXT:  return
 func.func @round_nearest_even(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.round_nearest_even %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.round_nearest_even %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.round_nearest_even %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.round_nearest_even %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.round_nearest_even %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.round_nearest_even %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.round_nearest_even %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.round_nearest_even %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -339,14 +339,14 @@ func.func @round_nearest_even(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?
 // CHECK-LABEL: func @rsqrt
 // CHECK-NEXT:  return
 func.func @rsqrt(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.rsqrt %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.rsqrt %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.rsqrt %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.rsqrt %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.rsqrt %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.rsqrt %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.rsqrt %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.rsqrt %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -355,14 +355,14 @@ func.func @rsqrt(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @sign
 // CHECK-NEXT:  return
 func.func @sign(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.sign %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.sign %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.sign %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.sign %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.sign %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.sign %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.sign %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.sign %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -371,14 +371,14 @@ func.func @sign(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @sine
 // CHECK-NEXT:  return
 func.func @sine(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.sine %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.sine %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.sine %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.sine %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.sine %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.sine %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.sine %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.sine %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -387,14 +387,14 @@ func.func @sine(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @sqrt
 // CHECK-NEXT:  return
 func.func @sqrt(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.sqrt %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.sqrt %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.sqrt %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.sqrt %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.sqrt %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.sqrt %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.sqrt %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.sqrt %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -403,14 +403,14 @@ func.func @sqrt(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @tanh
 // CHECK-NEXT:  return
 func.func @tanh(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.tanh %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.tanh %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.tanh %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.tanh %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.tanh %static_arg : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.tanh %static_arg : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.tanh %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.tanh %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -423,28 +423,28 @@ func.func @tanh(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @pad
 // CHECK-NEXT:  return
 func.func @pad(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>, %padding_value: tensor<f64>) {
-  %speculatable_0 = stablehlo.pad %static_arg, %padding_value, low = [0], high = [0], interior = [0] : (tensor<2xf64>, tensor<f64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.pad %static_arg, %padding_value, low = [0], high = [0], interior = [0] : (tensor<2xf64>, tensor<f64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.pad %dynamic_arg, %padding_value, low = [0], high = [0], interior = [0] : (tensor<?xf64>, tensor<f64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.pad %dynamic_arg, %padding_value, low = [0], high = [0], interior = [0] : (tensor<?xf64>, tensor<f64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.pad %static_arg, %padding_value, low = [0], high = [0], interior = [0] : (tensor<2xf64>, tensor<f64>) -> tensor<2xf64>
+  %1 = stablehlo.pad %static_arg, %padding_value, low = [0], high = [0], interior = [0] : (tensor<2xf64>, tensor<f64>) -> tensor<?xf64>
+  %2 = stablehlo.pad %dynamic_arg, %padding_value, low = [0], high = [0], interior = [0] : (tensor<?xf64>, tensor<f64>) -> tensor<2xf64>
+  %3 = stablehlo.pad %dynamic_arg, %padding_value, low = [0], high = [0], interior = [0] : (tensor<?xf64>, tensor<f64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
 // CHECK-LABEL: func @reduce_precision
 // CHECK-NEXT:  return
 func.func @reduce_precision(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.reduce_precision %static_arg, format = e5m10 : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.reduce_precision %static_arg, format = e5m10 : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.reduce_precision %dynamic_arg, format = e5m10 : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.reduce_precision %dynamic_arg, format = e5m10 : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.reduce_precision %static_arg, format = e5m10 : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.reduce_precision %static_arg, format = e5m10 : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.reduce_precision %dynamic_arg, format = e5m10 : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.reduce_precision %dynamic_arg, format = e5m10 : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -453,14 +453,14 @@ func.func @reduce_precision(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf
 // CHECK-LABEL: func @reverse
 // CHECK-NEXT:  return
 func.func @reverse(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.reverse %static_arg, dims = [0] : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.reverse %static_arg, dims = [0] : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.reverse %dynamic_arg, dims = [0] : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.reverse %dynamic_arg, dims = [0] : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.reverse %static_arg, dims = [0] : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.reverse %static_arg, dims = [0] : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.reverse %dynamic_arg, dims = [0] : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.reverse %dynamic_arg, dims = [0] : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -469,14 +469,14 @@ func.func @reverse(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @slice
 // CHECK-NEXT:  return
 func.func @slice(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.slice %static_arg [0:2] : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.slice %static_arg [0:2] : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.slice %dynamic_arg [0:2] : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.slice %dynamic_arg [0:2] : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.slice %static_arg [0:2] : (tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.slice %static_arg [0:2] : (tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.slice %dynamic_arg [0:2] : (tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.slice %dynamic_arg [0:2] : (tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -485,42 +485,41 @@ func.func @slice(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @all_reduce
 // CHECK-NEXT:  return
 func.func @all_reduce(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = "stablehlo.all_reduce"(%static_arg) ({
+  %0 = "stablehlo.all_reduce"(%static_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
-      %0 = stablehlo.add %arg0, %arg1 : tensor<f64>
-      stablehlo.return %0 : tensor<f64>
+      stablehlo.return %arg0 : tensor<f64>
   }) {
     replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
     channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
   } : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = "stablehlo.all_reduce"(%static_arg) ({
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+
+  %1 = "stablehlo.all_reduce"(%static_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
-      %0 = stablehlo.add %arg0, %arg1 : tensor<f64>
-      stablehlo.return %0 : tensor<f64>
+      stablehlo.return %arg0 : tensor<f64>
   }) {
     replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
     channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
   } : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = "stablehlo.all_reduce"(%dynamic_arg) ({
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+
+  %2 = "stablehlo.all_reduce"(%dynamic_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
-      %0 = stablehlo.add %arg0, %arg1 : tensor<f64>
-      stablehlo.return %0 : tensor<f64>
+      stablehlo.return %arg0 : tensor<f64>
   }) {
     replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
     channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
   } : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = "stablehlo.all_reduce"(%dynamic_arg) ({
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+
+  %3 = "stablehlo.all_reduce"(%dynamic_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
-      %0 = stablehlo.add %arg0, %arg1 : tensor<f64>
-      stablehlo.return %0 : tensor<f64>
+      stablehlo.return %arg0 : tensor<f64>
   }) {
     replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
     channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
   } : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -529,26 +528,29 @@ func.func @all_reduce(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @collective_broadcast
 // CHECK-NEXT:  return
 func.func @collective_broadcast(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = "stablehlo.collective_broadcast"(%static_arg) {
+  %0 = "stablehlo.collective_broadcast"(%static_arg) {
     replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
     channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
   } : (tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = "stablehlo.collective_broadcast"(%static_arg) {
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+
+  %1 = "stablehlo.collective_broadcast"(%static_arg) {
     replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
     channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
   } : (tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = "stablehlo.collective_broadcast"(%dynamic_arg) {
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+
+  %2 = "stablehlo.collective_broadcast"(%dynamic_arg) {
     replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
     channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
   } : (tensor<?xf64>) -> tensor<2xf64>
-  %speculatable_2 = "stablehlo.collective_broadcast"(%dynamic_arg) {
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+
+  %3 = "stablehlo.collective_broadcast"(%dynamic_arg) {
     replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
     channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
   } : (tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -557,26 +559,29 @@ func.func @collective_broadcast(%static_arg: tensor<2xf64>, %dynamic_arg: tensor
 // CHECK-LABEL: func @collective_permute
 // CHECK-NEXT:  return
 func.func @collective_permute(%static_arg: tensor<2x2xf64>, %dynamic_arg: tensor<?x?xf64>) {
-  %speculatable_0 = "stablehlo.collective_permute"(%static_arg) {
+  %0 = "stablehlo.collective_permute"(%static_arg) {
     source_target_pairs = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>,
     channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
   } : (tensor<2x2xf64>) -> tensor<2x2xf64>
-  %speculatable_1 = "stablehlo.collective_permute"(%static_arg) {
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2x2xf64>) -> ()
+
+  %1 = "stablehlo.collective_permute"(%static_arg) {
     source_target_pairs = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>,
     channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
   } : (tensor<2x2xf64>) -> tensor<?x?xf64>
-  %not_speculatable_0 = "stablehlo.collective_permute"(%dynamic_arg) {
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?x?xf64>) -> ()
+
+  %2 = "stablehlo.collective_permute"(%dynamic_arg) {
     source_target_pairs = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>,
     channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
   } : (tensor<?x?xf64>) -> tensor<2x2xf64>
-  %speculatable_2 = "stablehlo.collective_permute"(%dynamic_arg) {
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2x2xf64>) -> ()
+
+  %3 = "stablehlo.collective_permute"(%dynamic_arg) {
     source_target_pairs = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>,
     channel_handle = #stablehlo.channel_handle<handle = 0, type = 0>
   } : (tensor<?x?xf64>) -> tensor<?x?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2x2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2x2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?x?xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?x?xf64>) -> ()
   return
 }
 
@@ -585,22 +590,25 @@ func.func @collective_permute(%static_arg: tensor<2x2xf64>, %dynamic_arg: tensor
 // CHECK-LABEL: func @rng_bit_generator
 // CHECK-NEXT:  return
 func.func @rng_bit_generator(%static_arg: tensor<2xui64>, %dynamic_arg: tensor<?xui64>) {
-  %speculatable_0:2 = "stablehlo.rng_bit_generator"(%static_arg) {
+  %0:2 = "stablehlo.rng_bit_generator"(%static_arg) {
     rng_algorithm = #stablehlo<rng_algorithm THREE_FRY>
   } : (tensor<2xui64>) -> (tensor<2xui64>, tensor<2x2xui64>)
-  %speculatable_1:2 = "stablehlo.rng_bit_generator"(%static_arg) {
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xui64>) -> ()
+
+  %1:2 = "stablehlo.rng_bit_generator"(%static_arg) {
     rng_algorithm = #stablehlo<rng_algorithm THREE_FRY>
   } : (tensor<2xui64>) -> (tensor<?xui64>, tensor<2x2xui64>)
-  %not_speculatable_0:2 = "stablehlo.rng_bit_generator"(%dynamic_arg) {
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xui64>) -> ()
+
+  %2:2 = "stablehlo.rng_bit_generator"(%dynamic_arg) {
     rng_algorithm = #stablehlo<rng_algorithm THREE_FRY>
   } : (tensor<?xui64>) -> (tensor<2xui64>, tensor<2x2xui64>)
-  %speculatable_2:2 = "stablehlo.rng_bit_generator"(%dynamic_arg) {
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xui64>) -> ()
+
+  %3:2 = "stablehlo.rng_bit_generator"(%dynamic_arg) {
     rng_algorithm = #stablehlo<rng_algorithm THREE_FRY>
   } : (tensor<?xui64>) -> (tensor<?xui64>, tensor<2x2xui64>)
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xui64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xui64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xui64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xui64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xui64>) -> ()
   return
 }
 
@@ -613,37 +621,46 @@ func.func @rng_bit_generator(%static_arg: tensor<2xui64>, %dynamic_arg: tensor<?
 // CHECK-LABEL: func @all_gather
 // CHECK-NEXT:  return
 func.func @all_gather(%static_arg: tensor<2x2xf64>, %dynamic_arg: tensor<?x?xf64>) {
-    %static_all_gather_dim = "stablehlo.all_gather"(%static_arg) {
-      all_gather_dim = 1 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
-      channel_handle = #stablehlo.channel_handle<handle=1, type=0>
-    } : (tensor<2x2xf64>) -> tensor<2x8xf64>
-    %dynamic_all_gather_dim = "stablehlo.all_gather"(%static_arg) {
-      all_gather_dim = 1 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
-      channel_handle = #stablehlo.channel_handle<handle=1, type=0>
-    } : (tensor<2x2xf64>) -> tensor<2x?xf64>
-    %dynamic_all_gather_dim_not_speculatable = "stablehlo.all_gather"(%dynamic_arg) {
-      all_gather_dim = 1 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
-      channel_handle = #stablehlo.channel_handle<handle=1, type=0>
-    } : (tensor<?x?xf64>) -> tensor<2x?xf64>
-    %result_dynamic_input_static = "stablehlo.all_gather"(%static_arg) {
-      all_gather_dim = 1 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
-      channel_handle = #stablehlo.channel_handle<handle=1, type=0>
-    } : (tensor<2x2xf64>) -> tensor<?x?xf64>
-    %result_dynamic_input_dynamic = "stablehlo.all_gather"(%dynamic_arg) {
-      all_gather_dim = 1 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
-      channel_handle = #stablehlo.channel_handle<handle=1, type=0>
-    } : (tensor<?x?xf64>) -> tensor<?x?xf64>
-    "hlo_test_speculatability.is_not_speculatable"(%static_all_gather_dim) : (tensor<2x8xf64>) -> ()
-    "hlo_test_speculatability.is_speculatable"(%dynamic_all_gather_dim) : (tensor<2x?xf64>) -> ()
-    "hlo_test_speculatability.is_not_speculatable"(%dynamic_all_gather_dim_not_speculatable) : (tensor<2x?xf64>) -> ()
-    "hlo_test_speculatability.is_speculatable"(%result_dynamic_input_static) : (tensor<?x?xf64>) -> ()
-    "hlo_test_speculatability.is_speculatable"(%result_dynamic_input_dynamic) : (tensor<?x?xf64>) -> ()
-    return
+  // Everything static
+  %0 = "stablehlo.all_gather"(%static_arg) {
+    all_gather_dim = 1 : i64,
+    replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+    channel_handle = #stablehlo.channel_handle<handle=1, type=0>
+  } : (tensor<2x2xf64>) -> tensor<2x8xf64>
+  "hlo_test_speculatability.is_not_speculatable"(%0) : (tensor<2x8xf64>) -> ()
+
+  // all_gather_dim is static in input but dynamic in output
+  %1 = "stablehlo.all_gather"(%static_arg) {
+    all_gather_dim = 1 : i64,
+    replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+    channel_handle = #stablehlo.channel_handle<handle=1, type=0>
+  } : (tensor<2x2xf64>) -> tensor<2x?xf64>
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<2x?xf64>) -> ()
+
+  // input is dynamic, non-all_gather_dim is static in output
+  %2 = "stablehlo.all_gather"(%dynamic_arg) {
+    all_gather_dim = 1 : i64,
+    replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+    channel_handle = #stablehlo.channel_handle<handle=1, type=0>
+  } : (tensor<?x?xf64>) -> tensor<2x?xf64>
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2x?xf64>) -> ()
+
+  // input is static, output is dynamic
+  %3 = "stablehlo.all_gather"(%static_arg) {
+    all_gather_dim = 1 : i64,
+    replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+    channel_handle = #stablehlo.channel_handle<handle=1, type=0>
+  } : (tensor<2x2xf64>) -> tensor<?x?xf64>
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?x?xf64>) -> ()
+
+  // input and output are dynamic
+  %4 = "stablehlo.all_gather"(%dynamic_arg) {
+    all_gather_dim = 1 : i64,
+    replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+    channel_handle = #stablehlo.channel_handle<handle=1, type=0>
+  } : (tensor<?x?xf64>) -> tensor<?x?xf64>
+  "hlo_test_speculatability.is_speculatable"(%4) : (tensor<?x?xf64>) -> ()
+  return
 }
 
 // -----
@@ -698,57 +715,61 @@ func.func @fft(
 // CHECK-LABEL: func @reduce_scatter
 // CHECK-NEXT:  return
 func.func @reduce_scatter(%static_arg: tensor<2x4xf64>, %dynamic_arg: tensor<?x?xf64>) {
-    %static_scatter_dim = "stablehlo.reduce_scatter"(%static_arg) ({
-      ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
-        %0 = stablehlo.add %arg0, %arg1 : tensor<f64>
-        stablehlo.return %0 : tensor<f64>
-    }) {
-      scatter_dimension = 1 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
-      channel_handle = #stablehlo.channel_handle<handle=1, type=0>
-    } : (tensor<2x4xf64>) -> tensor<2x2xf64>
-    %dynamic_scatter_dim = "stablehlo.reduce_scatter"(%static_arg) ({
-      ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
-        %0 = stablehlo.add %arg0, %arg1 : tensor<f64>
-        stablehlo.return %0 : tensor<f64>
-    }) {
-      scatter_dimension = 1 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
-      channel_handle = #stablehlo.channel_handle<handle=1, type=0>
-    } : (tensor<2x4xf64>) -> tensor<2x?xf64>
-    %dynamic_scatter_dim_not_speculatable = "stablehlo.reduce_scatter"(%dynamic_arg) ({
-      ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
-        %0 = stablehlo.add %arg0, %arg1 : tensor<f64>
-        stablehlo.return %0 : tensor<f64>
-    }) {
-      scatter_dimension = 1 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
-      channel_handle = #stablehlo.channel_handle<handle=1, type=0>
-    } : (tensor<?x?xf64>) -> tensor<2x?xf64>
-    %result_dynamic_input_static = "stablehlo.reduce_scatter"(%static_arg) ({
-      ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
-        %0 = stablehlo.add %arg0, %arg1 : tensor<f64>
-        stablehlo.return %0 : tensor<f64>
-    }) {
-      scatter_dimension = 1 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
-      channel_handle = #stablehlo.channel_handle<handle=1, type=0>
-    } : (tensor<2x4xf64>) -> tensor<?x?xf64>
-    %result_dynamic_input_dynamic = "stablehlo.reduce_scatter"(%dynamic_arg) ({
-      ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
-        %0 = stablehlo.add %arg0, %arg1 : tensor<f64>
-        stablehlo.return %0 : tensor<f64>
-    }) {
-      scatter_dimension = 1 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
-      channel_handle = #stablehlo.channel_handle<handle=1, type=0>
-    } : (tensor<?x?xf64>) -> tensor<?x?xf64>
-    "hlo_test_speculatability.is_not_speculatable"(%static_scatter_dim) : (tensor<2x2xf64>) -> ()
-    "hlo_test_speculatability.is_speculatable"(%dynamic_scatter_dim) : (tensor<2x?xf64>) -> ()
-    "hlo_test_speculatability.is_not_speculatable"(%dynamic_scatter_dim_not_speculatable) : (tensor<2x?xf64>) -> ()
-    "hlo_test_speculatability.is_speculatable"(%result_dynamic_input_static) : (tensor<?x?xf64>) -> ()
-    "hlo_test_speculatability.is_speculatable"(%result_dynamic_input_dynamic) : (tensor<?x?xf64>) -> ()
-    return
+  // Everything static
+  %0 = "stablehlo.reduce_scatter"(%static_arg) ({
+    ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
+      stablehlo.return %arg0 : tensor<f64>
+  }) {
+    scatter_dimension = 1 : i64,
+    replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+    channel_handle = #stablehlo.channel_handle<handle=1, type=0>
+  } : (tensor<2x4xf64>) -> tensor<2x2xf64>
+  "hlo_test_speculatability.is_not_speculatable"(%0) : (tensor<2x2xf64>) -> ()
+
+  // Scatter dim is dynamic in output
+  %1 = "stablehlo.reduce_scatter"(%static_arg) ({
+    ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
+      stablehlo.return %arg0 : tensor<f64>
+  }) {
+    scatter_dimension = 1 : i64,
+    replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+    channel_handle = #stablehlo.channel_handle<handle=1, type=0>
+  } : (tensor<2x4xf64>) -> tensor<2x?xf64>
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<2x?xf64>) -> ()
+
+  // Dynamic arg, non-scatter_dim is static in output
+  %2 = "stablehlo.reduce_scatter"(%dynamic_arg) ({
+    ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
+      stablehlo.return %arg0 : tensor<f64>
+  }) {
+    scatter_dimension = 1 : i64,
+    replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+    channel_handle = #stablehlo.channel_handle<handle=1, type=0>
+  } : (tensor<?x?xf64>) -> tensor<2x?xf64>
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2x?xf64>) -> ()
+
+  // Static input, dynamic output
+  %3 = "stablehlo.reduce_scatter"(%static_arg) ({
+    ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
+      stablehlo.return %arg0 : tensor<f64>
+  }) {
+    scatter_dimension = 1 : i64,
+    replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+    channel_handle = #stablehlo.channel_handle<handle=1, type=0>
+  } : (tensor<2x4xf64>) -> tensor<?x?xf64>
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?x?xf64>) -> ()
+
+  // Everything dynamic
+  %4 = "stablehlo.reduce_scatter"(%dynamic_arg) ({
+    ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
+      stablehlo.return %arg0 : tensor<f64>
+  }) {
+    scatter_dimension = 1 : i64,
+    replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>,
+    channel_handle = #stablehlo.channel_handle<handle=1, type=0>
+  } : (tensor<?x?xf64>) -> tensor<?x?xf64>
+  "hlo_test_speculatability.is_speculatable"(%4) : (tensor<?x?xf64>) -> ()
+  return
 }
 
 // -----
@@ -756,56 +777,69 @@ func.func @reduce_scatter(%static_arg: tensor<2x4xf64>, %dynamic_arg: tensor<?x?
 // CHECK-LABEL: func @all_to_all
 // CHECK-NEXT:  return
 func.func @all_to_all(%static_arg: tensor<2x4x8xf64>, %dynamic_arg: tensor<?x?x?xf64>) {
-    %concat_and_split_are_static = "stablehlo.all_to_all"(%static_arg) {
-      concat_dimension = 0 : i64,
-      split_dimension = 1 : i64,
-      split_count = 2 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
-    } : (tensor<2x4x8xf64>) -> tensor<4x2x8xf64>
-    %concat_is_static = "stablehlo.all_to_all"(%static_arg) {
-      concat_dimension = 0 : i64,
-      split_dimension = 1 : i64,
-      split_count = 2 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
-    } : (tensor<2x4x8xf64>) -> tensor<4x?x8xf64>
-    %split_is_static = "stablehlo.all_to_all"(%static_arg) {
-      concat_dimension = 0 : i64,
-      split_dimension = 1 : i64,
-      split_count = 2 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
-    } : (tensor<2x4x8xf64>) -> tensor<?x2x8xf64>
-    %concat_and_split_are_dynamic = "stablehlo.all_to_all"(%static_arg) {
-      concat_dimension = 0 : i64,
-      split_dimension = 1 : i64,
-      split_count = 2 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
-    } : (tensor<2x4x8xf64>) -> tensor<?x?x8xf64>
-    %other_dim_static = "stablehlo.all_to_all"(%dynamic_arg) {
-      concat_dimension = 0 : i64,
-      split_dimension = 1 : i64,
-      split_count = 2 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
-    } : (tensor<?x?x?xf64>) -> tensor<?x?x8xf64>
-    %result_fully_dynamic_0 = "stablehlo.all_to_all"(%static_arg) {
-      concat_dimension = 0 : i64,
-      split_dimension = 1 : i64,
-      split_count = 2 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
-    } : (tensor<2x4x8xf64>) -> tensor<?x?x?xf64>
-    %result_fully_dynamic_1 = "stablehlo.all_to_all"(%dynamic_arg) {
-      concat_dimension = 0 : i64,
-      split_dimension = 1 : i64,
-      split_count = 2 : i64,
-      replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
-    } : (tensor<?x?x?xf64>) -> tensor<?x?x?xf64>
-    "hlo_test_speculatability.is_not_speculatable"(%concat_and_split_are_static) : (tensor<4x2x8xf64>) -> ()
-    "hlo_test_speculatability.is_not_speculatable"(%concat_is_static) : (tensor<4x?x8xf64>) -> ()
-    "hlo_test_speculatability.is_not_speculatable"(%split_is_static) : (tensor<?x2x8xf64>) -> ()
-    "hlo_test_speculatability.is_speculatable"(%concat_and_split_are_dynamic) : (tensor<?x?x8xf64>) -> ()
-    "hlo_test_speculatability.is_not_speculatable"(%other_dim_static) : (tensor<?x?x8xf64>) -> ()
-    "hlo_test_speculatability.is_speculatable"(%result_fully_dynamic_0) : (tensor<?x?x?xf64>) -> ()
-    "hlo_test_speculatability.is_speculatable"(%result_fully_dynamic_1) : (tensor<?x?x?xf64>) -> ()
-    return
+  // Everything static
+  %0 = "stablehlo.all_to_all"(%static_arg) {
+    concat_dimension = 0 : i64,
+    split_dimension = 1 : i64,
+    split_count = 2 : i64,
+    replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
+  } : (tensor<2x4x8xf64>) -> tensor<4x2x8xf64>
+  "hlo_test_speculatability.is_not_speculatable"(%0) : (tensor<4x2x8xf64>) -> ()
+
+  // Concat dim is static in output
+  %1 = "stablehlo.all_to_all"(%static_arg) {
+    concat_dimension = 0 : i64,
+    split_dimension = 1 : i64,
+    split_count = 2 : i64,
+    replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
+  } : (tensor<2x4x8xf64>) -> tensor<4x?x8xf64>
+  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<4x?x8xf64>) -> ()
+
+  // Split dim is static in output
+  %2 = "stablehlo.all_to_all"(%static_arg) {
+    concat_dimension = 0 : i64,
+    split_dimension = 1 : i64,
+    split_count = 2 : i64,
+    replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
+  } : (tensor<2x4x8xf64>) -> tensor<?x2x8xf64>
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?x2x8xf64>) -> ()
+
+  // Concat and split dims are dynamic in output and input is static
+  %3 = "stablehlo.all_to_all"(%static_arg) {
+    concat_dimension = 0 : i64,
+    split_dimension = 1 : i64,
+    split_count = 2 : i64,
+    replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
+  } : (tensor<2x4x8xf64>) -> tensor<?x?x8xf64>
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?x?x8xf64>) -> ()
+
+  // Concat and split dims are dynamic in output and input is dynamic
+  %4 = "stablehlo.all_to_all"(%dynamic_arg) {
+    concat_dimension = 0 : i64,
+    split_dimension = 1 : i64,
+    split_count = 2 : i64,
+    replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
+  } : (tensor<?x?x?xf64>) -> tensor<?x?x8xf64>
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<?x?x8xf64>) -> ()
+
+  // Output is dynamic, input is static
+  %5 = "stablehlo.all_to_all"(%static_arg) {
+    concat_dimension = 0 : i64,
+    split_dimension = 1 : i64,
+    split_count = 2 : i64,
+    replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
+  } : (tensor<2x4x8xf64>) -> tensor<?x?x?xf64>
+  "hlo_test_speculatability.is_speculatable"(%5) : (tensor<?x?x?xf64>) -> ()
+
+  // Output is dynamic, input is dynamic
+  %6 = "stablehlo.all_to_all"(%dynamic_arg) {
+    concat_dimension = 0 : i64,
+    split_dimension = 1 : i64,
+    split_count = 2 : i64,
+    replica_groups = dense<[[0, 1]]> : tensor<1x2xi64>
+  } : (tensor<?x?x?xf64>) -> tensor<?x?x?xf64>
+  "hlo_test_speculatability.is_speculatable"(%6) : (tensor<?x?x?xf64>) -> ()
+  return
 }
 
 // -----
@@ -817,25 +851,28 @@ func.func @transpose(
   %second_dim_dynamic: tensor<2x?xf64>, %dynamic: tensor<?x?xf64>,
   %three_d: tensor<1x2x3xf64>, %three_d_dynamic: tensor<1x2x?xf64>
 ) {
-  %speculatable_0 = stablehlo.transpose %static, dims = [1, 0] : (tensor<2x4xf64>) -> tensor<4x2xf64>
-  %not_speculatable_0 = stablehlo.transpose %second_dim_dynamic, dims = [1, 0] : (tensor<2x?xf64>) -> tensor<4x2xf64>
-  %speculatable_1 = stablehlo.transpose %second_dim_dynamic, dims = [1, 0] : (tensor<2x?xf64>) -> tensor<?x2xf64>
-  %not_speculatable_1 = stablehlo.transpose %first_dim_dynamic, dims = [1, 0] : (tensor<?x4xf64>) -> tensor<4x2xf64>
-  %speculatable_2 = stablehlo.transpose %first_dim_dynamic, dims = [1, 0] : (tensor<?x4xf64>) -> tensor<4x?xf64>
-  %not_speculatable_2 = stablehlo.transpose %dynamic, dims = [1, 0] : (tensor<?x?xf64>) -> tensor<4x2xf64>
-  %not_speculatable_3 = stablehlo.transpose %dynamic, dims = [1, 0] : (tensor<?x?xf64>) -> tensor<?x2xf64>
-  %not_speculatable_4 = stablehlo.transpose %dynamic, dims = [1, 0] : (tensor<?x?xf64>) -> tensor<4x?xf64>
-  %speculatable_3 = stablehlo.transpose %dynamic, dims = [1, 0] : (tensor<?x?xf64>) -> tensor<?x?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<4x2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<4x2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?x2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<4x2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<4x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<4x2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?x2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_4) : (tensor<4x?xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_3) : (tensor<?x?xf64>) -> ()
+  %0 = stablehlo.transpose %static, dims = [1, 0] : (tensor<2x4xf64>) -> tensor<4x2xf64>
+  %1 = stablehlo.transpose %second_dim_dynamic, dims = [1, 0] : (tensor<2x?xf64>) -> tensor<4x2xf64>
+  %2 = stablehlo.transpose %second_dim_dynamic, dims = [1, 0] : (tensor<2x?xf64>) -> tensor<?x2xf64>
+  %3 = stablehlo.transpose %first_dim_dynamic, dims = [1, 0] : (tensor<?x4xf64>) -> tensor<4x2xf64>
+  %4 = stablehlo.transpose %first_dim_dynamic, dims = [1, 0] : (tensor<?x4xf64>) -> tensor<4x?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<4x2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<4x2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%2) : (tensor<?x2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<4x2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%4) : (tensor<4x?xf64>) -> ()
 
+  // Fully dynamic input
+  %5 = stablehlo.transpose %dynamic, dims = [1, 0] : (tensor<?x?xf64>) -> tensor<4x2xf64>
+  %6 = stablehlo.transpose %dynamic, dims = [1, 0] : (tensor<?x?xf64>) -> tensor<?x2xf64>
+  %7 = stablehlo.transpose %dynamic, dims = [1, 0] : (tensor<?x?xf64>) -> tensor<4x?xf64>
+  %8 = stablehlo.transpose %dynamic, dims = [1, 0] : (tensor<?x?xf64>) -> tensor<?x?xf64>
+  "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<4x2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<?x2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<4x?xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%8) : (tensor<?x?xf64>) -> ()
+
+  // 3D
   %speculatable_4 = stablehlo.transpose %three_d, dims = [1, 0, 2] : (tensor<1x2x3xf64>) -> tensor<2x1x3xf64>
   %not_speculatable_5 = stablehlo.transpose %three_d_dynamic, dims = [1, 0, 2] : (tensor<1x2x?xf64>) -> tensor<2x1x3xf64>
   %speculatable_5 = stablehlo.transpose %three_d_dynamic, dims = [1, 0, 2] : (tensor<1x2x?xf64>) -> tensor<2x1x?xf64>
@@ -854,8 +891,8 @@ func.func @transpose(
 // CHECK-LABEL: func @add_multidim
 // CHECK-NEXT: return
 func.func @add_multidim(%static_arg: tensor<2x2xf64>, %partially_dynamic_arg: tensor<2x?xf64>) {
-  %not_speculatable = stablehlo.add %static_arg, %partially_dynamic_arg : (tensor<2x2xf64>, tensor<2x?xf64>) -> tensor<?x?xf64>
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable) : (tensor<?x?xf64>) -> ()
+  %0 = stablehlo.add %static_arg, %partially_dynamic_arg : (tensor<2x2xf64>, tensor<2x?xf64>) -> tensor<?x?xf64>
+  "hlo_test_speculatability.is_not_speculatable"(%0) : (tensor<?x?xf64>) -> ()
   return
 }
 
@@ -864,22 +901,22 @@ func.func @add_multidim(%static_arg: tensor<2x2xf64>, %partially_dynamic_arg: te
 // CHECK-LABEL: func @add
 // CHECK-NEXT: return
 func.func @add(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.add %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.add %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.add %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %not_speculatable_1 = stablehlo.add %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %not_speculatable_2 = stablehlo.add %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %not_speculatable_3 = stablehlo.add %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_4 = stablehlo.add %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %not_speculatable_5 = stablehlo.add %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_4) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_5) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.add %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.add %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.add %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.add %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
+  %4 = stablehlo.add %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
+  %5 = stablehlo.add %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %6 = stablehlo.add %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
+  %7 = stablehlo.add %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -888,22 +925,22 @@ func.func @add(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @atan2
 // CHECK-NEXT: return
 func.func @atan2(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.atan2 %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.atan2 %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.atan2 %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %not_speculatable_1 = stablehlo.atan2 %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %not_speculatable_2 = stablehlo.atan2 %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %not_speculatable_3 = stablehlo.atan2 %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_4 = stablehlo.atan2 %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %not_speculatable_5 = stablehlo.atan2 %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_4) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_5) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.atan2 %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.atan2 %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.atan2 %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.atan2 %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
+  %4 = stablehlo.atan2 %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
+  %5 = stablehlo.atan2 %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %6 = stablehlo.atan2 %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
+  %7 = stablehlo.atan2 %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -912,22 +949,22 @@ func.func @atan2(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @complex
 // CHECK-NEXT: return
 func.func @complex(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.complex %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xcomplex<f64>>
-  %speculatable_1 = stablehlo.complex %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xcomplex<f64>>
-  %not_speculatable_0 = stablehlo.complex %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xcomplex<f64>>
-  %not_speculatable_1 = stablehlo.complex %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xcomplex<f64>>
-  %not_speculatable_2 = stablehlo.complex %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xcomplex<f64>>
-  %not_speculatable_3 = stablehlo.complex %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xcomplex<f64>>
-  %not_speculatable_4 = stablehlo.complex %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xcomplex<f64>>
-  %not_speculatable_5 = stablehlo.complex %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xcomplex<f64>>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xcomplex<f64>>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xcomplex<f64>>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xcomplex<f64>>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xcomplex<f64>>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<2xcomplex<f64>>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?xcomplex<f64>>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_4) : (tensor<2xcomplex<f64>>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_5) : (tensor<?xcomplex<f64>>) -> ()
+  %0 = stablehlo.complex %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xcomplex<f64>>
+  %1 = stablehlo.complex %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xcomplex<f64>>
+  %2 = stablehlo.complex %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xcomplex<f64>>
+  %3 = stablehlo.complex %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xcomplex<f64>>
+  %4 = stablehlo.complex %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xcomplex<f64>>
+  %5 = stablehlo.complex %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xcomplex<f64>>
+  %6 = stablehlo.complex %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xcomplex<f64>>
+  %7 = stablehlo.complex %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xcomplex<f64>>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xcomplex<f64>>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xcomplex<f64>>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xcomplex<f64>>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xcomplex<f64>>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xcomplex<f64>>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xcomplex<f64>>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xcomplex<f64>>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xcomplex<f64>>) -> ()
   return
 }
 
@@ -936,22 +973,22 @@ func.func @complex(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @divide
 // CHECK-NEXT: return
 func.func @divide(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.divide %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.divide %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.divide %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %not_speculatable_1 = stablehlo.divide %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %not_speculatable_2 = stablehlo.divide %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %not_speculatable_3 = stablehlo.divide %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_4 = stablehlo.divide %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %not_speculatable_5 = stablehlo.divide %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_4) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_5) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.divide %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.divide %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.divide %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.divide %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
+  %4 = stablehlo.divide %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
+  %5 = stablehlo.divide %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %6 = stablehlo.divide %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
+  %7 = stablehlo.divide %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -960,22 +997,22 @@ func.func @divide(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @maximum
 // CHECK-NEXT: return
 func.func @maximum(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.maximum %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.maximum %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.maximum %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %not_speculatable_1 = stablehlo.maximum %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %not_speculatable_2 = stablehlo.maximum %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %not_speculatable_3 = stablehlo.maximum %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_4 = stablehlo.maximum %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %not_speculatable_5 = stablehlo.maximum %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_4) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_5) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.maximum %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.maximum %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.maximum %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.maximum %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
+  %4 = stablehlo.maximum %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
+  %5 = stablehlo.maximum %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %6 = stablehlo.maximum %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
+  %7 = stablehlo.maximum %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -984,22 +1021,22 @@ func.func @maximum(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @minimum
 // CHECK-NEXT: return
 func.func @minimum(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.minimum %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.minimum %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.minimum %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %not_speculatable_1 = stablehlo.minimum %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %not_speculatable_2 = stablehlo.minimum %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %not_speculatable_3 = stablehlo.minimum %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_4 = stablehlo.minimum %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %not_speculatable_5 = stablehlo.minimum %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_4) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_5) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.minimum %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.minimum %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.minimum %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.minimum %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
+  %4 = stablehlo.minimum %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
+  %5 = stablehlo.minimum %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %6 = stablehlo.minimum %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
+  %7 = stablehlo.minimum %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -1008,22 +1045,22 @@ func.func @minimum(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @multiply
 // CHECK-NEXT: return
 func.func @multiply(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.multiply %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.multiply %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.multiply %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %not_speculatable_1 = stablehlo.multiply %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %not_speculatable_2 = stablehlo.multiply %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %not_speculatable_3 = stablehlo.multiply %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_4 = stablehlo.multiply %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %not_speculatable_5 = stablehlo.multiply %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_4) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_5) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.multiply %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.multiply %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.multiply %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.multiply %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
+  %4 = stablehlo.multiply %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
+  %5 = stablehlo.multiply %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %6 = stablehlo.multiply %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
+  %7 = stablehlo.multiply %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -1032,22 +1069,22 @@ func.func @multiply(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @power
 // CHECK-NEXT: return
 func.func @power(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.power %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.power %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.power %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %not_speculatable_1 = stablehlo.power %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %not_speculatable_2 = stablehlo.power %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %not_speculatable_3 = stablehlo.power %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_4 = stablehlo.power %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %not_speculatable_5 = stablehlo.power %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_4) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_5) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.power %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.power %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.power %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.power %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
+  %4 = stablehlo.power %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
+  %5 = stablehlo.power %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %6 = stablehlo.power %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
+  %7 = stablehlo.power %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -1056,22 +1093,22 @@ func.func @power(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @remainder
 // CHECK-NEXT: return
 func.func @remainder(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.remainder %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.remainder %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.remainder %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %not_speculatable_1 = stablehlo.remainder %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %not_speculatable_2 = stablehlo.remainder %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %not_speculatable_3 = stablehlo.remainder %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_4 = stablehlo.remainder %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %not_speculatable_5 = stablehlo.remainder %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_4) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_5) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.remainder %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.remainder %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.remainder %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.remainder %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
+  %4 = stablehlo.remainder %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
+  %5 = stablehlo.remainder %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %6 = stablehlo.remainder %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
+  %7 = stablehlo.remainder %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -1080,22 +1117,22 @@ func.func @remainder(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @shift_left
 // CHECK-NEXT: return
 func.func @shift_left(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
-  %speculatable_0 = stablehlo.shift_left %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %speculatable_1 = stablehlo.shift_left %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %not_speculatable_0 = stablehlo.shift_left %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %not_speculatable_1 = stablehlo.shift_left %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
-  %not_speculatable_2 = stablehlo.shift_left %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %not_speculatable_3 = stablehlo.shift_left %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %not_speculatable_4 = stablehlo.shift_left %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %not_speculatable_5 = stablehlo.shift_left %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_4) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_5) : (tensor<?xi64>) -> ()
+  %0 = stablehlo.shift_left %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<2xi64>
+  %1 = stablehlo.shift_left %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
+  %2 = stablehlo.shift_left %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
+  %3 = stablehlo.shift_left %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
+  %4 = stablehlo.shift_left %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
+  %5 = stablehlo.shift_left %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
+  %6 = stablehlo.shift_left %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
+  %7 = stablehlo.shift_left %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xi64>) -> ()
   return
 }
 
@@ -1104,22 +1141,22 @@ func.func @shift_left(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
 // CHECK-LABEL: func @shift_right_arithmetic
 // CHECK-NEXT: return
 func.func @shift_right_arithmetic(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
-  %speculatable_0 = stablehlo.shift_right_arithmetic %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %speculatable_1 = stablehlo.shift_right_arithmetic %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %not_speculatable_0 = stablehlo.shift_right_arithmetic %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %not_speculatable_1 = stablehlo.shift_right_arithmetic %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
-  %not_speculatable_2 = stablehlo.shift_right_arithmetic %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %not_speculatable_3 = stablehlo.shift_right_arithmetic %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %not_speculatable_4 = stablehlo.shift_right_arithmetic %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %not_speculatable_5 = stablehlo.shift_right_arithmetic %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_4) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_5) : (tensor<?xi64>) -> ()
+  %0 = stablehlo.shift_right_arithmetic %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<2xi64>
+  %1 = stablehlo.shift_right_arithmetic %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
+  %2 = stablehlo.shift_right_arithmetic %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
+  %3 = stablehlo.shift_right_arithmetic %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
+  %4 = stablehlo.shift_right_arithmetic %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
+  %5 = stablehlo.shift_right_arithmetic %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
+  %6 = stablehlo.shift_right_arithmetic %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
+  %7 = stablehlo.shift_right_arithmetic %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xi64>) -> ()
   return
 }
 
@@ -1128,22 +1165,22 @@ func.func @shift_right_arithmetic(%static_arg: tensor<2xi64>, %dynamic_arg: tens
 // CHECK-LABEL: func @shift_right_logical
 // CHECK-NEXT: return
 func.func @shift_right_logical(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
-  %speculatable_0 = stablehlo.shift_right_logical %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %speculatable_1 = stablehlo.shift_right_logical %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %not_speculatable_0 = stablehlo.shift_right_logical %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %not_speculatable_1 = stablehlo.shift_right_logical %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
-  %not_speculatable_2 = stablehlo.shift_right_logical %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %not_speculatable_3 = stablehlo.shift_right_logical %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %not_speculatable_4 = stablehlo.shift_right_logical %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %not_speculatable_5 = stablehlo.shift_right_logical %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_4) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_5) : (tensor<?xi64>) -> ()
+  %0 = stablehlo.shift_right_logical %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<2xi64>
+  %1 = stablehlo.shift_right_logical %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
+  %2 = stablehlo.shift_right_logical %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
+  %3 = stablehlo.shift_right_logical %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
+  %4 = stablehlo.shift_right_logical %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
+  %5 = stablehlo.shift_right_logical %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
+  %6 = stablehlo.shift_right_logical %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
+  %7 = stablehlo.shift_right_logical %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xi64>) -> ()
   return
 }
 
@@ -1152,22 +1189,22 @@ func.func @shift_right_logical(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<
 // CHECK-LABEL: func @subtract
 // CHECK-NEXT: return
 func.func @subtract(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.subtract %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.subtract %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.subtract %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %not_speculatable_1 = stablehlo.subtract %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %not_speculatable_2 = stablehlo.subtract %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %not_speculatable_3 = stablehlo.subtract %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_4 = stablehlo.subtract %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %not_speculatable_5 = stablehlo.subtract %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_4) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_5) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.subtract %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
+  %1 = stablehlo.subtract %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.subtract %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
+  %3 = stablehlo.subtract %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
+  %4 = stablehlo.subtract %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
+  %5 = stablehlo.subtract %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %6 = stablehlo.subtract %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
+  %7 = stablehlo.subtract %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -1176,22 +1213,22 @@ func.func @subtract(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @and
 // CHECK-NEXT: return
 func.func @and(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
-  %speculatable_0 = stablehlo.and %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %speculatable_1 = stablehlo.and %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %not_speculatable_0 = stablehlo.and %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %not_speculatable_1 = stablehlo.and %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
-  %not_speculatable_2 = stablehlo.and %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %not_speculatable_3 = stablehlo.and %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %not_speculatable_4 = stablehlo.and %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %not_speculatable_5 = stablehlo.and %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_4) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_5) : (tensor<?xi64>) -> ()
+  %0 = stablehlo.and %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<2xi64>
+  %1 = stablehlo.and %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
+  %2 = stablehlo.and %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
+  %3 = stablehlo.and %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
+  %4 = stablehlo.and %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
+  %5 = stablehlo.and %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
+  %6 = stablehlo.and %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
+  %7 = stablehlo.and %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xi64>) -> ()
   return
 }
 
@@ -1200,22 +1237,22 @@ func.func @and(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
 // CHECK-LABEL: func @or
 // CHECK-NEXT: return
 func.func @or(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
-  %speculatable_0 = stablehlo.or %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %speculatable_1 = stablehlo.or %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %not_speculatable_0 = stablehlo.or %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %not_speculatable_1 = stablehlo.or %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
-  %not_speculatable_2 = stablehlo.or %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %not_speculatable_3 = stablehlo.or %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %not_speculatable_4 = stablehlo.or %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %not_speculatable_5 = stablehlo.or %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_4) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_5) : (tensor<?xi64>) -> ()
+  %0 = stablehlo.or %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<2xi64>
+  %1 = stablehlo.or %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
+  %2 = stablehlo.or %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
+  %3 = stablehlo.or %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
+  %4 = stablehlo.or %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
+  %5 = stablehlo.or %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
+  %6 = stablehlo.or %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
+  %7 = stablehlo.or %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xi64>) -> ()
   return
 }
 
@@ -1224,22 +1261,22 @@ func.func @or(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
 // CHECK-LABEL: func @xor
 // CHECK-NEXT: return
 func.func @xor(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
-  %speculatable_0 = stablehlo.xor %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %speculatable_1 = stablehlo.xor %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %not_speculatable_0 = stablehlo.xor %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %not_speculatable_1 = stablehlo.xor %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
-  %not_speculatable_2 = stablehlo.xor %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %not_speculatable_3 = stablehlo.xor %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %not_speculatable_4 = stablehlo.xor %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %not_speculatable_5 = stablehlo.xor %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_4) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_5) : (tensor<?xi64>) -> ()
+  %0 = stablehlo.xor %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<2xi64>
+  %1 = stablehlo.xor %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
+  %2 = stablehlo.xor %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
+  %3 = stablehlo.xor %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
+  %4 = stablehlo.xor %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
+  %5 = stablehlo.xor %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
+  %6 = stablehlo.xor %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
+  %7 = stablehlo.xor %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xi64>) -> ()
   return
 }
 
@@ -1252,16 +1289,16 @@ func.func @xor(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
 // CHECK-LABEL: func @clamp
 // CHECK-NEXT: return
 func.func @clamp(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.clamp %static_arg, %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.clamp %dynamic_arg, %static_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_1 = stablehlo.clamp %static_arg, %dynamic_arg, %static_arg : (tensor<2xf64>, tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_2 = stablehlo.clamp %static_arg, %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %not_speculatable_3 = stablehlo.clamp %dynamic_arg, %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.clamp %static_arg, %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %1 = stablehlo.clamp %dynamic_arg, %static_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.clamp %static_arg, %dynamic_arg, %static_arg : (tensor<2xf64>, tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %3 = stablehlo.clamp %static_arg, %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
+  %4 = stablehlo.clamp %dynamic_arg, %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -1270,14 +1307,14 @@ func.func @clamp(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @compare
 // CHECK-NEXT: return
 func.func @compare(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.compare EQ, %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xi1>
-  %not_speculatable_0 = stablehlo.compare EQ, %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xi1>
-  %not_speculatable_1 = stablehlo.compare EQ, %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xi1>
-  %not_speculatable_2 = stablehlo.compare EQ, %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xi1>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<?xi1>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<?xi1>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xi1>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<?xi1>) -> ()
+  %0 = stablehlo.compare EQ, %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xi1>
+  %1 = stablehlo.compare EQ, %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xi1>
+  %2 = stablehlo.compare EQ, %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xi1>
+  %3 = stablehlo.compare EQ, %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xi1>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<?xi1>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?xi1>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?xi1>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xi1>) -> ()
   return
 }
 
@@ -1286,14 +1323,14 @@ func.func @compare(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @complex
 // CHECK-NEXT: return
 func.func @complex(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.complex %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xcomplex<f64>>
-  %not_speculatable_0 = stablehlo.complex %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xcomplex<f64>>
-  %not_speculatable_1 = stablehlo.complex %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xcomplex<f64>>
-  %not_speculatable_2 = stablehlo.complex %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xcomplex<f64>>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<?xcomplex<f64>>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<?xcomplex<f64>>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xcomplex<f64>>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<?xcomplex<f64>>) -> ()
+  %0 = stablehlo.complex %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xcomplex<f64>>
+  %1 = stablehlo.complex %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xcomplex<f64>>
+  %2 = stablehlo.complex %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xcomplex<f64>>
+  %3 = stablehlo.complex %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xcomplex<f64>>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<?xcomplex<f64>>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?xcomplex<f64>>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?xcomplex<f64>>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xcomplex<f64>>) -> ()
   return
 }
 
@@ -1302,16 +1339,16 @@ func.func @complex(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-LABEL: func @select
 // CHECK-NEXT: return
 func.func @select(%static_pred: tensor<2xi1>, %dynamic_pred: tensor<?xi1>, %static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
-  %speculatable_0 = stablehlo.select %static_pred, %static_arg, %static_arg : (tensor<2xi1>, tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.select %dynamic_pred, %static_arg, %static_arg : (tensor<?xi1>, tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_1 = stablehlo.select %static_pred, %dynamic_arg, %static_arg : (tensor<2xi1>, tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %not_speculatable_2 = stablehlo.select %static_pred, %static_arg, %dynamic_arg : (tensor<2xi1>, tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %not_speculatable_3 = stablehlo.select %dynamic_pred, %dynamic_arg, %dynamic_arg : (tensor<?xi1>, tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.select %static_pred, %static_arg, %static_arg : (tensor<2xi1>, tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %1 = stablehlo.select %dynamic_pred, %static_arg, %static_arg : (tensor<?xi1>, tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %2 = stablehlo.select %static_pred, %dynamic_arg, %static_arg : (tensor<2xi1>, tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
+  %3 = stablehlo.select %static_pred, %static_arg, %dynamic_arg : (tensor<2xi1>, tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
+  %4 = stablehlo.select %dynamic_pred, %dynamic_arg, %dynamic_arg : (tensor<?xi1>, tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -1324,43 +1361,45 @@ func.func @select(%static_pred: tensor<2xi1>, %dynamic_pred: tensor<?xi1>, %stat
 // CHECK-LABEL: func @concatenate
 // CHECK-NEXT: return
 func.func @concatenate(%static_arg: tensor<2x2xi64>, %first_dim_dynamic: tensor<?x2xi64>, %second_dim_dynamic: tensor<2x?xi64>, %dynamic_arg: tensor<?x?xi64>) {
-  %speculatable_0 = stablehlo.concatenate %static_arg, %static_arg, dim = 0 : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<?x?xi64>
-  %speculatable_1 = stablehlo.concatenate %static_arg, %static_arg, dim = 1 : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<?x?xi64>
-  %speculatable_2 = stablehlo.concatenate %static_arg, %first_dim_dynamic, dim = 0 : (tensor<2x2xi64>, tensor<?x2xi64>) -> tensor<?x?xi64>
-  %speculatable_3 = stablehlo.concatenate %second_dim_dynamic, %static_arg, dim = 1 : (tensor<2x?xi64>, tensor<2x2xi64>) -> tensor<?x?xi64>
+  // Non-concat dims are static
+  %0 = stablehlo.concatenate %static_arg, %static_arg, dim = 0 : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<4x2xi64>
+  %1 = stablehlo.concatenate %static_arg, %static_arg, dim = 1 : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<2x4xi64>
+  %2 = stablehlo.concatenate %static_arg, %static_arg, dim = 0 : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<?x?xi64>
+  %3 = stablehlo.concatenate %static_arg, %static_arg, dim = 1 : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<?x?xi64>
+  %4 = stablehlo.concatenate %static_arg, %first_dim_dynamic, dim = 0 : (tensor<2x2xi64>, tensor<?x2xi64>) -> tensor<?x?xi64>
+  %5 = stablehlo.concatenate %second_dim_dynamic, %static_arg, dim = 1 : (tensor<2x?xi64>, tensor<2x2xi64>) -> tensor<?x?xi64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<4x2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<2x4xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%2) : (tensor<?x?xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?x?xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%4) : (tensor<?x?xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%5) : (tensor<?x?xi64>) -> ()
 
-  %speculatable_4 = stablehlo.concatenate %static_arg, %static_arg, dim = 0 : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<4x2xi64>
-  %speculatable_5 = stablehlo.concatenate %static_arg, %static_arg, dim = 1 : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<2x4xi64>
-  %not_speculatable_0 = stablehlo.concatenate %static_arg, %first_dim_dynamic, dim = 0 : (tensor<2x2xi64>, tensor<?x2xi64>) -> tensor<4x2xi64>
-  %not_speculatable_1 = stablehlo.concatenate %second_dim_dynamic, %static_arg, dim = 1 : (tensor<2x?xi64>, tensor<2x2xi64>) -> tensor<2x4xi64>
+  // Concat dim dynamic in input
+  %6 = stablehlo.concatenate %static_arg, %first_dim_dynamic, dim = 0 : (tensor<2x2xi64>, tensor<?x2xi64>) -> tensor<4x2xi64>
+  %7 = stablehlo.concatenate %second_dim_dynamic, %static_arg, dim = 1 : (tensor<2x?xi64>, tensor<2x2xi64>) -> tensor<2x4xi64>
+  %8 = stablehlo.concatenate %first_dim_dynamic, %first_dim_dynamic, dim = 0 : (tensor<?x2xi64>, tensor<?x2xi64>) -> tensor<4x?xi64>
+  %9 = stablehlo.concatenate %second_dim_dynamic, %second_dim_dynamic, dim = 1 : (tensor<2x?xi64>, tensor<2x?xi64>) -> tensor<?x4xi64>
+  %10 = stablehlo.concatenate %first_dim_dynamic, %first_dim_dynamic, dim = 0 : (tensor<?x2xi64>, tensor<?x2xi64>) -> tensor<?x?xi64>
+  %11 = stablehlo.concatenate %second_dim_dynamic, %second_dim_dynamic, dim = 1 : (tensor<2x?xi64>, tensor<2x?xi64>) -> tensor<?x?xi64>
+  "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<4x2xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<2x4xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%8) : (tensor<4x?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%9) : (tensor<?x4xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%10) : (tensor<?x?xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%11) : (tensor<?x?xi64>) -> ()
 
-  %speculatable_6 = stablehlo.concatenate %first_dim_dynamic, %first_dim_dynamic, dim = 0 : (tensor<?x2xi64>, tensor<?x2xi64>) -> tensor<?x?xi64>
-  %not_speculatable_2 = stablehlo.concatenate %first_dim_dynamic, %first_dim_dynamic, dim = 0 : (tensor<?x2xi64>, tensor<?x2xi64>) -> tensor<4x?xi64>
-  %not_speculatable_3 = stablehlo.concatenate %first_dim_dynamic, %first_dim_dynamic, dim = 1 : (tensor<?x2xi64>, tensor<?x2xi64>) -> tensor<?x?xi64>
+  // Non-concat dim dynamic in input
+  %12 = stablehlo.concatenate %first_dim_dynamic, %first_dim_dynamic, dim = 1 : (tensor<?x2xi64>, tensor<?x2xi64>) -> tensor<?x?xi64>
+  %13 = stablehlo.concatenate %second_dim_dynamic, %second_dim_dynamic, dim = 0 : (tensor<2x?xi64>, tensor<2x?xi64>) -> tensor<?x?xi64>
+  "hlo_test_speculatability.is_not_speculatable"(%12) : (tensor<?x?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%13) : (tensor<?x?xi64>) -> ()
 
-  %not_speculatable_4 = stablehlo.concatenate %second_dim_dynamic, %second_dim_dynamic, dim = 0 : (tensor<2x?xi64>, tensor<2x?xi64>) -> tensor<?x?xi64>
-  %not_speculatable_5 = stablehlo.concatenate %second_dim_dynamic, %second_dim_dynamic, dim = 1 : (tensor<2x?xi64>, tensor<2x?xi64>) -> tensor<?x4xi64>
-  %speculatable_7 = stablehlo.concatenate %second_dim_dynamic, %second_dim_dynamic, dim = 1 : (tensor<2x?xi64>, tensor<2x?xi64>) -> tensor<?x?xi64>
-
-  %not_speculatable_6 = stablehlo.concatenate %dynamic_arg, %dynamic_arg, dim = 0 : (tensor<?x?xi64>, tensor<?x?xi64>) -> tensor<?x?xi64>
-  %not_speculatable_7 = stablehlo.concatenate %dynamic_arg, %dynamic_arg, dim = 1 : (tensor<?x?xi64>, tensor<?x?xi64>) -> tensor<?x?xi64>
-
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<?x?xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?x?xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?x?xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_3) : (tensor<?x?xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_4) : (tensor<4x2xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_5) : (tensor<2x4xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_6) : (tensor<?x?xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_7) : (tensor<?x?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<4x2xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<2x4xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<4x?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?x?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_4) : (tensor<?x?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_5) : (tensor<?x4xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_6) : (tensor<?x?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_7) : (tensor<?x?xi64>) -> ()
+  // Fully dynamic
+  %14 = stablehlo.concatenate %dynamic_arg, %dynamic_arg, dim = 0 : (tensor<?x?xi64>, tensor<?x?xi64>) -> tensor<?x?xi64>
+  %15 = stablehlo.concatenate %dynamic_arg, %dynamic_arg, dim = 1 : (tensor<?x?xi64>, tensor<?x?xi64>) -> tensor<?x?xi64>
+  "hlo_test_speculatability.is_not_speculatable"(%14) : (tensor<?x?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%15) : (tensor<?x?xi64>) -> ()
   return
 }
 
@@ -1528,7 +1567,8 @@ func.func @gather(
   %static_arg: tensor<3x4x2xi32>, %static_indices: tensor<2x3x2xi64>,
   %dynamic_arg: tensor<?x?x?xi32>, %dynamic_indices: tensor<?x?x?xi64>
 ) {
-  %speculatable_0 = "stablehlo.gather"(%static_arg, %static_indices) {
+  // Static inputs, indices_are_sorted = false
+  %0 = "stablehlo.gather"(%static_arg, %static_indices) {
     dimension_numbers = #stablehlo.gather<
       offset_dims = [2, 3],
       collapsed_slice_dims = [0],
@@ -1537,7 +1577,10 @@ func.func @gather(
     slice_sizes = array<i64: 1, 2, 2>,
     indices_are_sorted = false
   } : (tensor<3x4x2xi32>, tensor<2x3x2xi64>) -> tensor<?x?x?x?xi32>
-  %not_speculatable_0 = "stablehlo.gather"(%static_arg, %static_indices) {
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<?x?x?x?xi32>) -> ()
+
+  // Static inputs, indices_are_sorted = true
+  %1 = "stablehlo.gather"(%static_arg, %static_indices) {
     dimension_numbers = #stablehlo.gather<
       offset_dims = [2, 3],
       collapsed_slice_dims = [0],
@@ -1546,38 +1589,39 @@ func.func @gather(
     slice_sizes = array<i64: 1, 2, 2>,
     indices_are_sorted = true
   } : (tensor<3x4x2xi32>, tensor<2x3x2xi64>) -> tensor<?x?x?x?xi32>
-  %not_speculatable_1 = "stablehlo.gather"(%dynamic_arg, %static_indices) {
+  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?x?x?x?xi32>) -> ()
+
+  // Dynamic inputs
+  %2 = "stablehlo.gather"(%dynamic_arg, %static_indices) {
     dimension_numbers = #stablehlo.gather<
       offset_dims = [2, 3],
       collapsed_slice_dims = [0],
       start_index_map = [1, 0],
       index_vector_dim = 2>,
     slice_sizes = array<i64: 1, 2, 2>,
-    indices_are_sorted = true
+    indices_are_sorted = false
   } : (tensor<?x?x?xi32>, tensor<2x3x2xi64>) -> tensor<?x?x?x?xi32>
-  %not_speculatable_2 = "stablehlo.gather"(%static_arg, %dynamic_indices) {
+  %3 = "stablehlo.gather"(%static_arg, %dynamic_indices) {
     dimension_numbers = #stablehlo.gather<
       offset_dims = [2, 3],
       collapsed_slice_dims = [0],
       start_index_map = [1, 0],
       index_vector_dim = 2>,
     slice_sizes = array<i64: 1, 2, 2>,
-    indices_are_sorted = true
+    indices_are_sorted = false
   } : (tensor<3x4x2xi32>, tensor<?x?x?xi64>) -> tensor<?x?x?x?xi32>
-  %not_speculatable_3 = "stablehlo.gather"(%dynamic_arg, %dynamic_indices) {
+  %4 = "stablehlo.gather"(%dynamic_arg, %dynamic_indices) {
     dimension_numbers = #stablehlo.gather<
       offset_dims = [2, 3],
       collapsed_slice_dims = [0],
       start_index_map = [1, 0],
       index_vector_dim = 2>,
     slice_sizes = array<i64: 1, 2, 2>,
-    indices_are_sorted = true
+    indices_are_sorted = false
   } : (tensor<?x?x?xi32>, tensor<?x?x?xi64>) -> tensor<?x?x?x?xi32>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<?x?x?x?xi32>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<?x?x?x?xi32>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?x?x?x?xi32>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<?x?x?x?xi32>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?x?x?x?xi32>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?x?x?x?xi32>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?x?x?x?xi32>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<?x?x?x?xi32>) -> ()
   return
 }
 
@@ -1589,7 +1633,8 @@ func.func @scatter(
   %static_inputs: tensor<3x4x2xf64>, %static_indices: tensor<2x3x2xi64>, %static_updates: tensor<2x3x2x2xf64>,
   %dynamic_inputs: tensor<?x?x?xf64>, %dynamic_indices: tensor<?x?x?xi64>, %dynamic_updates: tensor<?x?x?x?xf64>
 ) {
-  %recursively_speculatable_0 = "stablehlo.scatter"(%static_inputs, %static_indices, %static_updates) ({
+  // Static inputs, indices_are_sorted = false, unique_indices = false
+  %0 = "stablehlo.scatter"(%static_inputs, %static_indices, %static_updates) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
       stablehlo.return %arg0 : tensor<f64>
   }) {
@@ -1601,7 +1646,10 @@ func.func @scatter(
     indices_are_sorted = false,
     unique_indices = false
   } : (tensor<3x4x2xf64>, tensor<2x3x2xi64>, tensor<2x3x2x2xf64>) -> tensor<?x?x?xf64>
-  %not_speculatable_0 = "stablehlo.scatter"(%static_inputs, %static_indices, %static_updates) ({
+  "hlo_test_speculatability.is_recursively_speculatable"(%0) : (tensor<?x?x?xf64>) -> ()
+
+  // Static inputs, indices_are_sorted = false, unique_indices = true
+  %1 = "stablehlo.scatter"(%static_inputs, %static_indices, %static_updates) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
       stablehlo.return %arg0 : tensor<f64>
   }) {
@@ -1613,7 +1661,10 @@ func.func @scatter(
     indices_are_sorted = false,
     unique_indices = true
   } : (tensor<3x4x2xf64>, tensor<2x3x2xi64>, tensor<2x3x2x2xf64>) -> tensor<?x?x?xf64>
-  %not_speculatable_1 = "stablehlo.scatter"(%static_inputs, %static_indices, %static_updates) ({
+  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?x?x?xf64>) -> ()
+
+  // Static inputs, indices_are_sorted = true, unique_indices = false
+  %2 = "stablehlo.scatter"(%static_inputs, %static_indices, %static_updates) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
       stablehlo.return %arg0 : tensor<f64>
   }) {
@@ -1625,7 +1676,10 @@ func.func @scatter(
     indices_are_sorted = true,
     unique_indices = false
   } : (tensor<3x4x2xf64>, tensor<2x3x2xi64>, tensor<2x3x2x2xf64>) -> tensor<?x?x?xf64>
-  %not_speculatable_2 = "stablehlo.scatter"(%dynamic_inputs, %static_indices, %static_updates) ({
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?x?x?xf64>) -> ()
+
+  // Dynamic inputs
+  %3 = "stablehlo.scatter"(%dynamic_inputs, %static_indices, %static_updates) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
       stablehlo.return %arg0 : tensor<f64>
   }) {
@@ -1637,7 +1691,7 @@ func.func @scatter(
     indices_are_sorted = false,
     unique_indices = false
   } : (tensor<?x?x?xf64>, tensor<2x3x2xi64>, tensor<2x3x2x2xf64>) -> tensor<?x?x?xf64>
-  %not_speculatable_3 = "stablehlo.scatter"(%static_inputs, %dynamic_indices, %static_updates) ({
+  %4 = "stablehlo.scatter"(%static_inputs, %dynamic_indices, %static_updates) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
       stablehlo.return %arg0 : tensor<f64>
   }) {
@@ -1649,7 +1703,7 @@ func.func @scatter(
     indices_are_sorted = false,
     unique_indices = false
   } : (tensor<3x4x2xf64>, tensor<?x?x?xi64>, tensor<2x3x2x2xf64>) -> tensor<?x?x?xf64>
-  %not_speculatable_4 = "stablehlo.scatter"(%static_inputs, %static_indices, %dynamic_updates) ({
+  %5 = "stablehlo.scatter"(%static_inputs, %static_indices, %dynamic_updates) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
       stablehlo.return %arg0 : tensor<f64>
   }) {
@@ -1661,12 +1715,9 @@ func.func @scatter(
     indices_are_sorted = false,
     unique_indices = false
   } : (tensor<3x4x2xf64>, tensor<2x3x2xi64>, tensor<?x?x?x?xf64>) -> tensor<?x?x?xf64>
-  "hlo_test_speculatability.is_recursively_speculatable"(%recursively_speculatable_0) : (tensor<?x?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<?x?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?x?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<?x?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_3) : (tensor<?x?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_4) : (tensor<?x?x?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?x?x?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<?x?x?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?x?x?xf64>) -> ()
   return
 }
 
@@ -1680,22 +1731,22 @@ func.func @scatter(
 // CHECK-NEXT:  return
 func.func @dynamic_iota(%unknown_shape: tensor<2xi32>) {
   %constant_shape = stablehlo.constant dense<[3, 4]> : tensor<2xi32>
-  %speculatable_0 = stablehlo.dynamic_iota %constant_shape, dim = 0 : (tensor<2xi32>) -> tensor<3x4xi64>
-  %speculatable_1 = stablehlo.dynamic_iota %constant_shape, dim = 0 : (tensor<2xi32>) -> tensor<3x?xi64>
-  %speculatable_2 = stablehlo.dynamic_iota %constant_shape, dim = 0 : (tensor<2xi32>) -> tensor<?x4xi64>
-  %speculatable_3 = stablehlo.dynamic_iota %constant_shape, dim = 0 : (tensor<2xi32>) -> tensor<?x?xi64>
-  %not_speculatable_0 = stablehlo.dynamic_iota %unknown_shape, dim = 0 : (tensor<2xi32>) -> tensor<3x4xi64>
-  %not_speculatable_1 = stablehlo.dynamic_iota %unknown_shape, dim = 0 : (tensor<2xi32>) -> tensor<3x?xi64>
-  %not_speculatable_2 = stablehlo.dynamic_iota %unknown_shape, dim = 0 : (tensor<2xi32>) -> tensor<?x4xi64>
-  %speculatable_4 = stablehlo.dynamic_iota %unknown_shape, dim = 0 : (tensor<2xi32>) -> tensor<?x?xi64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<3x4xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<3x?xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?x4xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_3) : (tensor<?x?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<3x4xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<3x?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<?x4xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_4) : (tensor<?x?xi64>) -> ()
+  %0 = stablehlo.dynamic_iota %constant_shape, dim = 0 : (tensor<2xi32>) -> tensor<3x4xi64>
+  %1 = stablehlo.dynamic_iota %constant_shape, dim = 0 : (tensor<2xi32>) -> tensor<3x?xi64>
+  %2 = stablehlo.dynamic_iota %constant_shape, dim = 0 : (tensor<2xi32>) -> tensor<?x4xi64>
+  %3 = stablehlo.dynamic_iota %constant_shape, dim = 0 : (tensor<2xi32>) -> tensor<?x?xi64>
+  %4 = stablehlo.dynamic_iota %unknown_shape, dim = 0 : (tensor<2xi32>) -> tensor<3x4xi64>
+  %5 = stablehlo.dynamic_iota %unknown_shape, dim = 0 : (tensor<2xi32>) -> tensor<3x?xi64>
+  %6 = stablehlo.dynamic_iota %unknown_shape, dim = 0 : (tensor<2xi32>) -> tensor<?x4xi64>
+  %7 = stablehlo.dynamic_iota %unknown_shape, dim = 0 : (tensor<2xi32>) -> tensor<?x?xi64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<3x4xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<3x?xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%2) : (tensor<?x4xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?x?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<3x4xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<3x?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<?x4xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%7) : (tensor<?x?xi64>) -> ()
   return
 }
 
@@ -1770,26 +1821,26 @@ func.func @dynamic_reshape(
 // CHECK-LABEL: func @map
 // CHECK-NEXT: return
 func.func @map(%static_arg: tensor<2x4xf64>, %dynamic_arg: tensor<?x?xf64>, %arg: tensor<f64>) {
-  %recursively_speculatable_0 = "stablehlo.map"(%static_arg, %static_arg) ({
+  %0 = "stablehlo.map"(%static_arg, %static_arg) ({
     ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
       stablehlo.return %arg : tensor<f64>
   }) {dimensions = array<i64: 0, 1>} : (tensor<2x4xf64>, tensor<2x4xf64>) -> tensor<?x?xf64>
-  %not_speculatable_0 = "stablehlo.map"(%static_arg, %dynamic_arg) ({
+  %1 = "stablehlo.map"(%static_arg, %dynamic_arg) ({
     ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
       stablehlo.return %arg : tensor<f64>
   }) {dimensions = array<i64: 0, 1>} : (tensor<2x4xf64>, tensor<?x?xf64>) -> tensor<?x?xf64>
-  %not_speculatable_1 = "stablehlo.map"(%dynamic_arg, %static_arg) ({
+  %2 = "stablehlo.map"(%dynamic_arg, %static_arg) ({
     ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
       stablehlo.return %arg : tensor<f64>
   }) {dimensions = array<i64: 0, 1>} : (tensor<?x?xf64>, tensor<2x4xf64>) -> tensor<?x?xf64>
-  %not_speculatable_2 = "stablehlo.map"(%dynamic_arg, %dynamic_arg) ({
+  %3 = "stablehlo.map"(%dynamic_arg, %dynamic_arg) ({
     ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
       stablehlo.return %arg : tensor<f64>
   }) {dimensions = array<i64: 0, 1>} : (tensor<?x?xf64>, tensor<?x?xf64>) -> tensor<?x?xf64>
-  "hlo_test_speculatability.is_recursively_speculatable"(%recursively_speculatable_0) : (tensor<?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<?x?xf64>) -> ()
+  "hlo_test_speculatability.is_recursively_speculatable"(%0) : (tensor<?x?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?x?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?x?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?x?xf64>) -> ()
   return
 }
 
@@ -1798,26 +1849,26 @@ func.func @map(%static_arg: tensor<2x4xf64>, %dynamic_arg: tensor<?x?xf64>, %arg
 // CHECK-LABEL: func @reduce
 // CHECK-NEXT: return
 func.func @reduce(%static_arg: tensor<2x4xf64>, %dynamic_arg: tensor<?x?xf64>, %init_arg: tensor<f64>) {
-  %recursively_speculatable_0:2 = "stablehlo.reduce"(%static_arg, %static_arg, %init_arg, %init_arg) ({
+  %0:2 = "stablehlo.reduce"(%static_arg, %static_arg, %init_arg, %init_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>):
       stablehlo.return %arg0, %arg0 : tensor<f64>, tensor<f64>
   }) {dimensions = array<i64: 0>} : (tensor<2x4xf64>, tensor<2x4xf64>, tensor<f64>, tensor<f64>) -> (tensor<?xf64>, tensor<?xf64>)
-  %not_speculatable_0:2 = "stablehlo.reduce"(%dynamic_arg, %static_arg, %init_arg, %init_arg) ({
+  %1:2 = "stablehlo.reduce"(%dynamic_arg, %static_arg, %init_arg, %init_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>):
       stablehlo.return %arg0, %arg0 : tensor<f64>, tensor<f64>
   }) {dimensions = array<i64: 0>} : (tensor<?x?xf64>, tensor<2x4xf64>, tensor<f64>, tensor<f64>) -> (tensor<?xf64>, tensor<?xf64>)
-  %not_speculatable_1:2 = "stablehlo.reduce"(%static_arg, %dynamic_arg, %init_arg, %init_arg) ({
+  %2:2 = "stablehlo.reduce"(%static_arg, %dynamic_arg, %init_arg, %init_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>):
       stablehlo.return %arg0, %arg0 : tensor<f64>, tensor<f64>
   }) {dimensions = array<i64: 0>} : (tensor<2x4xf64>, tensor<?x?xf64>, tensor<f64>, tensor<f64>) -> (tensor<?xf64>, tensor<?xf64>)
-  %not_speculatable_2:2 = "stablehlo.reduce"(%dynamic_arg, %dynamic_arg, %init_arg, %init_arg) ({
+  %3:2 = "stablehlo.reduce"(%dynamic_arg, %dynamic_arg, %init_arg, %init_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>):
       stablehlo.return %arg0, %arg0 : tensor<f64>, tensor<f64>
   }) {dimensions = array<i64: 0>} : (tensor<?x?xf64>, tensor<?x?xf64>, tensor<f64>, tensor<f64>) -> (tensor<?xf64>, tensor<?xf64>)
-  "hlo_test_speculatability.is_recursively_speculatable"(%recursively_speculatable_0) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_recursively_speculatable"(%0) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -1826,7 +1877,7 @@ func.func @reduce(%static_arg: tensor<2x4xf64>, %dynamic_arg: tensor<?x?xf64>, %
 // CHECK-LABEL: func @reduce_window
 // CHECK-NEXT: return
 func.func @reduce_window(%static_arg: tensor<2x4xf64>, %dynamic_arg: tensor<?x?xf64>, %init_arg: tensor<f64>) {
-  %recursively_speculatable_0:2 = "stablehlo.reduce_window"(%static_arg, %static_arg, %init_arg, %init_arg) ({
+  %0:2 = "stablehlo.reduce_window"(%static_arg, %static_arg, %init_arg, %init_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>):
       stablehlo.return %arg0, %arg0 : tensor<f64>, tensor<f64>
     }) {
@@ -1836,7 +1887,9 @@ func.func @reduce_window(%static_arg: tensor<2x4xf64>, %dynamic_arg: tensor<?x?x
     window_dilations = array<i64: 1, 1>,
     padding = dense<[[0, 0], [0, 0]]> : tensor<2x2xi64>
   } : (tensor<2x4xf64>,  tensor<2x4xf64>, tensor<f64>, tensor<f64>) -> (tensor<?x?xf64>, tensor<?x?xf64>)
-  %not_speculatable_0:2 = "stablehlo.reduce_window"(%dynamic_arg, %static_arg, %init_arg, %init_arg) ({
+  "hlo_test_speculatability.is_recursively_speculatable"(%0) : (tensor<?x?xf64>) -> ()
+
+  %1:2 = "stablehlo.reduce_window"(%dynamic_arg, %static_arg, %init_arg, %init_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>):
       stablehlo.return %arg0, %arg0 : tensor<f64>, tensor<f64>
     }) {
@@ -1846,7 +1899,9 @@ func.func @reduce_window(%static_arg: tensor<2x4xf64>, %dynamic_arg: tensor<?x?x
     window_dilations = array<i64: 1, 1>,
     padding = dense<[[0, 0], [0, 0]]> : tensor<2x2xi64>
   } : (tensor<?x?xf64>,  tensor<2x4xf64>, tensor<f64>, tensor<f64>) -> (tensor<?x?xf64>, tensor<?x?xf64>)
-  %not_speculatable_1:2 = "stablehlo.reduce_window"(%static_arg, %dynamic_arg, %init_arg, %init_arg) ({
+  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?x?xf64>) -> ()
+
+  %2:2 = "stablehlo.reduce_window"(%static_arg, %dynamic_arg, %init_arg, %init_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>):
       stablehlo.return %arg0, %arg0 : tensor<f64>, tensor<f64>
     }) {
@@ -1856,7 +1911,9 @@ func.func @reduce_window(%static_arg: tensor<2x4xf64>, %dynamic_arg: tensor<?x?x
     window_dilations = array<i64: 1, 1>,
     padding = dense<[[0, 0], [0, 0]]> : tensor<2x2xi64>
   } : (tensor<2x4xf64>,  tensor<?x?xf64>, tensor<f64>, tensor<f64>) -> (tensor<?x?xf64>, tensor<?x?xf64>)
-  %not_speculatable_2:2 = "stablehlo.reduce_window"(%dynamic_arg, %dynamic_arg, %init_arg, %init_arg) ({
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?x?xf64>) -> ()
+
+  %3:2 = "stablehlo.reduce_window"(%dynamic_arg, %dynamic_arg, %init_arg, %init_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>):
       stablehlo.return %arg0, %arg0 : tensor<f64>, tensor<f64>
     }) {
@@ -1866,10 +1923,7 @@ func.func @reduce_window(%static_arg: tensor<2x4xf64>, %dynamic_arg: tensor<?x?x
     window_dilations = array<i64: 1, 1>,
     padding = dense<[[0, 0], [0, 0]]> : tensor<2x2xi64>
   } : (tensor<?x?xf64>,  tensor<?x?xf64>, tensor<f64>, tensor<f64>) -> (tensor<?x?xf64>, tensor<?x?xf64>)
-  "hlo_test_speculatability.is_recursively_speculatable"(%recursively_speculatable_0) : (tensor<?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<?x?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?x?xf64>) -> ()
   return
 }
 
@@ -1883,12 +1937,12 @@ func.func @select_and_scatter(
 ) {
   // Inputs and output are static
   %0 = "stablehlo.select_and_scatter"(%static_arg, %source, %init) ({
-  ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
-    %c0 = stablehlo.constant dense<false> : tensor<i1>
-    stablehlo.return %c0 : tensor<i1>
+    ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
+      %c0 = stablehlo.constant dense<false> : tensor<i1>
+      stablehlo.return %c0 : tensor<i1>
   },  {
-  ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
-    stablehlo.return %arg0 : tensor<f64>
+    ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
+      stablehlo.return %arg0 : tensor<f64>
   }) {
     window_dimensions = array<i64: 1, 2, 2, 1>,
     window_strides = array<i64: 1, 2, 2, 1>
@@ -1897,12 +1951,12 @@ func.func @select_and_scatter(
 
   // Inputs are static, output is dynamic
   %1 = "stablehlo.select_and_scatter"(%static_arg, %source, %init) ({
-  ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
-    %c0 = stablehlo.constant dense<false> : tensor<i1>
-    stablehlo.return %c0 : tensor<i1>
+    ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
+      %c0 = stablehlo.constant dense<false> : tensor<i1>
+      stablehlo.return %c0 : tensor<i1>
   },  {
-  ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
-    stablehlo.return %arg0 : tensor<f64>
+    ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
+      stablehlo.return %arg0 : tensor<f64>
   }) {
     window_dimensions = array<i64: 1, 2, 2, 1>,
     window_strides = array<i64: 1, 2, 2, 1>
@@ -1911,12 +1965,12 @@ func.func @select_and_scatter(
 
   // Inputs are dynamic, output is static
   %2 = "stablehlo.select_and_scatter"(%dynamic_arg, %source, %init) ({
-  ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
-    %c0 = stablehlo.constant dense<false> : tensor<i1>
-    stablehlo.return %c0 : tensor<i1>
+    ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
+      %c0 = stablehlo.constant dense<false> : tensor<i1>
+      stablehlo.return %c0 : tensor<i1>
   },  {
-  ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
-    stablehlo.return %arg0 : tensor<f64>
+    ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
+      stablehlo.return %arg0 : tensor<f64>
   }) {
     window_dimensions = array<i64: 1, 2, 2, 1>,
     window_strides = array<i64: 1, 2, 2, 1>
@@ -1925,12 +1979,12 @@ func.func @select_and_scatter(
 
   // Inputs and output are dynamic
   %3 = "stablehlo.select_and_scatter"(%dynamic_arg, %source, %init) ({
-  ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
-    %c0 = stablehlo.constant dense<false> : tensor<i1>
-    stablehlo.return %c0 : tensor<i1>
+    ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
+      %c0 = stablehlo.constant dense<false> : tensor<i1>
+      stablehlo.return %c0 : tensor<i1>
   },  {
-  ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
-    stablehlo.return %arg0 : tensor<f64>
+    ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
+      stablehlo.return %arg0 : tensor<f64>
   }) {
     window_dimensions = array<i64: 1, 2, 2, 1>,
     window_strides = array<i64: 1, 2, 2, 1>
@@ -1945,38 +1999,30 @@ func.func @select_and_scatter(
 // CHECK-LABEL: func @sort
 // CHECK-NEXT: return
 func.func @sort(%static_arg: tensor<2x4xf64>, %dynamic_arg: tensor<?x?xf64>) {
-  %recursively_speculatable_0:2 = "stablehlo.sort"(%static_arg, %static_arg) ({
+  %0:2 = "stablehlo.sort"(%static_arg, %static_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>):
-      %predicate = "stablehlo.compare"(%arg0, %arg1) {
-        comparison_direction = #stablehlo<comparison_direction GT>
-      } : (tensor<f64>, tensor<f64>) -> tensor<i1>
+      %predicate = stablehlo.constant dense<false> : tensor<i1>
       stablehlo.return %predicate : tensor<i1>
   }) {dimension = 0 : i64, is_stable = true} : (tensor<2x4xf64>, tensor<2x4xf64>) -> (tensor<?x?xf64>, tensor<?x?xf64>)
-  %not_recursively_speculatable_0:2 = "stablehlo.sort"(%dynamic_arg, %static_arg) ({
+  %1:2 = "stablehlo.sort"(%dynamic_arg, %static_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>):
-      %predicate = "stablehlo.compare"(%arg0, %arg1) {
-        comparison_direction = #stablehlo<comparison_direction GT>
-      } : (tensor<f64>, tensor<f64>) -> tensor<i1>
+      %predicate = stablehlo.constant dense<false> : tensor<i1>
       stablehlo.return %predicate : tensor<i1>
   }) {dimension = 0 : i64, is_stable = true} : (tensor<?x?xf64>, tensor<2x4xf64>) -> (tensor<?x?xf64>, tensor<?x?xf64>)
-  %not_recursively_speculatable_1:2 = "stablehlo.sort"(%static_arg, %dynamic_arg) ({
+  %2:2 = "stablehlo.sort"(%static_arg, %dynamic_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>):
-      %predicate = "stablehlo.compare"(%arg0, %arg1) {
-        comparison_direction = #stablehlo<comparison_direction GT>
-      } : (tensor<f64>, tensor<f64>) -> tensor<i1>
+      %predicate = stablehlo.constant dense<false> : tensor<i1>
       stablehlo.return %predicate : tensor<i1>
   }) {dimension = 0 : i64, is_stable = true} : (tensor<2x4xf64>, tensor<?x?xf64>) -> (tensor<?x?xf64>, tensor<?x?xf64>)
-  %not_recursively_speculatable_2:2 = "stablehlo.sort"(%dynamic_arg, %dynamic_arg) ({
+  %3:2 = "stablehlo.sort"(%dynamic_arg, %dynamic_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>):
-      %predicate = "stablehlo.compare"(%arg0, %arg1) {
-        comparison_direction = #stablehlo<comparison_direction GT>
-      } : (tensor<f64>, tensor<f64>) -> tensor<i1>
+      %predicate = stablehlo.constant dense<false> : tensor<i1>
       stablehlo.return %predicate : tensor<i1>
   }) {dimension = 0 : i64, is_stable = true} : (tensor<?x?xf64>, tensor<?x?xf64>) -> (tensor<?x?xf64>, tensor<?x?xf64>)
-  "hlo_test_speculatability.is_recursively_speculatable"(%recursively_speculatable_0) : (tensor<?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_recursively_speculatable_0) : (tensor<?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_recursively_speculatable_1) : (tensor<?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_recursively_speculatable_2) : (tensor<?x?xf64>) -> ()
+  "hlo_test_speculatability.is_recursively_speculatable"(%0) : (tensor<?x?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?x?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?x?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?x?xf64>) -> ()
   return
 }
 
@@ -1992,35 +2038,35 @@ func.func @bitcast_convert(
   %static_arg_64: tensor<2xi64>, %dynamic_arg_64: tensor<?xi64>,
   %static_arg_32: tensor<2x?xi32>, %dynamic_arg_32: tensor<?x?xi32>
 ) {
-  %speculatable_0 = stablehlo.bitcast_convert %static_arg_64 : (tensor<2xi64>) -> tensor<2xf64>
-  %speculatable_1 = stablehlo.bitcast_convert %static_arg_64 : (tensor<2xi64>) -> tensor<?xf64>
-  %not_speculatable_0 = stablehlo.bitcast_convert %dynamic_arg_64 : (tensor<?xi64>) -> tensor<2xf64>
-  %speculatable_2 = stablehlo.bitcast_convert %dynamic_arg_64 : (tensor<?xi64>) -> tensor<?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<2xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_2) : (tensor<?xf64>) -> ()
+  %0 = stablehlo.bitcast_convert %static_arg_64 : (tensor<2xi64>) -> tensor<2xf64>
+  %1 = stablehlo.bitcast_convert %static_arg_64 : (tensor<2xi64>) -> tensor<?xf64>
+  %2 = stablehlo.bitcast_convert %dynamic_arg_64 : (tensor<?xi64>) -> tensor<2xf64>
+  %3 = stablehlo.bitcast_convert %dynamic_arg_64 : (tensor<?xi64>) -> tensor<?xf64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
 
-  %speculatable_3 = stablehlo.bitcast_convert %static_arg_64 : (tensor<2xi64>) -> tensor<2x?xi32>
-  %speculatable_4 = stablehlo.bitcast_convert %static_arg_64 : (tensor<2xi64>) -> tensor<?x?xi32>
-  %not_speculatable_1 = stablehlo.bitcast_convert %dynamic_arg_64 : (tensor<?xi64>) -> tensor<2x?xi32>
-  %speculatable_5 = stablehlo.bitcast_convert %dynamic_arg_64 : (tensor<?xi64>) -> tensor<?x?xi32>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_3) : (tensor<2x?xi32>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_4) : (tensor<?x?xi32>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<2x?xi32>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_5) : (tensor<?x?xi32>) -> ()
+  %4 = stablehlo.bitcast_convert %static_arg_64 : (tensor<2xi64>) -> tensor<2x?xi32>
+  %5 = stablehlo.bitcast_convert %static_arg_64 : (tensor<2xi64>) -> tensor<?x?xi32>
+  %6 = stablehlo.bitcast_convert %dynamic_arg_64 : (tensor<?xi64>) -> tensor<2x?xi32>
+  %7 = stablehlo.bitcast_convert %dynamic_arg_64 : (tensor<?xi64>) -> tensor<?x?xi32>
+  "hlo_test_speculatability.is_speculatable"(%4) : (tensor<2x?xi32>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%5) : (tensor<?x?xi32>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2x?xi32>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%7) : (tensor<?x?xi32>) -> ()
 
-  %speculatable_6 = stablehlo.bitcast_convert %static_arg_32 : (tensor<2x?xi32>) -> tensor<2xi64>
-  %speculatable_7 = stablehlo.bitcast_convert %static_arg_32 : (tensor<2x?xi32>) -> tensor<?xi64>
-  %not_speculatable_2 = stablehlo.bitcast_convert %dynamic_arg_32 : (tensor<?x?xi32>) -> tensor<2xi64>
-  %speculatable_8 = stablehlo.bitcast_convert %dynamic_arg_32 : (tensor<?x?xi32>) -> tensor<?xi64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_6) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_7) : (tensor<?xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<2xi64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_8) : (tensor<?xi64>) -> ()
+  %8 = stablehlo.bitcast_convert %static_arg_32 : (tensor<2x?xi32>) -> tensor<2xi64>
+  %9 = stablehlo.bitcast_convert %static_arg_32 : (tensor<2x?xi32>) -> tensor<?xi64>
+  %10 = stablehlo.bitcast_convert %dynamic_arg_32 : (tensor<?x?xi32>) -> tensor<2xi64>
+  %11 = stablehlo.bitcast_convert %dynamic_arg_32 : (tensor<?x?xi32>) -> tensor<?xi64>
+  "hlo_test_speculatability.is_speculatable"(%8) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%9) : (tensor<?xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%10) : (tensor<2xi64>) -> ()
+  "hlo_test_speculatability.is_speculatable"(%11) : (tensor<?xi64>) -> ()
 
-  %speculatable_9 = stablehlo.bitcast_convert %static_arg_64 : (tensor<2xi64>) -> tensor<2x2xi32>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_9) : (tensor<2x2xi32>) -> ()
+  %12 = stablehlo.bitcast_convert %static_arg_64 : (tensor<2xi64>) -> tensor<2x2xi32>
+  "hlo_test_speculatability.is_speculatable"(%12) : (tensor<2x2xi32>) -> ()
   return
 }
 
@@ -2034,14 +2080,14 @@ func.func @reshape(
   %dynamic_1: tensor<3x?xi64>,
   %dynamic_2: tensor<?x?xi64>
 ) {
-  %speculatable = stablehlo.reshape %static : (tensor<3x4xi64>) -> tensor<12xi64>
-  %not_speculatable_0 = stablehlo.reshape %dynamic_0 : (tensor<?x4xi64>) -> tensor<12xi64>
-  %not_speculatable_1 = stablehlo.reshape %dynamic_1 : (tensor<3x?xi64>) -> tensor<12xi64>
-  %not_speculatable_2 = stablehlo.reshape %dynamic_2 : (tensor<?x?xi64>) -> tensor<12xi64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable) : (tensor<12xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_0) : (tensor<12xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_1) : (tensor<12xi64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_2) : (tensor<12xi64>) -> ()
+  %0 = stablehlo.reshape %static : (tensor<3x4xi64>) -> tensor<12xi64>
+  %1 = stablehlo.reshape %dynamic_0 : (tensor<?x4xi64>) -> tensor<12xi64>
+  %2 = stablehlo.reshape %dynamic_1 : (tensor<3x?xi64>) -> tensor<12xi64>
+  %3 = stablehlo.reshape %dynamic_2 : (tensor<?x?xi64>) -> tensor<12xi64>
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<12xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<12xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<12xi64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<12xi64>) -> ()
   return
 }
 
@@ -2053,26 +2099,31 @@ func.func @triangular_solve(
   %static: tensor<2x2xf64>,
   %dynamic: tensor<?x?xf64>
 ) {
-  %static_inputs = "stablehlo.triangular_solve"(%static, %static) {
+  // Static inputs
+  %0 = "stablehlo.triangular_solve"(%static, %static) {
     left_side = true, lower = true, transpose_a = #stablehlo<transpose NO_TRANSPOSE>, unit_diagonal = false
   } : (tensor<2x2xf64>, tensor<2x2xf64>) -> tensor<?x?xf64>
-  %dynamic_inputs_0 = "stablehlo.triangular_solve"(%dynamic, %static) {
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<?x?xf64>) -> ()
+
+  // Dynamic inputs
+  %1 = "stablehlo.triangular_solve"(%dynamic, %static) {
     left_side = true, lower = true, transpose_a = #stablehlo<transpose NO_TRANSPOSE>, unit_diagonal = false
   } : (tensor<?x?xf64>, tensor<2x2xf64>) -> tensor<?x?xf64>
-  %dynamic_inputs_1 = "stablehlo.triangular_solve"(%static, %dynamic) {
+  %2 = "stablehlo.triangular_solve"(%static, %dynamic) {
     left_side = true, lower = true, transpose_a = #stablehlo<transpose NO_TRANSPOSE>, unit_diagonal = false
   } : (tensor<2x2xf64>, tensor<?x?xf64>) -> tensor<?x?xf64>
-  %dynamic_inputs_2 = "stablehlo.triangular_solve"(%dynamic, %dynamic) {
+  %3 = "stablehlo.triangular_solve"(%dynamic, %dynamic) {
     left_side = true, lower = true, transpose_a = #stablehlo<transpose NO_TRANSPOSE>, unit_diagonal = false
   } : (tensor<?x?xf64>, tensor<?x?xf64>) -> tensor<?x?xf64>
-  %unit_diagonal = "stablehlo.triangular_solve"(%static, %static) {
+  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?x?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?x?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?x?xf64>) -> ()
+
+  // unit_diagonal = true
+  %4 = "stablehlo.triangular_solve"(%static, %static) {
     left_side = true, lower = true, transpose_a = #stablehlo<transpose NO_TRANSPOSE>, unit_diagonal = true
   } : (tensor<2x2xf64>, tensor<2x2xf64>) -> tensor<?x?xf64>
-  "hlo_test_speculatability.is_speculatable"(%static_inputs) : (tensor<?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%dynamic_inputs_0) : (tensor<?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%dynamic_inputs_1) : (tensor<?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%dynamic_inputs_2) : (tensor<?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%unit_diagonal) : (tensor<?x?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<?x?xf64>) -> ()
   return
 }
 
@@ -2081,14 +2132,14 @@ func.func @triangular_solve(
 // CHECK-LABEL: func @batch_norm_grad
 // CHECK-NEXT:  return
 func.func @batch_norm_grad(%static: tensor<2xf64>, %dynamic: tensor<?xf64>) {
-  %all_inputs_static:3 = "stablehlo.batch_norm_grad" (%static, %static, %static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
-  %first_input_dynamic:3 = "stablehlo.batch_norm_grad" (%dynamic, %static, %static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
-  %last_input_dynamic:3 = "stablehlo.batch_norm_grad" (%static, %static, %static, %static, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<?xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
-  %all_inputs_dynamic:3 = "stablehlo.batch_norm_grad" (%dynamic, %dynamic, %dynamic, %dynamic, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>, tensor<?xf64>, tensor<?xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
-  "hlo_test_speculatability.is_speculatable"(%all_inputs_static#0) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%first_input_dynamic#0) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%last_input_dynamic#0) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%all_inputs_dynamic#0) : (tensor<?xf64>) -> ()
+  %0:3 = "stablehlo.batch_norm_grad" (%static, %static, %static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
+  %1:3 = "stablehlo.batch_norm_grad" (%dynamic, %static, %static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
+  %2:3 = "stablehlo.batch_norm_grad" (%static, %static, %static, %static, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<?xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
+  %3:3 = "stablehlo.batch_norm_grad" (%dynamic, %dynamic, %dynamic, %dynamic, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>, tensor<?xf64>, tensor<?xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
+  "hlo_test_speculatability.is_speculatable"(%0#0) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%1#0) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2#0) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3#0) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -2097,14 +2148,14 @@ func.func @batch_norm_grad(%static: tensor<2xf64>, %dynamic: tensor<?xf64>) {
 // CHECK-LABEL: func @batch_norm_inference
 // CHECK-NEXT:  return
 func.func @batch_norm_inference(%static: tensor<2xf64>, %dynamic: tensor<?xf64>) {
-  %all_inputs_static = "stablehlo.batch_norm_inference" (%static, %static, %static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>)
-  %first_input_dynamic = "stablehlo.batch_norm_inference" (%dynamic, %static, %static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>)
-  %last_input_dynamic = "stablehlo.batch_norm_inference" (%static, %static, %static, %static, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<?xf64>) -> (tensor<?xf64>)
-  %all_inputs_dynamic = "stablehlo.batch_norm_inference" (%dynamic, %dynamic, %dynamic, %dynamic, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>, tensor<?xf64>, tensor<?xf64>) -> (tensor<?xf64>)
-  "hlo_test_speculatability.is_speculatable"(%all_inputs_static) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%first_input_dynamic) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%last_input_dynamic) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%all_inputs_dynamic) : (tensor<?xf64>) -> ()
+  %0 = "stablehlo.batch_norm_inference" (%static, %static, %static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>)
+  %1 = "stablehlo.batch_norm_inference" (%dynamic, %static, %static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>)
+  %2 = "stablehlo.batch_norm_inference" (%static, %static, %static, %static, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<?xf64>) -> (tensor<?xf64>)
+  %3 = "stablehlo.batch_norm_inference" (%dynamic, %dynamic, %dynamic, %dynamic, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>, tensor<?xf64>, tensor<?xf64>) -> (tensor<?xf64>)
+  "hlo_test_speculatability.is_speculatable"(%0) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
 
@@ -2113,13 +2164,13 @@ func.func @batch_norm_inference(%static: tensor<2xf64>, %dynamic: tensor<?xf64>)
 // CHECK-LABEL: func @batch_norm_training
 // CHECK-NEXT:  return
 func.func @batch_norm_training(%static: tensor<2xf64>, %dynamic: tensor<?xf64>) {
-  %all_inputs_static:3 = "stablehlo.batch_norm_training" (%static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
-  %first_input_dynamic:3 = "stablehlo.batch_norm_training" (%dynamic, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
-  %last_input_dynamic:3 = "stablehlo.batch_norm_training" (%static, %static, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<?xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
-  %all_inputs_dynamic:3 = "stablehlo.batch_norm_training" (%dynamic, %dynamic, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
-  "hlo_test_speculatability.is_speculatable"(%all_inputs_static#0) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%first_input_dynamic#0) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%last_input_dynamic#0) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%all_inputs_dynamic#0) : (tensor<?xf64>) -> ()
+  %0:3 = "stablehlo.batch_norm_training" (%static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
+  %1:3 = "stablehlo.batch_norm_training" (%dynamic, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
+  %2:3 = "stablehlo.batch_norm_training" (%static, %static, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<?xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
+  %3:3 = "stablehlo.batch_norm_training" (%dynamic, %dynamic, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
+  "hlo_test_speculatability.is_speculatable"(%0#0) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%1#0) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%2#0) : (tensor<?xf64>) -> ()
+  "hlo_test_speculatability.is_not_speculatable"(%3#0) : (tensor<?xf64>) -> ()
   return
 }

--- a/stablehlo/tests/ops_speculatability.mlir
+++ b/stablehlo/tests/ops_speculatability.mlir
@@ -20,12 +20,12 @@ func.func @abs_multidim(%dynamic_arg: tensor<?x?xf64>) {
 // CHECK-NEXT:  return
 func.func @abs(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.abs %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.abs %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.abs %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.abs %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.abs %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.abs %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.abs %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -36,12 +36,12 @@ func.func @abs(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT:  return
 func.func @cbrt(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.cbrt %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.cbrt %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.cbrt %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.cbrt %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.cbrt %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.cbrt %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.cbrt %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -52,12 +52,12 @@ func.func @cbrt(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT:  return
 func.func @ceil(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.ceil %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.ceil %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.ceil %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.ceil %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.ceil %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.ceil %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.ceil %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -68,12 +68,12 @@ func.func @ceil(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT:  return
 func.func @convert(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.convert %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.convert %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.convert %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.convert %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.convert %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.convert %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.convert %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -84,12 +84,12 @@ func.func @convert(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT:  return
 func.func @count_leading_zeros(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
   %0 = stablehlo.count_leading_zeros %static_arg : (tensor<2xi64>) -> tensor<2xi64>
-  %1 = stablehlo.count_leading_zeros %static_arg : (tensor<2xi64>) -> tensor<?xi64>
-  %2 = stablehlo.count_leading_zeros %dynamic_arg : (tensor<?xi64>) -> tensor<2xi64>
-  %3 = stablehlo.count_leading_zeros %dynamic_arg : (tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xi64>) -> ()
+  %1 = stablehlo.count_leading_zeros %static_arg : (tensor<2xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xi64>) -> ()
+  %2 = stablehlo.count_leading_zeros %dynamic_arg : (tensor<?xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xi64>) -> ()
+  %3 = stablehlo.count_leading_zeros %dynamic_arg : (tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xi64>) -> ()
   return
 }
@@ -100,12 +100,12 @@ func.func @count_leading_zeros(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<
 // CHECK-NEXT:  return
 func.func @cosine(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.cosine %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.cosine %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.cosine %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.cosine %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.cosine %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.cosine %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.cosine %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -116,12 +116,12 @@ func.func @cosine(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT:  return
 func.func @exponential(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.exponential %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.exponential %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.exponential %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.exponential %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.exponential %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.exponential %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.exponential %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -132,12 +132,12 @@ func.func @exponential(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) 
 // CHECK-NEXT:  return
 func.func @exponential_minus_one(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.exponential_minus_one %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.exponential_minus_one %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.exponential_minus_one %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.exponential_minus_one %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.exponential_minus_one %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.exponential_minus_one %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.exponential_minus_one %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -148,12 +148,12 @@ func.func @exponential_minus_one(%static_arg: tensor<2xf64>, %dynamic_arg: tenso
 // CHECK-NEXT:  return
 func.func @floor(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.floor %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.floor %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.floor %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.floor %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.floor %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.floor %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.floor %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -164,12 +164,12 @@ func.func @floor(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT:  return
 func.func @imag(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.imag %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.imag %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.imag %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.imag %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.imag %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.imag %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.imag %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -180,12 +180,12 @@ func.func @imag(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT:  return
 func.func @is_finite(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.is_finite %static_arg : (tensor<2xf64>) -> tensor<2xi1>
-  %1 = stablehlo.is_finite %static_arg : (tensor<2xf64>) -> tensor<?xi1>
-  %2 = stablehlo.is_finite %dynamic_arg : (tensor<?xf64>) -> tensor<2xi1>
-  %3 = stablehlo.is_finite %dynamic_arg : (tensor<?xf64>) -> tensor<?xi1>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xi1>) -> ()
+  %1 = stablehlo.is_finite %static_arg : (tensor<2xf64>) -> tensor<?xi1>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xi1>) -> ()
+  %2 = stablehlo.is_finite %dynamic_arg : (tensor<?xf64>) -> tensor<2xi1>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xi1>) -> ()
+  %3 = stablehlo.is_finite %dynamic_arg : (tensor<?xf64>) -> tensor<?xi1>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xi1>) -> ()
   return
 }
@@ -196,12 +196,12 @@ func.func @is_finite(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT:  return
 func.func @log(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.log %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.log %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.log %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.log %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.log %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.log %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.log %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -212,12 +212,12 @@ func.func @log(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT:  return
 func.func @log_plus_one(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.log_plus_one %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.log_plus_one %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.log_plus_one %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.log_plus_one %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.log_plus_one %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.log_plus_one %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.log_plus_one %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -228,12 +228,12 @@ func.func @log_plus_one(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>)
 // CHECK-NEXT:  return
 func.func @logistic(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.logistic %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.logistic %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.logistic %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.logistic %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.logistic %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.logistic %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.logistic %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -244,12 +244,12 @@ func.func @logistic(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT:  return
 func.func @not(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
   %0 = stablehlo.not %static_arg : (tensor<2xi64>) -> tensor<2xi64>
-  %1 = stablehlo.not %static_arg : (tensor<2xi64>) -> tensor<?xi64>
-  %2 = stablehlo.not %dynamic_arg : (tensor<?xi64>) -> tensor<2xi64>
-  %3 = stablehlo.not %dynamic_arg : (tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xi64>) -> ()
+  %1 = stablehlo.not %static_arg : (tensor<2xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xi64>) -> ()
+  %2 = stablehlo.not %dynamic_arg : (tensor<?xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xi64>) -> ()
+  %3 = stablehlo.not %dynamic_arg : (tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xi64>) -> ()
   return
 }
@@ -260,12 +260,12 @@ func.func @not(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
 // CHECK-NEXT:  return
 func.func @negate(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.negate %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.negate %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.negate %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.negate %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.negate %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.negate %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.negate %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -276,12 +276,12 @@ func.func @negate(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT:  return
 func.func @popcnt(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
   %0 = stablehlo.popcnt %static_arg : (tensor<2xi64>) -> tensor<2xi64>
-  %1 = stablehlo.popcnt %static_arg : (tensor<2xi64>) -> tensor<?xi64>
-  %2 = stablehlo.popcnt %dynamic_arg : (tensor<?xi64>) -> tensor<2xi64>
-  %3 = stablehlo.popcnt %dynamic_arg : (tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xi64>) -> ()
+  %1 = stablehlo.popcnt %static_arg : (tensor<2xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xi64>) -> ()
+  %2 = stablehlo.popcnt %dynamic_arg : (tensor<?xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xi64>) -> ()
+  %3 = stablehlo.popcnt %dynamic_arg : (tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xi64>) -> ()
   return
 }
@@ -292,12 +292,12 @@ func.func @popcnt(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
 // CHECK-NEXT:  return
 func.func @real(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.real %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.real %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.real %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.real %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.real %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.real %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.real %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -308,12 +308,12 @@ func.func @real(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT:  return
 func.func @round_nearest_afz(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.round_nearest_afz %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.round_nearest_afz %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.round_nearest_afz %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.round_nearest_afz %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.round_nearest_afz %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.round_nearest_afz %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.round_nearest_afz %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -324,12 +324,12 @@ func.func @round_nearest_afz(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?x
 // CHECK-NEXT:  return
 func.func @round_nearest_even(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.round_nearest_even %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.round_nearest_even %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.round_nearest_even %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.round_nearest_even %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.round_nearest_even %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.round_nearest_even %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.round_nearest_even %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -340,12 +340,12 @@ func.func @round_nearest_even(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?
 // CHECK-NEXT:  return
 func.func @rsqrt(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.rsqrt %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.rsqrt %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.rsqrt %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.rsqrt %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.rsqrt %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.rsqrt %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.rsqrt %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -356,12 +356,12 @@ func.func @rsqrt(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT:  return
 func.func @sign(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.sign %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.sign %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.sign %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.sign %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.sign %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.sign %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.sign %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -372,12 +372,12 @@ func.func @sign(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT:  return
 func.func @sine(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.sine %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.sine %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.sine %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.sine %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.sine %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.sine %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.sine %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -388,12 +388,12 @@ func.func @sine(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT:  return
 func.func @sqrt(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.sqrt %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.sqrt %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.sqrt %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.sqrt %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.sqrt %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.sqrt %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.sqrt %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -404,12 +404,12 @@ func.func @sqrt(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT:  return
 func.func @tanh(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.tanh %static_arg : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.tanh %static_arg : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.tanh %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.tanh %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.tanh %static_arg : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.tanh %dynamic_arg : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.tanh %dynamic_arg : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -424,12 +424,12 @@ func.func @tanh(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT:  return
 func.func @pad(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>, %padding_value: tensor<f64>) {
   %0 = stablehlo.pad %static_arg, %padding_value, low = [0], high = [0], interior = [0] : (tensor<2xf64>, tensor<f64>) -> tensor<2xf64>
-  %1 = stablehlo.pad %static_arg, %padding_value, low = [0], high = [0], interior = [0] : (tensor<2xf64>, tensor<f64>) -> tensor<?xf64>
-  %2 = stablehlo.pad %dynamic_arg, %padding_value, low = [0], high = [0], interior = [0] : (tensor<?xf64>, tensor<f64>) -> tensor<2xf64>
-  %3 = stablehlo.pad %dynamic_arg, %padding_value, low = [0], high = [0], interior = [0] : (tensor<?xf64>, tensor<f64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.pad %static_arg, %padding_value, low = [0], high = [0], interior = [0] : (tensor<2xf64>, tensor<f64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.pad %dynamic_arg, %padding_value, low = [0], high = [0], interior = [0] : (tensor<?xf64>, tensor<f64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.pad %dynamic_arg, %padding_value, low = [0], high = [0], interior = [0] : (tensor<?xf64>, tensor<f64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -438,12 +438,12 @@ func.func @pad(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>, %padding
 // CHECK-NEXT:  return
 func.func @reduce_precision(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.reduce_precision %static_arg, format = e5m10 : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.reduce_precision %static_arg, format = e5m10 : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.reduce_precision %dynamic_arg, format = e5m10 : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.reduce_precision %dynamic_arg, format = e5m10 : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.reduce_precision %static_arg, format = e5m10 : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.reduce_precision %dynamic_arg, format = e5m10 : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.reduce_precision %dynamic_arg, format = e5m10 : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -454,12 +454,12 @@ func.func @reduce_precision(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf
 // CHECK-NEXT:  return
 func.func @reverse(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.reverse %static_arg, dims = [0] : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.reverse %static_arg, dims = [0] : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.reverse %dynamic_arg, dims = [0] : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.reverse %dynamic_arg, dims = [0] : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.reverse %static_arg, dims = [0] : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.reverse %dynamic_arg, dims = [0] : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.reverse %dynamic_arg, dims = [0] : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -470,12 +470,12 @@ func.func @reverse(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT:  return
 func.func @slice(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.slice %static_arg [0:2] : (tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.slice %static_arg [0:2] : (tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.slice %dynamic_arg [0:2] : (tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.slice %dynamic_arg [0:2] : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.slice %static_arg [0:2] : (tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.slice %dynamic_arg [0:2] : (tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.slice %dynamic_arg [0:2] : (tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -673,39 +673,39 @@ func.func @fft(
   %static_irfft_arg: tensor<3x5xcomplex<f64>>, %dynamic_irfft_arg: tensor<?x?xcomplex<f64>>
 ) {
   %fft_0 = stablehlo.fft %static_arg, type = FFT, length = [9] : (tensor<3x9xcomplex<f64>>) -> tensor<3x9xcomplex<f64>>
-  %fft_1 = stablehlo.fft %static_arg, type = FFT, length = [9] : (tensor<3x9xcomplex<f64>>) -> tensor<?x?xcomplex<f64>>
-  %fft_2 = stablehlo.fft %dynamic_arg, type = FFT, length = [9] : (tensor<?x?xcomplex<f64>>) -> tensor<3x9xcomplex<f64>>
-  %fft_3 = stablehlo.fft %dynamic_arg, type = FFT, length = [9] : (tensor<?x?xcomplex<f64>>) -> tensor<?x?xcomplex<f64>>
   "hlo_test_speculatability.is_speculatable"(%fft_0) : (tensor<3x9xcomplex<f64>>) -> ()
+  %fft_1 = stablehlo.fft %static_arg, type = FFT, length = [9] : (tensor<3x9xcomplex<f64>>) -> tensor<?x?xcomplex<f64>>
   "hlo_test_speculatability.is_speculatable"(%fft_1) : (tensor<?x?xcomplex<f64>>) -> ()
+  %fft_2 = stablehlo.fft %dynamic_arg, type = FFT, length = [9] : (tensor<?x?xcomplex<f64>>) -> tensor<3x9xcomplex<f64>>
   "hlo_test_speculatability.is_not_speculatable"(%fft_2) : (tensor<3x9xcomplex<f64>>) -> ()
+  %fft_3 = stablehlo.fft %dynamic_arg, type = FFT, length = [9] : (tensor<?x?xcomplex<f64>>) -> tensor<?x?xcomplex<f64>>
   "hlo_test_speculatability.is_speculatable"(%fft_3) : (tensor<?x?xcomplex<f64>>) -> ()
 
   %ifft_0 = stablehlo.fft %static_arg, type = IFFT, length = [9] : (tensor<3x9xcomplex<f64>>) -> tensor<3x9xcomplex<f64>>
-  %ifft_1 = stablehlo.fft %static_arg, type = IFFT, length = [9] : (tensor<3x9xcomplex<f64>>) -> tensor<?x?xcomplex<f64>>
-  %ifft_2 = stablehlo.fft %dynamic_arg, type = IFFT, length = [9] : (tensor<?x?xcomplex<f64>>) -> tensor<3x9xcomplex<f64>>
-  %ifft_3 = stablehlo.fft %dynamic_arg, type = IFFT, length = [9] : (tensor<?x?xcomplex<f64>>) -> tensor<?x?xcomplex<f64>>
   "hlo_test_speculatability.is_speculatable"(%ifft_0) : (tensor<3x9xcomplex<f64>>) -> ()
+  %ifft_1 = stablehlo.fft %static_arg, type = IFFT, length = [9] : (tensor<3x9xcomplex<f64>>) -> tensor<?x?xcomplex<f64>>
   "hlo_test_speculatability.is_speculatable"(%ifft_1) : (tensor<?x?xcomplex<f64>>) -> ()
+  %ifft_2 = stablehlo.fft %dynamic_arg, type = IFFT, length = [9] : (tensor<?x?xcomplex<f64>>) -> tensor<3x9xcomplex<f64>>
   "hlo_test_speculatability.is_not_speculatable"(%ifft_2) : (tensor<3x9xcomplex<f64>>) -> ()
+  %ifft_3 = stablehlo.fft %dynamic_arg, type = IFFT, length = [9] : (tensor<?x?xcomplex<f64>>) -> tensor<?x?xcomplex<f64>>
   "hlo_test_speculatability.is_speculatable"(%ifft_3) : (tensor<?x?xcomplex<f64>>) -> ()
 
   %rfft_0 = stablehlo.fft %static_rfft_arg, type = RFFT, length = [9] : (tensor<3x9xf64>) -> tensor<3x5xcomplex<f64>>
-  %rfft_1 = stablehlo.fft %static_rfft_arg, type = RFFT, length = [9] : (tensor<3x9xf64>) -> tensor<?x?xcomplex<f64>>
-  %rfft_2 = stablehlo.fft %dynamic_rfft_arg, type = RFFT, length = [9] : (tensor<?x?xf64>) -> tensor<3x5xcomplex<f64>>
-  %rfft_3 = stablehlo.fft %dynamic_rfft_arg, type = RFFT, length = [9] : (tensor<?x?xf64>) -> tensor<?x?xcomplex<f64>>
   "hlo_test_speculatability.is_speculatable"(%rfft_0) : (tensor<3x5xcomplex<f64>>) -> ()
+  %rfft_1 = stablehlo.fft %static_rfft_arg, type = RFFT, length = [9] : (tensor<3x9xf64>) -> tensor<?x?xcomplex<f64>>
   "hlo_test_speculatability.is_speculatable"(%rfft_1) : (tensor<?x?xcomplex<f64>>) -> ()
+  %rfft_2 = stablehlo.fft %dynamic_rfft_arg, type = RFFT, length = [9] : (tensor<?x?xf64>) -> tensor<3x5xcomplex<f64>>
   "hlo_test_speculatability.is_not_speculatable"(%rfft_2) : (tensor<3x5xcomplex<f64>>) -> ()
+  %rfft_3 = stablehlo.fft %dynamic_rfft_arg, type = RFFT, length = [9] : (tensor<?x?xf64>) -> tensor<?x?xcomplex<f64>>
   "hlo_test_speculatability.is_not_speculatable"(%rfft_3) : (tensor<?x?xcomplex<f64>>) -> ()
 
   %irfft_0 = stablehlo.fft %static_irfft_arg, type = IRFFT, length = [9] : (tensor<3x5xcomplex<f64>>) -> tensor<3x9xf64>
-  %irfft_1 = stablehlo.fft %static_irfft_arg, type = IRFFT, length = [9] : (tensor<3x5xcomplex<f64>>) -> tensor<?x?xf64>
-  %irfft_2 = stablehlo.fft %dynamic_irfft_arg, type = IRFFT, length = [9] : (tensor<?x?xcomplex<f64>>) -> tensor<3x9xf64>
-  %irfft_3 = stablehlo.fft %dynamic_irfft_arg, type = IRFFT, length = [9] : (tensor<?x?xcomplex<f64>>) -> tensor<?x?xf64>
   "hlo_test_speculatability.is_speculatable"(%irfft_0) : (tensor<3x9xf64>) -> ()
+  %irfft_1 = stablehlo.fft %static_irfft_arg, type = IRFFT, length = [9] : (tensor<3x5xcomplex<f64>>) -> tensor<?x?xf64>
   "hlo_test_speculatability.is_speculatable"(%irfft_1) : (tensor<?x?xf64>) -> ()
+  %irfft_2 = stablehlo.fft %dynamic_irfft_arg, type = IRFFT, length = [9] : (tensor<?x?xcomplex<f64>>) -> tensor<3x9xf64>
   "hlo_test_speculatability.is_not_speculatable"(%irfft_2) : (tensor<3x9xf64>) -> ()
+  %irfft_3 = stablehlo.fft %dynamic_irfft_arg, type = IRFFT, length = [9] : (tensor<?x?xcomplex<f64>>) -> tensor<?x?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%irfft_3) : (tensor<?x?xf64>) -> ()
   return
 }
@@ -852,33 +852,33 @@ func.func @transpose(
   %three_d: tensor<1x2x3xf64>, %three_d_dynamic: tensor<1x2x?xf64>
 ) {
   %0 = stablehlo.transpose %static, dims = [1, 0] : (tensor<2x4xf64>) -> tensor<4x2xf64>
-  %1 = stablehlo.transpose %second_dim_dynamic, dims = [1, 0] : (tensor<2x?xf64>) -> tensor<4x2xf64>
-  %2 = stablehlo.transpose %second_dim_dynamic, dims = [1, 0] : (tensor<2x?xf64>) -> tensor<?x2xf64>
-  %3 = stablehlo.transpose %first_dim_dynamic, dims = [1, 0] : (tensor<?x4xf64>) -> tensor<4x2xf64>
-  %4 = stablehlo.transpose %first_dim_dynamic, dims = [1, 0] : (tensor<?x4xf64>) -> tensor<4x?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<4x2xf64>) -> ()
+  %1 = stablehlo.transpose %second_dim_dynamic, dims = [1, 0] : (tensor<2x?xf64>) -> tensor<4x2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<4x2xf64>) -> ()
+  %2 = stablehlo.transpose %second_dim_dynamic, dims = [1, 0] : (tensor<2x?xf64>) -> tensor<?x2xf64>
   "hlo_test_speculatability.is_speculatable"(%2) : (tensor<?x2xf64>) -> ()
+  %3 = stablehlo.transpose %first_dim_dynamic, dims = [1, 0] : (tensor<?x4xf64>) -> tensor<4x2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<4x2xf64>) -> ()
+  %4 = stablehlo.transpose %first_dim_dynamic, dims = [1, 0] : (tensor<?x4xf64>) -> tensor<4x?xf64>
   "hlo_test_speculatability.is_speculatable"(%4) : (tensor<4x?xf64>) -> ()
 
   // Fully dynamic input
   %5 = stablehlo.transpose %dynamic, dims = [1, 0] : (tensor<?x?xf64>) -> tensor<4x2xf64>
-  %6 = stablehlo.transpose %dynamic, dims = [1, 0] : (tensor<?x?xf64>) -> tensor<?x2xf64>
-  %7 = stablehlo.transpose %dynamic, dims = [1, 0] : (tensor<?x?xf64>) -> tensor<4x?xf64>
-  %8 = stablehlo.transpose %dynamic, dims = [1, 0] : (tensor<?x?xf64>) -> tensor<?x?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<4x2xf64>) -> ()
+  %6 = stablehlo.transpose %dynamic, dims = [1, 0] : (tensor<?x?xf64>) -> tensor<?x2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<?x2xf64>) -> ()
+  %7 = stablehlo.transpose %dynamic, dims = [1, 0] : (tensor<?x?xf64>) -> tensor<4x?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<4x?xf64>) -> ()
+  %8 = stablehlo.transpose %dynamic, dims = [1, 0] : (tensor<?x?xf64>) -> tensor<?x?xf64>
   "hlo_test_speculatability.is_speculatable"(%8) : (tensor<?x?xf64>) -> ()
 
   // 3D
-  %speculatable_4 = stablehlo.transpose %three_d, dims = [1, 0, 2] : (tensor<1x2x3xf64>) -> tensor<2x1x3xf64>
-  %not_speculatable_5 = stablehlo.transpose %three_d_dynamic, dims = [1, 0, 2] : (tensor<1x2x?xf64>) -> tensor<2x1x3xf64>
-  %speculatable_5 = stablehlo.transpose %three_d_dynamic, dims = [1, 0, 2] : (tensor<1x2x?xf64>) -> tensor<2x1x?xf64>
-  "hlo_test_speculatability.is_speculatable"(%speculatable_4) : (tensor<2x1x3xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%not_speculatable_5) : (tensor<2x1x3xf64>) -> ()
-  "hlo_test_speculatability.is_speculatable"(%speculatable_5) : (tensor<2x1x?xf64>) -> ()
+  %9 = stablehlo.transpose %three_d, dims = [1, 0, 2] : (tensor<1x2x3xf64>) -> tensor<2x1x3xf64>
+  "hlo_test_speculatability.is_speculatable"(%9) : (tensor<2x1x3xf64>) -> ()
+  %10 = stablehlo.transpose %three_d_dynamic, dims = [1, 0, 2] : (tensor<1x2x?xf64>) -> tensor<2x1x3xf64>
+  "hlo_test_speculatability.is_not_speculatable"(%10) : (tensor<2x1x3xf64>) -> ()
+  %11 = stablehlo.transpose %three_d_dynamic, dims = [1, 0, 2] : (tensor<1x2x?xf64>) -> tensor<2x1x?xf64>
+  "hlo_test_speculatability.is_speculatable"(%11) : (tensor<2x1x?xf64>) -> ()
   return
 }
 
@@ -902,20 +902,20 @@ func.func @add_multidim(%static_arg: tensor<2x2xf64>, %partially_dynamic_arg: te
 // CHECK-NEXT: return
 func.func @add(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.add %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.add %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.add %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.add %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %4 = stablehlo.add %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %5 = stablehlo.add %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %6 = stablehlo.add %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %7 = stablehlo.add %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.add %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.add %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.add %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  %4 = stablehlo.add %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xf64>) -> ()
+  %5 = stablehlo.add %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xf64>) -> ()
+  %6 = stablehlo.add %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xf64>) -> ()
+  %7 = stablehlo.add %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xf64>) -> ()
   return
 }
@@ -926,20 +926,20 @@ func.func @add(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT: return
 func.func @atan2(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.atan2 %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.atan2 %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.atan2 %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.atan2 %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %4 = stablehlo.atan2 %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %5 = stablehlo.atan2 %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %6 = stablehlo.atan2 %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %7 = stablehlo.atan2 %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.atan2 %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.atan2 %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.atan2 %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  %4 = stablehlo.atan2 %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xf64>) -> ()
+  %5 = stablehlo.atan2 %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xf64>) -> ()
+  %6 = stablehlo.atan2 %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xf64>) -> ()
+  %7 = stablehlo.atan2 %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xf64>) -> ()
   return
 }
@@ -950,20 +950,20 @@ func.func @atan2(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT: return
 func.func @complex(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.complex %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xcomplex<f64>>
-  %1 = stablehlo.complex %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xcomplex<f64>>
-  %2 = stablehlo.complex %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xcomplex<f64>>
-  %3 = stablehlo.complex %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xcomplex<f64>>
-  %4 = stablehlo.complex %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xcomplex<f64>>
-  %5 = stablehlo.complex %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xcomplex<f64>>
-  %6 = stablehlo.complex %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xcomplex<f64>>
-  %7 = stablehlo.complex %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xcomplex<f64>>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xcomplex<f64>>) -> ()
+  %1 = stablehlo.complex %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xcomplex<f64>>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xcomplex<f64>>) -> ()
+  %2 = stablehlo.complex %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xcomplex<f64>>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xcomplex<f64>>) -> ()
+  %3 = stablehlo.complex %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xcomplex<f64>>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xcomplex<f64>>) -> ()
+  %4 = stablehlo.complex %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xcomplex<f64>>
   "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xcomplex<f64>>) -> ()
+  %5 = stablehlo.complex %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xcomplex<f64>>
   "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xcomplex<f64>>) -> ()
+  %6 = stablehlo.complex %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xcomplex<f64>>
   "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xcomplex<f64>>) -> ()
+  %7 = stablehlo.complex %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xcomplex<f64>>
   "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xcomplex<f64>>) -> ()
   return
 }
@@ -974,20 +974,20 @@ func.func @complex(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT: return
 func.func @divide(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.divide %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.divide %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.divide %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.divide %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %4 = stablehlo.divide %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %5 = stablehlo.divide %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %6 = stablehlo.divide %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %7 = stablehlo.divide %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.divide %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.divide %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.divide %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  %4 = stablehlo.divide %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xf64>) -> ()
+  %5 = stablehlo.divide %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xf64>) -> ()
+  %6 = stablehlo.divide %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xf64>) -> ()
+  %7 = stablehlo.divide %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xf64>) -> ()
   return
 }
@@ -998,20 +998,20 @@ func.func @divide(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT: return
 func.func @maximum(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.maximum %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.maximum %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.maximum %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.maximum %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %4 = stablehlo.maximum %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %5 = stablehlo.maximum %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %6 = stablehlo.maximum %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %7 = stablehlo.maximum %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.maximum %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.maximum %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.maximum %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  %4 = stablehlo.maximum %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xf64>) -> ()
+  %5 = stablehlo.maximum %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xf64>) -> ()
+  %6 = stablehlo.maximum %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xf64>) -> ()
+  %7 = stablehlo.maximum %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xf64>) -> ()
   return
 }
@@ -1022,20 +1022,20 @@ func.func @maximum(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT: return
 func.func @minimum(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.minimum %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.minimum %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.minimum %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.minimum %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %4 = stablehlo.minimum %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %5 = stablehlo.minimum %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %6 = stablehlo.minimum %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %7 = stablehlo.minimum %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.minimum %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.minimum %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.minimum %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  %4 = stablehlo.minimum %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xf64>) -> ()
+  %5 = stablehlo.minimum %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xf64>) -> ()
+  %6 = stablehlo.minimum %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xf64>) -> ()
+  %7 = stablehlo.minimum %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xf64>) -> ()
   return
 }
@@ -1046,20 +1046,20 @@ func.func @minimum(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT: return
 func.func @multiply(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.multiply %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.multiply %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.multiply %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.multiply %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %4 = stablehlo.multiply %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %5 = stablehlo.multiply %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %6 = stablehlo.multiply %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %7 = stablehlo.multiply %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.multiply %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.multiply %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.multiply %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  %4 = stablehlo.multiply %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xf64>) -> ()
+  %5 = stablehlo.multiply %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xf64>) -> ()
+  %6 = stablehlo.multiply %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xf64>) -> ()
+  %7 = stablehlo.multiply %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xf64>) -> ()
   return
 }
@@ -1070,20 +1070,20 @@ func.func @multiply(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT: return
 func.func @power(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.power %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.power %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.power %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.power %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %4 = stablehlo.power %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %5 = stablehlo.power %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %6 = stablehlo.power %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %7 = stablehlo.power %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.power %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.power %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.power %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  %4 = stablehlo.power %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xf64>) -> ()
+  %5 = stablehlo.power %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xf64>) -> ()
+  %6 = stablehlo.power %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xf64>) -> ()
+  %7 = stablehlo.power %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xf64>) -> ()
   return
 }
@@ -1094,20 +1094,20 @@ func.func @power(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT: return
 func.func @remainder(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.remainder %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.remainder %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.remainder %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.remainder %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %4 = stablehlo.remainder %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %5 = stablehlo.remainder %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %6 = stablehlo.remainder %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %7 = stablehlo.remainder %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.remainder %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.remainder %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.remainder %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  %4 = stablehlo.remainder %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xf64>) -> ()
+  %5 = stablehlo.remainder %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xf64>) -> ()
+  %6 = stablehlo.remainder %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xf64>) -> ()
+  %7 = stablehlo.remainder %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xf64>) -> ()
   return
 }
@@ -1118,20 +1118,20 @@ func.func @remainder(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT: return
 func.func @shift_left(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
   %0 = stablehlo.shift_left %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %1 = stablehlo.shift_left %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %2 = stablehlo.shift_left %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %3 = stablehlo.shift_left %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
-  %4 = stablehlo.shift_left %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %5 = stablehlo.shift_left %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %6 = stablehlo.shift_left %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %7 = stablehlo.shift_left %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xi64>) -> ()
+  %1 = stablehlo.shift_left %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xi64>) -> ()
+  %2 = stablehlo.shift_left %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xi64>) -> ()
+  %3 = stablehlo.shift_left %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xi64>) -> ()
+  %4 = stablehlo.shift_left %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xi64>) -> ()
+  %5 = stablehlo.shift_left %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xi64>) -> ()
+  %6 = stablehlo.shift_left %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xi64>) -> ()
+  %7 = stablehlo.shift_left %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xi64>) -> ()
   return
 }
@@ -1142,20 +1142,20 @@ func.func @shift_left(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
 // CHECK-NEXT: return
 func.func @shift_right_arithmetic(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
   %0 = stablehlo.shift_right_arithmetic %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %1 = stablehlo.shift_right_arithmetic %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %2 = stablehlo.shift_right_arithmetic %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %3 = stablehlo.shift_right_arithmetic %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
-  %4 = stablehlo.shift_right_arithmetic %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %5 = stablehlo.shift_right_arithmetic %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %6 = stablehlo.shift_right_arithmetic %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %7 = stablehlo.shift_right_arithmetic %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xi64>) -> ()
+  %1 = stablehlo.shift_right_arithmetic %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xi64>) -> ()
+  %2 = stablehlo.shift_right_arithmetic %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xi64>) -> ()
+  %3 = stablehlo.shift_right_arithmetic %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xi64>) -> ()
+  %4 = stablehlo.shift_right_arithmetic %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xi64>) -> ()
+  %5 = stablehlo.shift_right_arithmetic %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xi64>) -> ()
+  %6 = stablehlo.shift_right_arithmetic %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xi64>) -> ()
+  %7 = stablehlo.shift_right_arithmetic %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xi64>) -> ()
   return
 }
@@ -1166,20 +1166,20 @@ func.func @shift_right_arithmetic(%static_arg: tensor<2xi64>, %dynamic_arg: tens
 // CHECK-NEXT: return
 func.func @shift_right_logical(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
   %0 = stablehlo.shift_right_logical %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %1 = stablehlo.shift_right_logical %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %2 = stablehlo.shift_right_logical %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %3 = stablehlo.shift_right_logical %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
-  %4 = stablehlo.shift_right_logical %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %5 = stablehlo.shift_right_logical %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %6 = stablehlo.shift_right_logical %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %7 = stablehlo.shift_right_logical %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xi64>) -> ()
+  %1 = stablehlo.shift_right_logical %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xi64>) -> ()
+  %2 = stablehlo.shift_right_logical %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xi64>) -> ()
+  %3 = stablehlo.shift_right_logical %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xi64>) -> ()
+  %4 = stablehlo.shift_right_logical %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xi64>) -> ()
+  %5 = stablehlo.shift_right_logical %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xi64>) -> ()
+  %6 = stablehlo.shift_right_logical %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xi64>) -> ()
+  %7 = stablehlo.shift_right_logical %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xi64>) -> ()
   return
 }
@@ -1190,20 +1190,20 @@ func.func @shift_right_logical(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<
 // CHECK-NEXT: return
 func.func @subtract(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.subtract %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %1 = stablehlo.subtract %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.subtract %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %3 = stablehlo.subtract %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %4 = stablehlo.subtract %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
-  %5 = stablehlo.subtract %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %6 = stablehlo.subtract %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
-  %7 = stablehlo.subtract %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.subtract %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.subtract %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.subtract %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  %4 = stablehlo.subtract %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xf64>) -> ()
+  %5 = stablehlo.subtract %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xf64>) -> ()
+  %6 = stablehlo.subtract %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xf64>) -> ()
+  %7 = stablehlo.subtract %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xf64>) -> ()
   return
 }
@@ -1214,20 +1214,20 @@ func.func @subtract(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT: return
 func.func @and(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
   %0 = stablehlo.and %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %1 = stablehlo.and %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %2 = stablehlo.and %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %3 = stablehlo.and %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
-  %4 = stablehlo.and %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %5 = stablehlo.and %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %6 = stablehlo.and %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %7 = stablehlo.and %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xi64>) -> ()
+  %1 = stablehlo.and %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xi64>) -> ()
+  %2 = stablehlo.and %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xi64>) -> ()
+  %3 = stablehlo.and %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xi64>) -> ()
+  %4 = stablehlo.and %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xi64>) -> ()
+  %5 = stablehlo.and %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xi64>) -> ()
+  %6 = stablehlo.and %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xi64>) -> ()
+  %7 = stablehlo.and %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xi64>) -> ()
   return
 }
@@ -1238,20 +1238,20 @@ func.func @and(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
 // CHECK-NEXT: return
 func.func @or(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
   %0 = stablehlo.or %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %1 = stablehlo.or %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %2 = stablehlo.or %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %3 = stablehlo.or %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
-  %4 = stablehlo.or %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %5 = stablehlo.or %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %6 = stablehlo.or %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %7 = stablehlo.or %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xi64>) -> ()
+  %1 = stablehlo.or %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xi64>) -> ()
+  %2 = stablehlo.or %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xi64>) -> ()
+  %3 = stablehlo.or %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xi64>) -> ()
+  %4 = stablehlo.or %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xi64>) -> ()
+  %5 = stablehlo.or %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xi64>) -> ()
+  %6 = stablehlo.or %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xi64>) -> ()
+  %7 = stablehlo.or %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xi64>) -> ()
   return
 }
@@ -1262,20 +1262,20 @@ func.func @or(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
 // CHECK-NEXT: return
 func.func @xor(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
   %0 = stablehlo.xor %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %1 = stablehlo.xor %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %2 = stablehlo.xor %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %3 = stablehlo.xor %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
-  %4 = stablehlo.xor %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
-  %5 = stablehlo.xor %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
-  %6 = stablehlo.xor %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
-  %7 = stablehlo.xor %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xi64>) -> ()
+  %1 = stablehlo.xor %static_arg, %static_arg : (tensor<2xi64>, tensor<2xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xi64>) -> ()
+  %2 = stablehlo.xor %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xi64>) -> ()
+  %3 = stablehlo.xor %static_arg, %dynamic_arg : (tensor<2xi64>, tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xi64>) -> ()
+  %4 = stablehlo.xor %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<2xi64>) -> ()
+  %5 = stablehlo.xor %dynamic_arg, %static_arg : (tensor<?xi64>, tensor<2xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?xi64>) -> ()
+  %6 = stablehlo.xor %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2xi64>) -> ()
+  %7 = stablehlo.xor %dynamic_arg, %dynamic_arg : (tensor<?xi64>, tensor<?xi64>) -> tensor<?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<?xi64>) -> ()
   return
 }
@@ -1290,14 +1290,14 @@ func.func @xor(%static_arg: tensor<2xi64>, %dynamic_arg: tensor<?xi64>) {
 // CHECK-NEXT: return
 func.func @clamp(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.clamp %static_arg, %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %1 = stablehlo.clamp %dynamic_arg, %static_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.clamp %static_arg, %dynamic_arg, %static_arg : (tensor<2xf64>, tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %3 = stablehlo.clamp %static_arg, %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %4 = stablehlo.clamp %dynamic_arg, %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<?xf64>) -> ()
+  %1 = stablehlo.clamp %dynamic_arg, %static_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.clamp %static_arg, %dynamic_arg, %static_arg : (tensor<2xf64>, tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?xf64>) -> ()
+  %3 = stablehlo.clamp %static_arg, %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  %4 = stablehlo.clamp %dynamic_arg, %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<?xf64>) -> ()
   return
 }
@@ -1308,12 +1308,12 @@ func.func @clamp(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT: return
 func.func @compare(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.compare EQ, %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xi1>
-  %1 = stablehlo.compare EQ, %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xi1>
-  %2 = stablehlo.compare EQ, %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xi1>
-  %3 = stablehlo.compare EQ, %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xi1>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<?xi1>) -> ()
+  %1 = stablehlo.compare EQ, %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xi1>
   "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?xi1>) -> ()
+  %2 = stablehlo.compare EQ, %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xi1>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?xi1>) -> ()
+  %3 = stablehlo.compare EQ, %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xi1>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xi1>) -> ()
   return
 }
@@ -1324,12 +1324,12 @@ func.func @compare(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT: return
 func.func @complex(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.complex %static_arg, %static_arg : (tensor<2xf64>, tensor<2xf64>) -> tensor<?xcomplex<f64>>
-  %1 = stablehlo.complex %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xcomplex<f64>>
-  %2 = stablehlo.complex %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xcomplex<f64>>
-  %3 = stablehlo.complex %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xcomplex<f64>>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<?xcomplex<f64>>) -> ()
+  %1 = stablehlo.complex %dynamic_arg, %static_arg : (tensor<?xf64>, tensor<2xf64>) -> tensor<?xcomplex<f64>>
   "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?xcomplex<f64>>) -> ()
+  %2 = stablehlo.complex %static_arg, %dynamic_arg : (tensor<2xf64>, tensor<?xf64>) -> tensor<?xcomplex<f64>>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?xcomplex<f64>>) -> ()
+  %3 = stablehlo.complex %dynamic_arg, %dynamic_arg : (tensor<?xf64>, tensor<?xf64>) -> tensor<?xcomplex<f64>>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xcomplex<f64>>) -> ()
   return
 }
@@ -1340,14 +1340,14 @@ func.func @complex(%static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
 // CHECK-NEXT: return
 func.func @select(%static_pred: tensor<2xi1>, %dynamic_pred: tensor<?xi1>, %static_arg: tensor<2xf64>, %dynamic_arg: tensor<?xf64>) {
   %0 = stablehlo.select %static_pred, %static_arg, %static_arg : (tensor<2xi1>, tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %1 = stablehlo.select %dynamic_pred, %static_arg, %static_arg : (tensor<?xi1>, tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %2 = stablehlo.select %static_pred, %dynamic_arg, %static_arg : (tensor<2xi1>, tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
-  %3 = stablehlo.select %static_pred, %static_arg, %dynamic_arg : (tensor<2xi1>, tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
-  %4 = stablehlo.select %dynamic_pred, %dynamic_arg, %dynamic_arg : (tensor<?xi1>, tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<?xf64>) -> ()
+  %1 = stablehlo.select %dynamic_pred, %static_arg, %static_arg : (tensor<?xi1>, tensor<2xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.select %static_pred, %dynamic_arg, %static_arg : (tensor<2xi1>, tensor<?xf64>, tensor<2xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?xf64>) -> ()
+  %3 = stablehlo.select %static_pred, %static_arg, %dynamic_arg : (tensor<2xi1>, tensor<2xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
+  %4 = stablehlo.select %dynamic_pred, %dynamic_arg, %dynamic_arg : (tensor<?xi1>, tensor<?xf64>, tensor<?xf64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<?xf64>) -> ()
   return
 }
@@ -1363,42 +1363,42 @@ func.func @select(%static_pred: tensor<2xi1>, %dynamic_pred: tensor<?xi1>, %stat
 func.func @concatenate(%static_arg: tensor<2x2xi64>, %first_dim_dynamic: tensor<?x2xi64>, %second_dim_dynamic: tensor<2x?xi64>, %dynamic_arg: tensor<?x?xi64>) {
   // Non-concat dims are static
   %0 = stablehlo.concatenate %static_arg, %static_arg, dim = 0 : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<4x2xi64>
-  %1 = stablehlo.concatenate %static_arg, %static_arg, dim = 1 : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<2x4xi64>
-  %2 = stablehlo.concatenate %static_arg, %static_arg, dim = 0 : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<?x?xi64>
-  %3 = stablehlo.concatenate %static_arg, %static_arg, dim = 1 : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<?x?xi64>
-  %4 = stablehlo.concatenate %static_arg, %first_dim_dynamic, dim = 0 : (tensor<2x2xi64>, tensor<?x2xi64>) -> tensor<?x?xi64>
-  %5 = stablehlo.concatenate %second_dim_dynamic, %static_arg, dim = 1 : (tensor<2x?xi64>, tensor<2x2xi64>) -> tensor<?x?xi64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<4x2xi64>) -> ()
+  %1 = stablehlo.concatenate %static_arg, %static_arg, dim = 1 : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<2x4xi64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<2x4xi64>) -> ()
+  %2 = stablehlo.concatenate %static_arg, %static_arg, dim = 0 : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<?x?xi64>
   "hlo_test_speculatability.is_speculatable"(%2) : (tensor<?x?xi64>) -> ()
+  %3 = stablehlo.concatenate %static_arg, %static_arg, dim = 1 : (tensor<2x2xi64>, tensor<2x2xi64>) -> tensor<?x?xi64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?x?xi64>) -> ()
+  %4 = stablehlo.concatenate %static_arg, %first_dim_dynamic, dim = 0 : (tensor<2x2xi64>, tensor<?x2xi64>) -> tensor<?x?xi64>
   "hlo_test_speculatability.is_speculatable"(%4) : (tensor<?x?xi64>) -> ()
+  %5 = stablehlo.concatenate %second_dim_dynamic, %static_arg, dim = 1 : (tensor<2x?xi64>, tensor<2x2xi64>) -> tensor<?x?xi64>
   "hlo_test_speculatability.is_speculatable"(%5) : (tensor<?x?xi64>) -> ()
 
   // Concat dim dynamic in input
   %6 = stablehlo.concatenate %static_arg, %first_dim_dynamic, dim = 0 : (tensor<2x2xi64>, tensor<?x2xi64>) -> tensor<4x2xi64>
-  %7 = stablehlo.concatenate %second_dim_dynamic, %static_arg, dim = 1 : (tensor<2x?xi64>, tensor<2x2xi64>) -> tensor<2x4xi64>
-  %8 = stablehlo.concatenate %first_dim_dynamic, %first_dim_dynamic, dim = 0 : (tensor<?x2xi64>, tensor<?x2xi64>) -> tensor<4x?xi64>
-  %9 = stablehlo.concatenate %second_dim_dynamic, %second_dim_dynamic, dim = 1 : (tensor<2x?xi64>, tensor<2x?xi64>) -> tensor<?x4xi64>
-  %10 = stablehlo.concatenate %first_dim_dynamic, %first_dim_dynamic, dim = 0 : (tensor<?x2xi64>, tensor<?x2xi64>) -> tensor<?x?xi64>
-  %11 = stablehlo.concatenate %second_dim_dynamic, %second_dim_dynamic, dim = 1 : (tensor<2x?xi64>, tensor<2x?xi64>) -> tensor<?x?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<4x2xi64>) -> ()
+  %7 = stablehlo.concatenate %second_dim_dynamic, %static_arg, dim = 1 : (tensor<2x?xi64>, tensor<2x2xi64>) -> tensor<2x4xi64>
   "hlo_test_speculatability.is_not_speculatable"(%7) : (tensor<2x4xi64>) -> ()
+  %8 = stablehlo.concatenate %first_dim_dynamic, %first_dim_dynamic, dim = 0 : (tensor<?x2xi64>, tensor<?x2xi64>) -> tensor<4x?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%8) : (tensor<4x?xi64>) -> ()
+  %9 = stablehlo.concatenate %second_dim_dynamic, %second_dim_dynamic, dim = 1 : (tensor<2x?xi64>, tensor<2x?xi64>) -> tensor<?x4xi64>
   "hlo_test_speculatability.is_not_speculatable"(%9) : (tensor<?x4xi64>) -> ()
+  %10 = stablehlo.concatenate %first_dim_dynamic, %first_dim_dynamic, dim = 0 : (tensor<?x2xi64>, tensor<?x2xi64>) -> tensor<?x?xi64>
   "hlo_test_speculatability.is_speculatable"(%10) : (tensor<?x?xi64>) -> ()
+  %11 = stablehlo.concatenate %second_dim_dynamic, %second_dim_dynamic, dim = 1 : (tensor<2x?xi64>, tensor<2x?xi64>) -> tensor<?x?xi64>
   "hlo_test_speculatability.is_speculatable"(%11) : (tensor<?x?xi64>) -> ()
 
   // Non-concat dim dynamic in input
   %12 = stablehlo.concatenate %first_dim_dynamic, %first_dim_dynamic, dim = 1 : (tensor<?x2xi64>, tensor<?x2xi64>) -> tensor<?x?xi64>
-  %13 = stablehlo.concatenate %second_dim_dynamic, %second_dim_dynamic, dim = 0 : (tensor<2x?xi64>, tensor<2x?xi64>) -> tensor<?x?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%12) : (tensor<?x?xi64>) -> ()
+  %13 = stablehlo.concatenate %second_dim_dynamic, %second_dim_dynamic, dim = 0 : (tensor<2x?xi64>, tensor<2x?xi64>) -> tensor<?x?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%13) : (tensor<?x?xi64>) -> ()
 
   // Fully dynamic
   %14 = stablehlo.concatenate %dynamic_arg, %dynamic_arg, dim = 0 : (tensor<?x?xi64>, tensor<?x?xi64>) -> tensor<?x?xi64>
-  %15 = stablehlo.concatenate %dynamic_arg, %dynamic_arg, dim = 1 : (tensor<?x?xi64>, tensor<?x?xi64>) -> tensor<?x?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%14) : (tensor<?x?xi64>) -> ()
+  %15 = stablehlo.concatenate %dynamic_arg, %dynamic_arg, dim = 1 : (tensor<?x?xi64>, tensor<?x?xi64>) -> tensor<?x?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%15) : (tensor<?x?xi64>) -> ()
   return
 }
@@ -1601,6 +1601,8 @@ func.func @gather(
     slice_sizes = array<i64: 1, 2, 2>,
     indices_are_sorted = false
   } : (tensor<?x?x?xi32>, tensor<2x3x2xi64>) -> tensor<?x?x?x?xi32>
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?x?x?x?xi32>) -> ()
+
   %3 = "stablehlo.gather"(%static_arg, %dynamic_indices) {
     dimension_numbers = #stablehlo.gather<
       offset_dims = [2, 3],
@@ -1610,6 +1612,8 @@ func.func @gather(
     slice_sizes = array<i64: 1, 2, 2>,
     indices_are_sorted = false
   } : (tensor<3x4x2xi32>, tensor<?x?x?xi64>) -> tensor<?x?x?x?xi32>
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?x?x?x?xi32>) -> ()
+
   %4 = "stablehlo.gather"(%dynamic_arg, %dynamic_indices) {
     dimension_numbers = #stablehlo.gather<
       offset_dims = [2, 3],
@@ -1619,8 +1623,6 @@ func.func @gather(
     slice_sizes = array<i64: 1, 2, 2>,
     indices_are_sorted = false
   } : (tensor<?x?x?xi32>, tensor<?x?x?xi64>) -> tensor<?x?x?x?xi32>
-  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?x?x?x?xi32>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?x?x?x?xi32>) -> ()
   "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<?x?x?x?xi32>) -> ()
   return
 }
@@ -1691,6 +1693,8 @@ func.func @scatter(
     indices_are_sorted = false,
     unique_indices = false
   } : (tensor<?x?x?xf64>, tensor<2x3x2xi64>, tensor<2x3x2x2xf64>) -> tensor<?x?x?xf64>
+  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?x?x?xf64>) -> ()
+
   %4 = "stablehlo.scatter"(%static_inputs, %dynamic_indices, %static_updates) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
       stablehlo.return %arg0 : tensor<f64>
@@ -1703,6 +1707,8 @@ func.func @scatter(
     indices_are_sorted = false,
     unique_indices = false
   } : (tensor<3x4x2xf64>, tensor<?x?x?xi64>, tensor<2x3x2x2xf64>) -> tensor<?x?x?xf64>
+  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<?x?x?xf64>) -> ()
+
   %5 = "stablehlo.scatter"(%static_inputs, %static_indices, %dynamic_updates) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
       stablehlo.return %arg0 : tensor<f64>
@@ -1715,8 +1721,6 @@ func.func @scatter(
     indices_are_sorted = false,
     unique_indices = false
   } : (tensor<3x4x2xf64>, tensor<2x3x2xi64>, tensor<?x?x?x?xf64>) -> tensor<?x?x?xf64>
-  "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?x?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<?x?x?xf64>) -> ()
   "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<?x?x?xf64>) -> ()
   return
 }
@@ -1731,21 +1735,23 @@ func.func @scatter(
 // CHECK-NEXT:  return
 func.func @dynamic_iota(%unknown_shape: tensor<2xi32>) {
   %constant_shape = stablehlo.constant dense<[3, 4]> : tensor<2xi32>
+
   %0 = stablehlo.dynamic_iota %constant_shape, dim = 0 : (tensor<2xi32>) -> tensor<3x4xi64>
-  %1 = stablehlo.dynamic_iota %constant_shape, dim = 0 : (tensor<2xi32>) -> tensor<3x?xi64>
-  %2 = stablehlo.dynamic_iota %constant_shape, dim = 0 : (tensor<2xi32>) -> tensor<?x4xi64>
-  %3 = stablehlo.dynamic_iota %constant_shape, dim = 0 : (tensor<2xi32>) -> tensor<?x?xi64>
-  %4 = stablehlo.dynamic_iota %unknown_shape, dim = 0 : (tensor<2xi32>) -> tensor<3x4xi64>
-  %5 = stablehlo.dynamic_iota %unknown_shape, dim = 0 : (tensor<2xi32>) -> tensor<3x?xi64>
-  %6 = stablehlo.dynamic_iota %unknown_shape, dim = 0 : (tensor<2xi32>) -> tensor<?x4xi64>
-  %7 = stablehlo.dynamic_iota %unknown_shape, dim = 0 : (tensor<2xi32>) -> tensor<?x?xi64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<3x4xi64>) -> ()
+  %1 = stablehlo.dynamic_iota %constant_shape, dim = 0 : (tensor<2xi32>) -> tensor<3x?xi64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<3x?xi64>) -> ()
+  %2 = stablehlo.dynamic_iota %constant_shape, dim = 0 : (tensor<2xi32>) -> tensor<?x4xi64>
   "hlo_test_speculatability.is_speculatable"(%2) : (tensor<?x4xi64>) -> ()
+  %3 = stablehlo.dynamic_iota %constant_shape, dim = 0 : (tensor<2xi32>) -> tensor<?x?xi64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?x?xi64>) -> ()
+
+  %4 = stablehlo.dynamic_iota %unknown_shape, dim = 0 : (tensor<2xi32>) -> tensor<3x4xi64>
   "hlo_test_speculatability.is_not_speculatable"(%4) : (tensor<3x4xi64>) -> ()
+  %5 = stablehlo.dynamic_iota %unknown_shape, dim = 0 : (tensor<2xi32>) -> tensor<3x?xi64>
   "hlo_test_speculatability.is_not_speculatable"(%5) : (tensor<3x?xi64>) -> ()
+  %6 = stablehlo.dynamic_iota %unknown_shape, dim = 0 : (tensor<2xi32>) -> tensor<?x4xi64>
   "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<?x4xi64>) -> ()
+  %7 = stablehlo.dynamic_iota %unknown_shape, dim = 0 : (tensor<2xi32>) -> tensor<?x?xi64>
   "hlo_test_speculatability.is_speculatable"(%7) : (tensor<?x?xi64>) -> ()
   return
 }
@@ -1825,21 +1831,24 @@ func.func @map(%static_arg: tensor<2x4xf64>, %dynamic_arg: tensor<?x?xf64>, %arg
     ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
       stablehlo.return %arg : tensor<f64>
   }) {dimensions = array<i64: 0, 1>} : (tensor<2x4xf64>, tensor<2x4xf64>) -> tensor<?x?xf64>
+  "hlo_test_speculatability.is_recursively_speculatable"(%0) : (tensor<?x?xf64>) -> ()
+
   %1 = "stablehlo.map"(%static_arg, %dynamic_arg) ({
     ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
       stablehlo.return %arg : tensor<f64>
   }) {dimensions = array<i64: 0, 1>} : (tensor<2x4xf64>, tensor<?x?xf64>) -> tensor<?x?xf64>
+  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?x?xf64>) -> ()
+
   %2 = "stablehlo.map"(%dynamic_arg, %static_arg) ({
     ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
       stablehlo.return %arg : tensor<f64>
   }) {dimensions = array<i64: 0, 1>} : (tensor<?x?xf64>, tensor<2x4xf64>) -> tensor<?x?xf64>
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?x?xf64>) -> ()
+
   %3 = "stablehlo.map"(%dynamic_arg, %dynamic_arg) ({
     ^bb0(%arg2: tensor<f64>, %arg3: tensor<f64>):
       stablehlo.return %arg : tensor<f64>
   }) {dimensions = array<i64: 0, 1>} : (tensor<?x?xf64>, tensor<?x?xf64>) -> tensor<?x?xf64>
-  "hlo_test_speculatability.is_recursively_speculatable"(%0) : (tensor<?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?x?xf64>) -> ()
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?x?xf64>) -> ()
   return
 }
@@ -1853,21 +1862,24 @@ func.func @reduce(%static_arg: tensor<2x4xf64>, %dynamic_arg: tensor<?x?xf64>, %
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>):
       stablehlo.return %arg0, %arg0 : tensor<f64>, tensor<f64>
   }) {dimensions = array<i64: 0>} : (tensor<2x4xf64>, tensor<2x4xf64>, tensor<f64>, tensor<f64>) -> (tensor<?xf64>, tensor<?xf64>)
+  "hlo_test_speculatability.is_recursively_speculatable"(%0) : (tensor<?xf64>) -> ()
+
   %1:2 = "stablehlo.reduce"(%dynamic_arg, %static_arg, %init_arg, %init_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>):
       stablehlo.return %arg0, %arg0 : tensor<f64>, tensor<f64>
   }) {dimensions = array<i64: 0>} : (tensor<?x?xf64>, tensor<2x4xf64>, tensor<f64>, tensor<f64>) -> (tensor<?xf64>, tensor<?xf64>)
+  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?xf64>) -> ()
+
   %2:2 = "stablehlo.reduce"(%static_arg, %dynamic_arg, %init_arg, %init_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>):
       stablehlo.return %arg0, %arg0 : tensor<f64>, tensor<f64>
   }) {dimensions = array<i64: 0>} : (tensor<2x4xf64>, tensor<?x?xf64>, tensor<f64>, tensor<f64>) -> (tensor<?xf64>, tensor<?xf64>)
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?xf64>) -> ()
+
   %3:2 = "stablehlo.reduce"(%dynamic_arg, %dynamic_arg, %init_arg, %init_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>):
       stablehlo.return %arg0, %arg0 : tensor<f64>, tensor<f64>
   }) {dimensions = array<i64: 0>} : (tensor<?x?xf64>, tensor<?x?xf64>, tensor<f64>, tensor<f64>) -> (tensor<?xf64>, tensor<?xf64>)
-  "hlo_test_speculatability.is_recursively_speculatable"(%0) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?xf64>) -> ()
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -2004,24 +2016,27 @@ func.func @sort(%static_arg: tensor<2x4xf64>, %dynamic_arg: tensor<?x?xf64>) {
       %predicate = stablehlo.constant dense<false> : tensor<i1>
       stablehlo.return %predicate : tensor<i1>
   }) {dimension = 0 : i64, is_stable = true} : (tensor<2x4xf64>, tensor<2x4xf64>) -> (tensor<?x?xf64>, tensor<?x?xf64>)
+  "hlo_test_speculatability.is_recursively_speculatable"(%0) : (tensor<?x?xf64>) -> ()
+
   %1:2 = "stablehlo.sort"(%dynamic_arg, %static_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>):
       %predicate = stablehlo.constant dense<false> : tensor<i1>
       stablehlo.return %predicate : tensor<i1>
   }) {dimension = 0 : i64, is_stable = true} : (tensor<?x?xf64>, tensor<2x4xf64>) -> (tensor<?x?xf64>, tensor<?x?xf64>)
+  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?x?xf64>) -> ()
+
   %2:2 = "stablehlo.sort"(%static_arg, %dynamic_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>):
       %predicate = stablehlo.constant dense<false> : tensor<i1>
       stablehlo.return %predicate : tensor<i1>
   }) {dimension = 0 : i64, is_stable = true} : (tensor<2x4xf64>, tensor<?x?xf64>) -> (tensor<?x?xf64>, tensor<?x?xf64>)
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?x?xf64>) -> ()
+
   %3:2 = "stablehlo.sort"(%dynamic_arg, %dynamic_arg) ({
     ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>):
       %predicate = stablehlo.constant dense<false> : tensor<i1>
       stablehlo.return %predicate : tensor<i1>
   }) {dimension = 0 : i64, is_stable = true} : (tensor<?x?xf64>, tensor<?x?xf64>) -> (tensor<?x?xf64>, tensor<?x?xf64>)
-  "hlo_test_speculatability.is_recursively_speculatable"(%0) : (tensor<?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?x?xf64>) -> ()
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?x?xf64>) -> ()
   return
 }
@@ -2039,30 +2054,30 @@ func.func @bitcast_convert(
   %static_arg_32: tensor<2x?xi32>, %dynamic_arg_32: tensor<?x?xi32>
 ) {
   %0 = stablehlo.bitcast_convert %static_arg_64 : (tensor<2xi64>) -> tensor<2xf64>
-  %1 = stablehlo.bitcast_convert %static_arg_64 : (tensor<2xi64>) -> tensor<?xf64>
-  %2 = stablehlo.bitcast_convert %dynamic_arg_64 : (tensor<?xi64>) -> tensor<2xf64>
-  %3 = stablehlo.bitcast_convert %dynamic_arg_64 : (tensor<?xi64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<2xf64>) -> ()
+  %1 = stablehlo.bitcast_convert %static_arg_64 : (tensor<2xi64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = stablehlo.bitcast_convert %dynamic_arg_64 : (tensor<?xi64>) -> tensor<2xf64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<2xf64>) -> ()
+  %3 = stablehlo.bitcast_convert %dynamic_arg_64 : (tensor<?xi64>) -> tensor<?xf64>
   "hlo_test_speculatability.is_speculatable"(%3) : (tensor<?xf64>) -> ()
 
   %4 = stablehlo.bitcast_convert %static_arg_64 : (tensor<2xi64>) -> tensor<2x?xi32>
-  %5 = stablehlo.bitcast_convert %static_arg_64 : (tensor<2xi64>) -> tensor<?x?xi32>
-  %6 = stablehlo.bitcast_convert %dynamic_arg_64 : (tensor<?xi64>) -> tensor<2x?xi32>
-  %7 = stablehlo.bitcast_convert %dynamic_arg_64 : (tensor<?xi64>) -> tensor<?x?xi32>
   "hlo_test_speculatability.is_speculatable"(%4) : (tensor<2x?xi32>) -> ()
+  %5 = stablehlo.bitcast_convert %static_arg_64 : (tensor<2xi64>) -> tensor<?x?xi32>
   "hlo_test_speculatability.is_speculatable"(%5) : (tensor<?x?xi32>) -> ()
+  %6 = stablehlo.bitcast_convert %dynamic_arg_64 : (tensor<?xi64>) -> tensor<2x?xi32>
   "hlo_test_speculatability.is_not_speculatable"(%6) : (tensor<2x?xi32>) -> ()
+  %7 = stablehlo.bitcast_convert %dynamic_arg_64 : (tensor<?xi64>) -> tensor<?x?xi32>
   "hlo_test_speculatability.is_speculatable"(%7) : (tensor<?x?xi32>) -> ()
 
   %8 = stablehlo.bitcast_convert %static_arg_32 : (tensor<2x?xi32>) -> tensor<2xi64>
-  %9 = stablehlo.bitcast_convert %static_arg_32 : (tensor<2x?xi32>) -> tensor<?xi64>
-  %10 = stablehlo.bitcast_convert %dynamic_arg_32 : (tensor<?x?xi32>) -> tensor<2xi64>
-  %11 = stablehlo.bitcast_convert %dynamic_arg_32 : (tensor<?x?xi32>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%8) : (tensor<2xi64>) -> ()
+  %9 = stablehlo.bitcast_convert %static_arg_32 : (tensor<2x?xi32>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%9) : (tensor<?xi64>) -> ()
+  %10 = stablehlo.bitcast_convert %dynamic_arg_32 : (tensor<?x?xi32>) -> tensor<2xi64>
   "hlo_test_speculatability.is_not_speculatable"(%10) : (tensor<2xi64>) -> ()
+  %11 = stablehlo.bitcast_convert %dynamic_arg_32 : (tensor<?x?xi32>) -> tensor<?xi64>
   "hlo_test_speculatability.is_speculatable"(%11) : (tensor<?xi64>) -> ()
 
   %12 = stablehlo.bitcast_convert %static_arg_64 : (tensor<2xi64>) -> tensor<2x2xi32>
@@ -2081,12 +2096,12 @@ func.func @reshape(
   %dynamic_2: tensor<?x?xi64>
 ) {
   %0 = stablehlo.reshape %static : (tensor<3x4xi64>) -> tensor<12xi64>
-  %1 = stablehlo.reshape %dynamic_0 : (tensor<?x4xi64>) -> tensor<12xi64>
-  %2 = stablehlo.reshape %dynamic_1 : (tensor<3x?xi64>) -> tensor<12xi64>
-  %3 = stablehlo.reshape %dynamic_2 : (tensor<?x?xi64>) -> tensor<12xi64>
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<12xi64>) -> ()
+  %1 = stablehlo.reshape %dynamic_0 : (tensor<?x4xi64>) -> tensor<12xi64>
   "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<12xi64>) -> ()
+  %2 = stablehlo.reshape %dynamic_1 : (tensor<3x?xi64>) -> tensor<12xi64>
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<12xi64>) -> ()
+  %3 = stablehlo.reshape %dynamic_2 : (tensor<?x?xi64>) -> tensor<12xi64>
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<12xi64>) -> ()
   return
 }
@@ -2109,14 +2124,16 @@ func.func @triangular_solve(
   %1 = "stablehlo.triangular_solve"(%dynamic, %static) {
     left_side = true, lower = true, transpose_a = #stablehlo<transpose NO_TRANSPOSE>, unit_diagonal = false
   } : (tensor<?x?xf64>, tensor<2x2xf64>) -> tensor<?x?xf64>
+  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?x?xf64>) -> ()
+
   %2 = "stablehlo.triangular_solve"(%static, %dynamic) {
     left_side = true, lower = true, transpose_a = #stablehlo<transpose NO_TRANSPOSE>, unit_diagonal = false
   } : (tensor<2x2xf64>, tensor<?x?xf64>) -> tensor<?x?xf64>
+  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?x?xf64>) -> ()
+
   %3 = "stablehlo.triangular_solve"(%dynamic, %dynamic) {
     left_side = true, lower = true, transpose_a = #stablehlo<transpose NO_TRANSPOSE>, unit_diagonal = false
   } : (tensor<?x?xf64>, tensor<?x?xf64>) -> tensor<?x?xf64>
-  "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?x?xf64>) -> ()
-  "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?x?xf64>) -> ()
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?x?xf64>) -> ()
 
   // unit_diagonal = true
@@ -2133,12 +2150,12 @@ func.func @triangular_solve(
 // CHECK-NEXT:  return
 func.func @batch_norm_grad(%static: tensor<2xf64>, %dynamic: tensor<?xf64>) {
   %0:3 = "stablehlo.batch_norm_grad" (%static, %static, %static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
-  %1:3 = "stablehlo.batch_norm_grad" (%dynamic, %static, %static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
-  %2:3 = "stablehlo.batch_norm_grad" (%static, %static, %static, %static, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<?xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
-  %3:3 = "stablehlo.batch_norm_grad" (%dynamic, %dynamic, %dynamic, %dynamic, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>, tensor<?xf64>, tensor<?xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
   "hlo_test_speculatability.is_speculatable"(%0#0) : (tensor<?xf64>) -> ()
+  %1:3 = "stablehlo.batch_norm_grad" (%dynamic, %static, %static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
   "hlo_test_speculatability.is_not_speculatable"(%1#0) : (tensor<?xf64>) -> ()
+  %2:3 = "stablehlo.batch_norm_grad" (%static, %static, %static, %static, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<?xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
   "hlo_test_speculatability.is_not_speculatable"(%2#0) : (tensor<?xf64>) -> ()
+  %3:3 = "stablehlo.batch_norm_grad" (%dynamic, %dynamic, %dynamic, %dynamic, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>, tensor<?xf64>, tensor<?xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
   "hlo_test_speculatability.is_not_speculatable"(%3#0) : (tensor<?xf64>) -> ()
   return
 }
@@ -2149,12 +2166,12 @@ func.func @batch_norm_grad(%static: tensor<2xf64>, %dynamic: tensor<?xf64>) {
 // CHECK-NEXT:  return
 func.func @batch_norm_inference(%static: tensor<2xf64>, %dynamic: tensor<?xf64>) {
   %0 = "stablehlo.batch_norm_inference" (%static, %static, %static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>)
-  %1 = "stablehlo.batch_norm_inference" (%dynamic, %static, %static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>)
-  %2 = "stablehlo.batch_norm_inference" (%static, %static, %static, %static, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<?xf64>) -> (tensor<?xf64>)
-  %3 = "stablehlo.batch_norm_inference" (%dynamic, %dynamic, %dynamic, %dynamic, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>, tensor<?xf64>, tensor<?xf64>) -> (tensor<?xf64>)
   "hlo_test_speculatability.is_speculatable"(%0) : (tensor<?xf64>) -> ()
+  %1 = "stablehlo.batch_norm_inference" (%dynamic, %static, %static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>)
   "hlo_test_speculatability.is_not_speculatable"(%1) : (tensor<?xf64>) -> ()
+  %2 = "stablehlo.batch_norm_inference" (%static, %static, %static, %static, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<2xf64>, tensor<?xf64>) -> (tensor<?xf64>)
   "hlo_test_speculatability.is_not_speculatable"(%2) : (tensor<?xf64>) -> ()
+  %3 = "stablehlo.batch_norm_inference" (%dynamic, %dynamic, %dynamic, %dynamic, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>, tensor<?xf64>, tensor<?xf64>) -> (tensor<?xf64>)
   "hlo_test_speculatability.is_not_speculatable"(%3) : (tensor<?xf64>) -> ()
   return
 }
@@ -2165,12 +2182,12 @@ func.func @batch_norm_inference(%static: tensor<2xf64>, %dynamic: tensor<?xf64>)
 // CHECK-NEXT:  return
 func.func @batch_norm_training(%static: tensor<2xf64>, %dynamic: tensor<?xf64>) {
   %0:3 = "stablehlo.batch_norm_training" (%static, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
-  %1:3 = "stablehlo.batch_norm_training" (%dynamic, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
-  %2:3 = "stablehlo.batch_norm_training" (%static, %static, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<?xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
-  %3:3 = "stablehlo.batch_norm_training" (%dynamic, %dynamic, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
   "hlo_test_speculatability.is_speculatable"(%0#0) : (tensor<?xf64>) -> ()
+  %1:3 = "stablehlo.batch_norm_training" (%dynamic, %static, %static) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<2xf64>, tensor<2xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
   "hlo_test_speculatability.is_not_speculatable"(%1#0) : (tensor<?xf64>) -> ()
+  %2:3 = "stablehlo.batch_norm_training" (%static, %static, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<2xf64>, tensor<2xf64>, tensor<?xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
   "hlo_test_speculatability.is_not_speculatable"(%2#0) : (tensor<?xf64>) -> ()
+  %3:3 = "stablehlo.batch_norm_training" (%dynamic, %dynamic, %dynamic) {epsilon = 0.001 : f32, feature_index = 0 : i64} : (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>) -> (tensor<?xf64>, tensor<?xf64>, tensor<?xf64>)
   "hlo_test_speculatability.is_not_speculatable"(%3#0) : (tensor<?xf64>) -> ()
   return
 }


### PR DESCRIPTION
Mostly, simplify redundant variable names, remove unnecessary ops in nested regions, and move ops around/add whitespace for readability.