### PR TITLE
Use free function instead of method for dyn_cast_or_null

### DIFF
--- a/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
@@ -829,7 +829,7 @@ struct TransposeOpToTransposeConverter final
     // TODO(#2216) Cleanup Attribute -> DenseArrayAttr
     rewriter.replaceOpWithNewOp<linalg::TransposeOp>(
         op, adaptor.getOperand(), emptyTensor,
-        op.getPermutationAttr().dyn_cast_or_null<DenseI64ArrayAttr>(),
+        dyn_cast_or_null<DenseI64ArrayAttr>(op.getPermutationAttr()),
         linalg::getPrunedAttributeList(op));
     return success();
   }


### PR DESCRIPTION
The method variant is deprecated.