### PR TITLE
Remove a few more deprecated method uses

### DIFF
--- a/stablehlo/dialect/StablehloAttrs.td
+++ b/stablehlo/dialect/StablehloAttrs.td
@@ -30,7 +30,7 @@ def GenericDenseI64ArrayAttr : Attr<DenseI64ArrayAttr.predicate, "DenseI64ArrayA
   let valueType = DenseI64ArrayAttr.valueType;
   let returnType = "::llvm::ArrayRef<int64_t>";
   let baseAttr = DenseI64ArrayAttr;
-  let convertFromStorage = "$_self.cast<DenseI64ArrayAttr>().asArrayRef()";
+  let convertFromStorage = "cast<DenseI64ArrayAttr>($_self).asArrayRef()";
   let constBuilderCall = "$_builder.getDenseI64ArrayAttr($0)";
 }
 
@@ -38,7 +38,7 @@ def GenericDenseBoolArrayAttr : Attr<DenseBoolArrayAttr.predicate, "DenseBoolArr
   let storageType = "Attribute";
   let valueType = DenseBoolArrayAttr.valueType;
   let returnType = "::llvm::ArrayRef<bool>";
-  let convertFromStorage = "$_self.cast<DenseBoolArrayAttr>().asArrayRef()";
+  let convertFromStorage = "cast<DenseBoolArrayAttr>($_self).asArrayRef()";
   let constBuilderCall = "$_builder.getDenseBoolArrayAttr($0)";
 }
 

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -257,7 +257,7 @@ LogicalResult CompositeOp::verifySymbolUses(
 void ConstantOp::getAsmResultNames(
     function_ref<void(Value, StringRef)> setNameFn) {
   mlir::TensorType type = getType();
-  if (type.getElementType().isa<IntegerType>()) {
+  if (isa<IntegerType>(type.getElementType())) {
     setNameFn(getResult(), "c");
   } else {
     setNameFn(getResult(), "cst");

--- a/stablehlo/transforms/StablehloAggressiveSimplification.cpp
+++ b/stablehlo/transforms/StablehloAggressiveSimplification.cpp
@@ -822,7 +822,7 @@ struct UnusedResultReduceOpCanon final
 
     auto newOp = rewriter.create<ReduceOp>(
         op.getLoc(), newInputs, newInitVals,
-        op.getDimensionsAttr().cast<DenseI64ArrayAttr>(), newElementTypes);
+        cast<DenseI64ArrayAttr>(op.getDimensionsAttr()), newElementTypes);
     Block *newReducerBlock = rewriter.createBlock(&newOp.getBody());
 
     IRMapping mapper;


### PR DESCRIPTION
I think these were added after/during the first round of changes.

Context: https://github.com/openxla/stablehlo/pull/2180