### PR TITLE
Interpreter support for dynamic programs

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -440,10 +440,12 @@ cc_library(
         ":reference_tensor",
         ":reference_value",
         ":register",
+        ":stablehlo_passes",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Parser",
+        "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Support",
     ],
 )

--- a/stablehlo/integrations/python/tests/stablehlo.py
+++ b/stablehlo/integrations/python/tests/stablehlo.py
@@ -251,6 +251,8 @@ def test_reference_api():
     # Numpy's uint treated as int by DenseElementsAttr, skipping np.uint tests
     ("2x2xf16", np.asarray([1, 2, 3, 4], np.float16).reshape(2,2)),
     ("2x1x2xf16", np.asarray([1, 2, 3, 4], np.float16).reshape(2,1,2)),
+    ("?x?xf16", np.asarray([1, 2, 3, 4], np.float16).reshape(2,2)),
+    ("?x2xf16", np.asarray([1, 2, 3, 4], np.float16).reshape(2,2)),
   ]
   for test in tests:
     tensor_type, arg = test

--- a/stablehlo/reference/Api.cpp
+++ b/stablehlo/reference/Api.cpp
@@ -68,7 +68,7 @@ FailureOr<func::FuncOp> getMainFunction(ModuleOp module, StringRef mainName) {
 class DefaultInterpreterFallback : public InterpreterFallback {
  public:
   DefaultInterpreterFallback(const InterpreterConfiguration &config)
-      : config(config) {};
+      : config(config){};
 
   virtual llvm::Error operator()(Operation &op, Scope &scope,
                                  Process *process) final {
@@ -153,6 +153,11 @@ LogicalResult validateEntrySignature(func::FuncOp func,
 //   refinement pipeline.
 LogicalResult removeDynamism(ModuleOp module, func::FuncOp func,
                              ArrayRef<InterpreterValue> inputs) {
+  if (llvm::all_of(func.getArgumentTypes(), [](Type type) {
+        return llvm::cast<ShapedType>(type).hasStaticShape();
+      })) {
+    return success();
+  }
   SmallVector<Type> refinedTypes = llvm::to_vector(llvm::map_range(
       inputs, [](InterpreterValue input) { return input.getType(); }));
 

--- a/stablehlo/reference/Api.cpp
+++ b/stablehlo/reference/Api.cpp
@@ -68,7 +68,7 @@ FailureOr<func::FuncOp> getMainFunction(ModuleOp module, StringRef mainName) {
 class DefaultInterpreterFallback : public InterpreterFallback {
  public:
   DefaultInterpreterFallback(const InterpreterConfiguration &config)
-      : config(config){};
+      : config(config) {};
 
   virtual llvm::Error operator()(Operation &op, Scope &scope,
                                  Process *process) final {
@@ -153,12 +153,6 @@ LogicalResult validateEntrySignature(func::FuncOp func,
 //   refinement pipeline.
 LogicalResult removeDynamism(ModuleOp module, func::FuncOp func,
                              ArrayRef<InterpreterValue> inputs) {
-  if (llvm::all_of(func.getArgumentTypes(), [](Type type) {
-        return llvm::cast<ShapedType>(type).hasStaticShape();
-      })) {
-    return success();
-  }
-
   SmallVector<Type> refinedTypes = llvm::to_vector(llvm::map_range(
       inputs, [](InterpreterValue input) { return input.getType(); }));
 

--- a/stablehlo/reference/CMakeLists.txt
+++ b/stablehlo/reference/CMakeLists.txt
@@ -19,8 +19,10 @@ add_mlir_library(StablehloReferenceApi
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRParser
+  MLIRPass
   MLIRSupport
   InterpreterOps
+  StablehloPasses
   StablehloReferenceConfiguration
   StablehloReferenceErrors
   StablehloReferenceNumPy

--- a/stablehlo/transforms/PassPipelines.cpp
+++ b/stablehlo/transforms/PassPipelines.cpp
@@ -28,8 +28,8 @@ void createStablehloDeserializePipeline(OpPassManager &pm) {
   pm.addPass(stablehlo::createVhloLegalizeToStablehloPass());
 }
 
-void createStablehloRefinePolymorphicModule(OpPassManager &pm,
-                                            TypeRange refinedTypes) {
+void createStablehloRemoveDynamismPipeline(OpPassManager &pm,
+                                           TypeRange refinedTypes) {
   pm.addPass(stablehlo::createStablehloRefineArgumentsPass(refinedTypes));
   pm.addPass(stablehlo::createStablehloRefineShapesPass());
   pm.addNestedPass<mlir::func::FuncOp>(

--- a/stablehlo/transforms/PassPipelines.cpp
+++ b/stablehlo/transforms/PassPipelines.cpp
@@ -28,6 +28,14 @@ void createStablehloDeserializePipeline(OpPassManager &pm) {
   pm.addPass(stablehlo::createVhloLegalizeToStablehloPass());
 }
 
+void createStablehloRefinePolymorphicModule(OpPassManager &pm,
+                                            TypeRange refinedTypes) {
+  pm.addPass(stablehlo::createStablehloRefineArgumentsPass(refinedTypes));
+  pm.addPass(stablehlo::createStablehloRefineShapesPass());
+  pm.addNestedPass<mlir::func::FuncOp>(
+      stablehlo::createStablehloCanonicalizeDynamismPass());
+}
+
 void registerPassPipelines() {
   PassPipelineRegistration<>("stablehlo-deserialize",
                              "Run an example pipeline.",

--- a/stablehlo/transforms/Passes.h
+++ b/stablehlo/transforms/Passes.h
@@ -86,8 +86,8 @@ std::unique_ptr<OperationPass<ModuleOp>> createStablehloRefineArgumentsPass(
 // the current version in order to legalize to StableHLO.
 void createStablehloDeserializePipeline(OpPassManager &pm);
 
-// Creates a pipeline of StableHLO-specific MLIR passes to refine a polymorphic
-// module. This is achieved via refining the "main" function's arguments
+// Creates a pipeline of StableHLO-specific MLIR passes to remove dynamism from
+// the program. This is achieved via refining the "main" function's arguments
 // and propagating new shapes throughout the program argument types and shapes
 // within an MLIR module. The main function is either a function with name
 // "main", if there are multiple functions, or the single function within the
@@ -98,8 +98,8 @@ void createStablehloDeserializePipeline(OpPassManager &pm);
 //   2. Refining shape information of operations within functions.
 //   3. Replaces dynamic StableHLO ops with the corresponding static
 //   counterparts if applicable.
-void createStablehloRefinePolymorphicModule(OpPassManager &pm,
-                                            TypeRange refinedTypes);
+void createStablehloRemoveDynamismPipeline(OpPassManager &pm,
+                                           TypeRange refinedTypes);
 
 // Adds `stablehlo-deserialize` pipeline as a registered pass pipeline
 // for opt tools.

--- a/stablehlo/transforms/Passes.h
+++ b/stablehlo/transforms/Passes.h
@@ -86,6 +86,21 @@ std::unique_ptr<OperationPass<ModuleOp>> createStablehloRefineArgumentsPass(
 // the current version in order to legalize to StableHLO.
 void createStablehloDeserializePipeline(OpPassManager &pm);
 
+// Creates a pipeline of StableHLO-specific MLIR passes to refine a polymorphic
+// module. This is achieved via refining the "main" function's arguments
+// and propagating new shapes throughout the program argument types and shapes
+// within an MLIR module. The main function is either a function with name
+// "main", if there are multiple functions, or the single function within the
+// module.
+//
+// This pipeline focuses on:
+//   1. Refining function argument types based on provided `refinedTypes`.
+//   2. Refining shape information of operations within functions.
+//   3. Replaces dynamic StableHLO ops with the corresponding static
+//   counterparts if applicable.
+void createStablehloRefinePolymorphicModule(OpPassManager &pm,
+                                            TypeRange refinedTypes);
+
 // Adds `stablehlo-deserialize` pipeline as a registered pass pipeline
 // for opt tools.
 void registerPassPipelines();


### PR DESCRIPTION
This PR adds a pass-pipeline to refine arguments and shapes of a program followed by [StablehloCanonicalizeDynamism](https://github.com/openxla/stablehlo/blob/main/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp) to replace dynamic StableHLO ops with the corresponding static counterparts if applicable* (see note below).

The goal is to interpret dynamic programs after applying the above pipeline.

partially-fixes https://github.com/openxla/stablehlo/issues/2202


Note:

For a programs like

```
func.func @main(%arg0: tensor<?xf32>, %arg1: tensor<2xi64>) -> tensor<?x?xf32> {
    %0 = stablehlo.dynamic_reshape %arg0, %arg1 : (tensor<?xf32>, tensor<2xi64>) -> tensor<?x?xf32>
    return %0 : tensor<?x?xf32>
}
```

when applied through the above pass-pipeline with  static input shapes like `tensor<6xf32>,tensor<2xi64>`, will not be able to replace  `stablehlo.dynamic_reshape`  with its static counterpart `reshape` as [StablehloCanonicalizeDynamism](https://github.com/openxla/stablehlo/blob/main/stablehlo/transforms/StablehloCanonicalizeDynamism.cpp) can only do that when the second argument of `stablehlo.dynamic_reshape`  is constant, which is not true in this case.