### PR TITLE
[RFC] StableHLO v1.0 Opset Deprecations & Cleanups

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -6602,7 +6602,7 @@ These operations fall into a few categories:
 * Unused ops - These operations may have been useful at some point, but the ops
   were either underdeveloped, or the pipelines using these ops have been
   refactored to not require them anymore. This includes `map`, `tuple` and
-  `get_tuple_element`, `rng`. 
+  `get_tuple_element`, `rng`.
 
 Some of these ops can confidently be easily removed (`broadcast`,
 `create_token`, `cross-replica-sum`, `dot`, `unary_einsum`, `trace`) and will be

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -6577,7 +6577,7 @@ compatibility.
 
 The CHLO opset contains higher level operations that decompose to StableHLO.
 Currently there are no compatibility guarantees for CHLO. For compatibility
-guarantees, the [CHLO-to-StableHLO decomposition pass](https://github.com/openxla/stablehlo/blob/12fd0a9e7b3c6f3dea3defc513870c962e62726d/stablehlo/transforms/Passes.td#L119)
+guarantees, the [chlo-legalize-to-stablehlo pass](https://github.com/openxla/stablehlo/blob/12fd0a9e7b3c6f3dea3defc513870c962e62726d/stablehlo/transforms/Passes.td#L119)
 must be used prior to serialization.
 
 ### Shape Operations
@@ -6591,14 +6591,15 @@ ops like `dim` or `from_elements`, and the builtin `index` type.
 The [Dynamism RFC > O2](https://github.com/openxla/stablehlo/blob/main/rfcs/20230704-dynamism-101.md#o2)
 denotes these as out of scope, however some support for `index` types is
 included for interop purposes. There are no compatibility guarantees for these
-ops or types. The [Shape-to-StableHLO](https://github.com/openxla/stablehlo/blob/12fd0a9e7b3c6f3dea3defc513870c962e62726d/stablehlo/transforms/Passes.td#L136)
+ops or types. The [shape-legalize-to-stablehlo](https://github.com/openxla/stablehlo/blob/12fd0a9e7b3c6f3dea3defc513870c962e62726d/stablehlo/transforms/Passes.td#L136)
 pass can be used to convert these operations to fully supported StableHLO ops.
 
 ## Deprecated Operations
 
-There are several StableHLO operations that were inherited from MHLO which are
-deprecated and on the way out of StableHLO. The full details on these removals
-can be found in the [StableHLO v1.0 Cleanup #2283](https://github.com/openxla/stablehlo/pull/2283).
+There are several StableHLO operations that were inherited from
+[MHLO](https://github.com/openxla/xla/blob/d63deb9250b9c212445290bd08c6effb5b6d0a2b/xla/mlir_hlo/mhlo/IR/hlo_ops.td)
+which are deprecated and on the way out of StableHLO. The full details on these
+removals can be found in the [StableHLO v1.0 Cleanup #2283](https://github.com/openxla/stablehlo/pull/2283).
 
 These operations fall into a few categories:
 
@@ -6609,16 +6610,17 @@ These operations fall into a few categories:
   ([#3](https://github.com/openxla/stablehlo/issues/3)).
 * Unused ops - These operations may have been useful at some point, but the ops
   were either underdeveloped, or the pipelines using these ops have been
-  refactored to not require them anymore. This includes `map`, `tuple` and
-  `get_tuple_element`, `rng`.
+  refactored to not require them anymore. This includes `map`, `tuple`,
+  `get_tuple_element`, and `rng`.
 
-Some of these ops can confidently be easily removed (`broadcast`,
-`create_token`, `cross-replica-sum`, `dot`, `unary_einsum`) and will be
-removed after the existing compatibilty window passes (6 months). Others
-are still being explored for removal (`einsum`, `get_tuple_element`, `map`,
-`rng` `torch_index_select`, `tuple`). Pending community feedback, these ops will
-either be removed, or added to the spec with full support. Until these ops
-futures are known, they are only guaranteed 6 months of compatibility.
+Some of these ops can be removed easily given that they can be expressed using
+existing ops (`broadcast`, `create_token`, `cross-replica-sum`, `dot`,
+`unary_einsum`) and will be removed after the existing compatibilty window
+passes (6 months). Others are still being explored for removal (`einsum`,
+`get_tuple_element`, `map`, `rng` `torch_index_select`, `tuple`). Pending
+community feedback, these ops will either be removed, or added to the spec with
+full support. Until these ops futures are known, they are only guaranteed 6
+months of compatibility.
 
 ## Execution
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3650,7 +3650,8 @@ component of the type. The element-type could be anything.
 
 > Note: Per [StableHLO v1.0 Cleanup #2283](https://github.com/openxla/stablehlo/pull/2283),
 > this op is being explored for deprecation as it appears to be unused by both
-> frameworks and compilers. As such, it has limited compatibility guarantees.
+> frameworks and compilers. As such, it has limited compatibility guarantees
+> (6 months).
 
 #### Semantics
 
@@ -4024,7 +4025,8 @@ Performs element-wise logistic operation on `operand` tensor and produces a
 
 > Note: Per [StableHLO v1.0 Cleanup #2283](https://github.com/openxla/stablehlo/pull/2283),
 > this op is being explored for deprecation as it appears to be unused by both
-> frameworks and compilers. As such, it has limited compatibility guarantees.
+> frameworks and compilers. As such, it has limited compatibility guarantees
+> (6 months).
 
 #### Semantics
 
@@ -5156,6 +5158,11 @@ and produces a `result` tensor. More formally,
 &nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/reverse.mlir)
 
 ### rng
+
+> Note: Per [StableHLO v1.0 Cleanup #2283](https://github.com/openxla/stablehlo/pull/2283),
+> this op is being explored for deprecation as it appears to be unused by both
+> frameworks and compilers. As such, it has limited compatibility guarantees
+> (6 months).
 
 #### Semantics
 
@@ -6326,7 +6333,8 @@ unit_diagonal, transpose_a), a, b, type(result))`.
 
 > Note: Per [StableHLO v1.0 Cleanup #2283](https://github.com/openxla/stablehlo/pull/2283),
 > this op is being explored for deprecation as it appears to be unused by both
-> frameworks and compilers. As such, it has limited compatibility guarantees.
+> frameworks and compilers. As such, it has limited compatibility guarantees
+> (6 months).
 
 #### Semantics
 
@@ -6597,7 +6605,7 @@ These operations fall into a few categories:
 * "Not in HLO" category of StableHLO operations - they were initially part of
   the StableHLO opset but have been later deemed to not fit it well:
   `broadcast`, `create_token`, `cross-replica-sum`, `dot`, `einsum`,
-  `torch_index_select`, `unary_einsum`, `trace`
+  `torch_index_select`, `unary_einsum`
   ([#3](https://github.com/openxla/stablehlo/issues/3)).
 * Unused ops - These operations may have been useful at some point, but the ops
   were either underdeveloped, or the pipelines using these ops have been
@@ -6605,7 +6613,7 @@ These operations fall into a few categories:
   `get_tuple_element`, `rng`.
 
 Some of these ops can confidently be easily removed (`broadcast`,
-`create_token`, `cross-replica-sum`, `dot`, `unary_einsum`, `trace`) and will be
+`create_token`, `cross-replica-sum`, `dot`, `unary_einsum`) and will be
 removed after the existing compatibilty window passes (6 months). Others
 are still being explored for removal (`einsum`, `get_tuple_element`, `map`,
 `rng` `torch_index_select`, `tuple`). Pending community feedback, these ops will

--- a/rfcs/20240503-opset-deprecations.md
+++ b/rfcs/20240503-opset-deprecations.md
@@ -8,8 +8,8 @@ Status: In review<br/>
 
 This doc covers a list of opset cleanups that we want to do for StableHLO v1.0.
 Most of these ops were never spec’ed and therefore have no formal compatibility
-guarantees, per the Unspecced Features compatibility exemption, however we can
-provide some backward / forward compatibility for most of them.
+guarantees, per the [Unspecced Features compatibility exemption][compat-out-of-scope],
+however we can provide some backward / forward compatibility for most of them.
 
 This doc will propose futures for the ops intentionally omitted from the spec,
 including:
@@ -30,7 +30,7 @@ deprecation steps will be as follows:
 1. Migrate uses of the ops to the supported StableHLO op (add builder methods).
 1. Change VHLO legalization to upgrade to the supported op for compatibility.
 1. Remove the redundant StableHLO op.
-1. Remove redundant op from VHLO after 6mo.
+1. Remove redundant op from VHLO after 6 months.
 
 ## Proposed Opset Changes
 
@@ -51,7 +51,7 @@ Helper methods can be added to the support op for compatibility, something like:
 ### P2: Deprecate `RealDynamicSliceOp`, Enhance `DynamicSliceOp`
 
 In terms of naming `stablehlo.dynamic_slice` is more in-model than
-`real_final_v2_dynamic_slice`. However in terms of functionality, per
+`real_dynamic_slice`. However in terms of functionality, per
 [Dynamism RFC P4](https://github.com/openxla/stablehlo/blob/main/rfcs/20230704-dynamism-101.md#p4)
 the behavior of `real_dynamic_slice` is correct. We propose to enhance
 `dynamic_slice_op` to have an identical feature set as `real_dynamic_slice`, and
@@ -77,13 +77,15 @@ These are all ops that seem to have very limited use in StableHLO. It would be
 great to remove them all or move them to CHLO, as opposed to providing long term
 compatibility on ops that aren't needed.
 
-In the interim, we only plan to guarantee the existing 6mo compatibility
-guarantees until these ops until their futures are more clearly known.
+In the interim, we only plan to guarantee the existing 6 month compatibility
+guarantees until these ops' futures are more clearly known.
 
-- **MapOp** is unused as far as we can tell, including in HLO. It’s uses tend to
+- **MapOp** is unused as far as we can tell, including in HLO. Its uses tend to
 be just for a region to mimic a composite, which is no longer needed after the
 addition of the `stablehlo.composite` op. This op likely can be removed.
-- **RngOp** is stateful, and there is a better alternative in RngBitGeneratorOp.
+- **RngOp** is stateful, and there is a better alternative in
+`RngBitGeneratorOp`. More work needs to be done to determine if all uses of this
+op can be safely migrated to the alternative.
 - **EinsumOp** can likely be moved to CHLO, the [xla::Einsum][einsum] method is
 similarly a decomposition. It is unclear how necessary this abstraction is for
 linalg lowerings though.
@@ -95,6 +97,7 @@ abstraction is to the community.
 Interested in feedback on any of the above proposals, or ideas for how to keep
 these changes from being too invasive to community projects!
 
+[compat-out-of-scope]: https://github.com/openxla/stablehlo/blob/main/docs/compatibility.md#out-of-scope
 [not-in-HLO]: https://github.com/openxla/stablehlo/blob/main/docs/spec.md#:~:text=%22Not%20in%20HLO%22,-category%20of%20StableHLO
 [CRS]: https://github.com/openxla/xla/blob/6cc24d8548094b3fc94dacc569fc6959227ae28b/xla/client/xla_builder.cc#L3619
 [einsum]: https://github.com/openxla/xla/blob/8371ea90202d9ca1cb1148237a1a1ef3620b354a/xla/client/lib/matrix.cc#L386

--- a/rfcs/20240503-opset-deprecations.md
+++ b/rfcs/20240503-opset-deprecations.md
@@ -21,6 +21,7 @@ including:
 opset updates: `real_dynamic_slice` vs `dynamic_slice`.
 - Potentially unused ops like stateful `rng` [#597](https://github.com/openxla/stablehlo/issues/597)
 and `map`.
+- Tuple Ops, including `get_tuple_element` and `tuple` ([#598](https://github.com/openxla/stablehlo/issues/598)).
 
 In general (unless the op is unused and can be trivially deleted), the
 deprecation steps will be as follows:
@@ -71,7 +72,7 @@ this op, and eventually we may, but we propose to move it to CHLO in the short
 term since frameworks map to this op, and this will keep the refactoring fairly
 trivial.
 
-### P4: (Feedback Requested) Deprecate `MapOp`, `RngOp`, `EinsumOp`, `TorchIndexSelectOp`
+### P4: (Feedback Requested) Deprecate `MapOp`, `RngOp`, `EinsumOp`, `TorchIndexSelectOp`, TupleOps
 
 These are all ops that seem to have very limited use in StableHLO. It would be
 great to remove them all or move them to CHLO, as opposed to providing long term
@@ -93,6 +94,9 @@ linalg lowerings though.
 [lowering to `gather`][torch-index-select] which can be used for a
 decomposition. However, similar to `einsum`, it is unclear how necessary this
 abstraction is to the community.
+- **Tuple Ops** include `get_tuple_element` and `tuple`, per [#598](https://github.com/openxla/stablehlo/issues/598)
+the use of tuples in MLIR is limited, and these are mostly kept around for
+interop with XLA and other dialects.
 
 Interested in feedback on any of the above proposals, or ideas for how to keep
 these changes from being too invasive to community projects!

--- a/rfcs/20240503-opset-deprecations.md
+++ b/rfcs/20240503-opset-deprecations.md
@@ -21,7 +21,8 @@ including:
 opset updates: `real_dynamic_slice` vs `dynamic_slice`.
 - Potentially unused ops like stateful `rng` [#597](https://github.com/openxla/stablehlo/issues/597)
 and `map`.
-- Tuple Ops, including `get_tuple_element` and `tuple` ([#598](https://github.com/openxla/stablehlo/issues/598)).
+- Tuple Ops and type, including `get_tuple_element` and `tuple` op, along with
+`tuple` type support in `custom_call` ([#598](https://github.com/openxla/stablehlo/issues/598)).
 
 In general (unless the op is unused and can be trivially deleted), the
 deprecation steps will be as follows:
@@ -72,7 +73,9 @@ this op, and eventually we may, but we propose to move it to CHLO in the short
 term since frameworks map to this op, and this will keep the refactoring fairly
 trivial.
 
-### P4: (Feedback Requested) Deprecate `MapOp`, `RngOp`, `EinsumOp`, `TorchIndexSelectOp`, TupleOps
+### P4: Deprecate `MapOp`, `RngOp`, `EinsumOp` `TorchIndexSelectOp`, Tuple support
+
+**Feedback Requested:** These opset changes are pending community feedback.
 
 These are all ops that seem to have very limited use in StableHLO. It would be
 great to remove them all or move them to CHLO, as opposed to providing long term
@@ -94,8 +97,9 @@ linalg lowerings though.
 [lowering to `gather`][torch-index-select] which can be used for a
 decomposition. However, similar to `einsum`, it is unclear how necessary this
 abstraction is to the community.
-- **Tuple Ops** include `get_tuple_element` and `tuple`, per [#598](https://github.com/openxla/stablehlo/issues/598)
-the use of tuples in MLIR is limited, and these are mostly kept around for
+- **Tuple Support** includes `get_tuple_element` and `tuple` ops, along with,
+support for `tuple` type in `custom_call` ([#598](https://github.com/openxla/stablehlo/issues/598)).
+The use of tuples in MLIR is limited, and these are mostly kept around for
 interop with XLA and other dialects.
 
 Interested in feedback on any of the above proposals, or ideas for how to keep

--- a/rfcs/20240503-opset-deprecations.md
+++ b/rfcs/20240503-opset-deprecations.md
@@ -1,0 +1,102 @@
+# RFC: StableHLO v1.0 Opset Deprecations & Cleanups
+
+Author: gleasonk<br/>
+Last Modified: 5/3/24<br/>
+Status: In review<br/>
+
+## Background
+
+This doc covers a list of opset cleanups that we want to do for StableHLO v1.0.
+Most of these ops were never spec’ed and therefore have no formal compatibility
+guarantees, per the Unspecced Features compatibility exemption, however we can
+provide some backward / forward compatibility for most of them.
+
+This doc will propose futures for the ops intentionally omitted from the spec,
+including:
+
+- [“Not in HLO” ops][not-in-HLO] ([#3](https://github.com/openxla/stablehlo/issues/3)):
+`broadcast`, `create_token`, `cross-replica-sum`, `dot`, `einsum`,
+`torch_index_select`, `unary_einsum`, `trace` ([#604](https://github.com/openxla/stablehlo/issues/604)).
+- [Dynamism RFC P4](https://github.com/openxla/stablehlo/blob/main/rfcs/20230704-dynamism-101.md#p4)
+opset updates: `real_dynamic_slice` vs `dynamic_slice`.
+- Potentially unused ops like stateful `rng` [#597](https://github.com/openxla/stablehlo/issues/597)
+and `map`.
+
+In general (unless the op is unused and can be trivially deleted), the
+deprecation steps will be as follows:
+
+1. Migrate framework uses of redundant ops.
+1. Block serialization of deprecated ops once frameworks migrated.
+1. Migrate uses of the ops to the supported StableHLO op (add builder methods).
+1. Change VHLO legalization to upgrade to the supported op for compatibility.
+1. Remove the redundant StableHLO op.
+1. Remove redundant op from VHLO after 6mo.
+
+## Proposed Opset Changes
+
+### P0: Delete `CreateTokenOp` and `TraceOp`
+
+These ops are both unused as far as we can tell. They can be trivially deleted.
+
+### P1: Deprecate `BroadcastOp`, `DotOp`, `UnaryEinsumOp`
+
+These ops are all a trivial subset of features of another op. I.e. BroadcastOp
+can be represented using BroadcastInDim, DotOp with DotGeneralOp, UnaryEinsum
+with [`einsum` lowering][einsum-lowering].
+These ops will follow the formal deprecation process listed above.
+
+Helper methods can be added to the support op for compatibility, something like:
+`isLhsBroadcast`, `isSimpleDot`, `isUnaryEinsum`.
+
+### P2: Deprecate `RealDynamicSliceOp`, Enhance `DynamicSliceOp`
+
+In terms of naming `stablehlo.dynamic_slice` is more in-model than
+`real_final_v2_dynamic_slice`. However in terms of functionality, per
+[Dynamism RFC P4](https://github.com/openxla/stablehlo/blob/main/rfcs/20230704-dynamism-101.md#p4)
+the behavior of `real_dynamic_slice` is correct. We propose to enhance
+`dynamic_slice_op` to have an identical feature set as `real_dynamic_slice`, and
+deprecate `real_dynamic_slice`. This change will be done with full
+forward and backward compatibility.
+
+One could make the argument that `dot` is a more proper name than `dot_general`,
+and I'm happy to go down that route, but it will likely cause a good deal of
+code churn in community repos. Interested in feedback here.
+
+### P3: Move `CrossReplicaSumOp` to CHLO
+
+The `cross-replica-sum` op  (hyphens not a typo), is just sugar for an
+`all-reduce` op. Even in the XlaBuilder's [xla::CrossReplicaSum][CRS]
+implementation this op is decomposed into an all reduce. We could just remove
+this op, and eventually we may, but we propose to move it to CHLO in the short
+term since frameworks map to this op, and this will keep the refactoring fairly
+trivial.
+
+### P4: (Feedback Requested) Deprecate `MapOp`, `RngOp`, `EinsumOp`, `TorchIndexSelectOp`
+
+These are all ops that seem to have very limited use in StableHLO. It would be
+great to remove them all or move them to CHLO, as opposed to providing long term
+compatibility on ops that aren't needed.
+
+In the interim, we only plan to guarantee the existing 6mo compatibility
+guarantees until these ops until their futures are more clearly known.
+
+- **MapOp** is unused as far as we can tell, including in HLO. It’s uses tend to
+be just for a region to mimic a composite, which is no longer needed after the
+addition of the `stablehlo.composite` op. This op likely can be removed.
+- **RngOp** is stateful, and there is a better alternative in RngBitGeneratorOp.
+- **EinsumOp** can likely be moved to CHLO, the [xla::Einsum][einsum] method is
+similarly a decomposition. It is unclear how necessary this abstraction is for
+linalg lowerings though.
+- **TorchIndexSelectOp** can also likely be moved to CHLO. There is an existing
+[lowering to `gather`][torch-index-select] which can be used for a
+decomposition. However, similar to `einsum`, it is unclear how necessary this
+abstraction is to the community.
+
+Interested in feedback on any of the above proposals, or ideas for how to keep
+these changes from being too invasive to community projects!
+
+[not-in-HLO]: https://github.com/openxla/stablehlo/blob/main/docs/spec.md#:~:text=%22Not%20in%20HLO%22,-category%20of%20StableHLO
+[CRS]: https://github.com/openxla/xla/blob/6cc24d8548094b3fc94dacc569fc6959227ae28b/xla/client/xla_builder.cc#L3619
+[einsum]: https://github.com/openxla/xla/blob/8371ea90202d9ca1cb1148237a1a1ef3620b354a/xla/client/lib/matrix.cc#L386
+[einsum-lowering]: https://github.com/openxla/xla/blob/6cc24d8548094b3fc94dacc569fc6959227ae28b/xla/mlir_hlo/mhlo/IR/mhlo_canonicalize.td#L30
+[torch-index-select]: https://github.com/openxla/xla/blob/8371ea90202d9ca1cb1148237a1a1ef3620b354a/xla/mlir_hlo/mhlo/transforms/legalize_torch_index_select_to_gather/legalize_torch_index_select_to_gather.cc#L45


### PR DESCRIPTION
A proposal to remove redundant operations from StableHLO before long-term compatibility guarantees go into place.

High level summary:
- Remove `CreateTokenOp`, `TraceOp`, `BroadcastOp`, `DotOp`, `UnaryEinsumOp`, `RealDynamicSliceOp`.
- Enhance `DynamicSliceOp`.
- Move `CrossReplicaSumOp` to CHLO.
- Hopefully remove/move to CHLO (need feedback) `MapOp`, `RngOp`, `EinsumOp`, `TorchIndexSelectOp`, `GetTupleElementOp`, and `tuple` type.

OpenXLA Discuss post: https://groups.google.com/a/openxla.org/g/openxla-discuss/c/sBAkvnd2bcA

Related tickets: #2176, #3 