### PR TITLE
Add initial deprecation upgrade patterns for testing impact radius

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -301,6 +301,21 @@ gentbl_cc_library(
     ],
 )
 
+gentbl_cc_library(
+    name = "stablehlo_legalize_deprecated_ops_inc_gen",
+    tbl_outs = [
+        (
+            ["--gen-rewriters"],
+            "stablehlo/transforms/StablehloLegalizeDeprecatedOpsPatterns.h.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "stablehlo/transforms/StablehloLegalizeDeprecatedOpsPatterns.td",
+    deps = [
+        ":stablehlo_ops_td_files",
+    ],
+)
+
 cc_library(
     name = "interpreter_ops",
     srcs = [
@@ -942,6 +957,7 @@ cc_library(
         "stablehlo/transforms/StablehloCanonicalizeDynamism.cpp",
         "stablehlo/transforms/StablehloInstrumentWithProbe.cpp",
         "stablehlo/transforms/StablehloLegalizeCompositeToCall.cpp",
+        "stablehlo/transforms/StablehloLegalizeDeprecatedOps.cpp",
         "stablehlo/transforms/StablehloLegalizeToVhlo.cpp",
         "stablehlo/transforms/StablehloRefineArguments.cpp",
         "stablehlo/transforms/StablehloRefineShapes.cpp",
@@ -960,6 +976,7 @@ cc_library(
         ":chlo_ops",
         ":chlo_rewriters_inc_gen",
         ":interpreter_ops",
+        ":stablehlo_legalize_deprecated_ops_inc_gen",
         ":stablehlo_ops",
         ":stablehlo_ops_inc_gen",
         ":stablehlo_pass_inc_gen",

--- a/stablehlo/tests/stablehlo_legalize_deprecated_ops.mlir
+++ b/stablehlo/tests/stablehlo_legalize_deprecated_ops.mlir
@@ -1,0 +1,76 @@
+// RUN: stablehlo-opt --stablehlo-legalize-deprecated-ops --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL: op_dot
+func.func @op_dot(%arg0: tensor<2x3xf32>,
+                 %arg1: tensor<3x?xf32>) -> tensor<2x?xf32> {
+  // CHECK: stablehlo.dot_general %arg0, %arg1, contracting_dims = [1] x [0] : (tensor<2x3xf32>, tensor<3x?xf32>) -> tensor<2x?xf32>
+  %0 = "stablehlo.dot"(%arg0, %arg1) : (tensor<2x3xf32>, tensor<3x?xf32>) -> tensor<2x?xf32>
+  func.return %0 : tensor<2x?xf32>
+}
+
+// CHECK-LABEL: op_unary_einsum
+func.func @op_unary_einsum(%arg0: tensor<8x16xf32>) -> tensor<8xf32> {
+  // CHECK: stablehlo.einsum %cst, %arg0, config = ",ab->a" : (tensor<f32>, tensor<8x16xf32>) -> tensor<8xf32>
+  %0 = "stablehlo.unary_einsum"(%arg0) {einsum_config = "ab->a"} : (tensor<8x16xf32>) -> tensor<8xf32>
+  func.return %0 : tensor<8xf32>
+}
+
+// CHECK-LABEL: op_broadcast
+func.func @op_broadcast(%arg: tensor<1xf32>) -> tensor<4x3x2x1xf32> {
+  // CHECK: stablehlo.broadcast_in_dim %arg0, dims = [3] : (tensor<1xf32>) -> tensor<4x3x2x1xf32>
+  %0 = "stablehlo.broadcast"(%arg) {broadcast_sizes = array<i64: 4, 3, 2>} : (tensor<1xf32>) -> tensor<4x3x2x1xf32>
+  func.return %0: tensor<4x3x2x1xf32>
+}
+
+// CHECK-LABEL: op_create_token
+func.func @op_create_token() -> !stablehlo.token {
+  // CHECK: stablehlo.after_all  : !stablehlo.token
+  %0 = "stablehlo.create_token"() : () -> !stablehlo.token
+  func.return %0 : !stablehlo.token
+}
+
+// CHECK-LABEL: op_cross_replica_sum
+func.func @op_cross_replica_sum(%arg0: tensor<f32>) -> tensor<f32> {
+  // CHECK: "stablehlo.all_reduce"(%arg0) <{replica_groups = dense<{{.*}}> : tensor<2x1xi64>}>
+  // CHECK:   stablehlo.add %arg1, %arg2 : tensor<f32>
+  %0 = "stablehlo.cross-replica-sum"(%arg0) {replica_groups = dense<[[0], [1]]> : tensor<2x1xi64>} : (tensor<f32>) -> tensor<f32>
+  func.return %0 : tensor<f32>
+}
+
+// CHECK-LABEL: op_einsum
+func.func @op_einsum(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x5x6xf32>) -> tensor<3x4x6xf32> {
+  // TODO CHECK
+  %0 = "stablehlo.einsum"(%arg0, %arg1) {einsum_config = "ijk,ikm->ijm"}: (tensor<3x4x5xf32>, tensor<3x5x6xf32>) -> tensor<3x4x6xf32>
+  func.return %0 : tensor<3x4x6xf32>
+}
+
+// CHECK-LABEL: op_torch_index_select
+func.func @op_torch_index_select(%arg0: tensor<5x1x5xi32>,
+                         %arg1: tensor<2xi32>) ->  tensor<2x1x5xi32> {
+  // TODO CHECK
+  %0 = "stablehlo.torch_index_select"(%arg0, %arg1) {dim = 0 : i64, batch_dims = 0 : i64} : (tensor<5x1x5xi32>, tensor<2xi32>) -> tensor<2x1x5xi32>
+  func.return %0 : tensor<2x1x5xi32>
+}
+
+// -----
+
+func.func @op_rng(%min: tensor<f32>, %max: tensor<f32>) -> tensor<10xf32> {
+  %shape = arith.constant dense<[10]>  : tensor<1xi32>
+  // expected-error @+1 {{failed to legalize operation 'stablehlo.rng' that was explicitly marked illegal}}
+  %0 = "stablehlo.rng"(%min, %max, %shape) {rng_distribution = #stablehlo<rng_distribution UNIFORM>} : (tensor<f32>, tensor<f32>, tensor<1xi32>) -> tensor<10xf32>
+  func.return %0 : tensor<10xf32>
+}
+
+// -----
+
+func.func @op_map(%arg0: tensor<16xf32>) -> tensor<16xf32> {
+  // expected-error @+1 {{failed to legalize operation 'stablehlo.map' that was explicitly marked illegal}}
+  %0 = "stablehlo.map"(%arg0) ({
+    ^bb0(%arg1: tensor<f32>):
+      %1 = "stablehlo.abs"(%arg1) : (tensor<f32>) -> tensor<f32>
+      "stablehlo.return"(%1) : (tensor<f32>) -> ()
+  }) {
+    dimensions = array<i64: 0>
+  } : (tensor<16xf32>) -> tensor<16xf32>
+  func.return %0 : tensor<16xf32>
+}

--- a/stablehlo/tests/stablehlo_legalize_deprecated_ops.mlir
+++ b/stablehlo/tests/stablehlo_legalize_deprecated_ops.mlir
@@ -8,12 +8,17 @@ func.func @op_dot(%arg0: tensor<2x3xf32>,
   func.return %0 : tensor<2x?xf32>
 }
 
+// -----
+
 // CHECK-LABEL: op_unary_einsum
 func.func @op_unary_einsum(%arg0: tensor<8x16xf32>) -> tensor<8xf32> {
-  // CHECK: stablehlo.einsum %cst, %arg0, config = ",ab->a" : (tensor<f32>, tensor<8x16xf32>) -> tensor<8xf32>
+  // CHECK:      %cst = stablehlo.constant dense<1.000000e+00> : tensor<f32>
+  // CHECK-NEXT: stablehlo.einsum %cst, %arg0, config = ",ab->a" : (tensor<f32>, tensor<8x16xf32>) -> tensor<8xf32>
   %0 = "stablehlo.unary_einsum"(%arg0) {einsum_config = "ab->a"} : (tensor<8x16xf32>) -> tensor<8xf32>
   func.return %0 : tensor<8xf32>
 }
+
+// -----
 
 // CHECK-LABEL: op_broadcast
 func.func @op_broadcast(%arg: tensor<1xf32>) -> tensor<4x3x2x1xf32> {
@@ -22,6 +27,8 @@ func.func @op_broadcast(%arg: tensor<1xf32>) -> tensor<4x3x2x1xf32> {
   func.return %0: tensor<4x3x2x1xf32>
 }
 
+// -----
+
 // CHECK-LABEL: op_create_token
 func.func @op_create_token() -> !stablehlo.token {
   // CHECK: stablehlo.after_all  : !stablehlo.token
@@ -29,13 +36,17 @@ func.func @op_create_token() -> !stablehlo.token {
   func.return %0 : !stablehlo.token
 }
 
+// -----
+
 // CHECK-LABEL: op_cross_replica_sum
 func.func @op_cross_replica_sum(%arg0: tensor<f32>) -> tensor<f32> {
-  // CHECK: "stablehlo.all_reduce"(%arg0) <{replica_groups = dense<{{.*}}> : tensor<2x1xi64>}>
+  // CHECK{LITERAL}: "stablehlo.all_reduce"(%arg0) <{replica_groups = dense<[[0], [1]]> : tensor<2x1xi64>}>
   // CHECK:   stablehlo.add %arg1, %arg2 : tensor<f32>
   %0 = "stablehlo.cross-replica-sum"(%arg0) {replica_groups = dense<[[0], [1]]> : tensor<2x1xi64>} : (tensor<f32>) -> tensor<f32>
   func.return %0 : tensor<f32>
 }
+
+// -----
 
 // CHECK-LABEL: op_einsum
 func.func @op_einsum(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x5x6xf32>) -> tensor<3x4x6xf32> {
@@ -43,6 +54,8 @@ func.func @op_einsum(%arg0: tensor<3x4x5xf32>, %arg1: tensor<3x5x6xf32>) -> tens
   %0 = "stablehlo.einsum"(%arg0, %arg1) {einsum_config = "ijk,ikm->ijm"}: (tensor<3x4x5xf32>, tensor<3x5x6xf32>) -> tensor<3x4x6xf32>
   func.return %0 : tensor<3x4x6xf32>
 }
+
+// -----
 
 // CHECK-LABEL: op_torch_index_select
 func.func @op_torch_index_select(%arg0: tensor<5x1x5xi32>,

--- a/stablehlo/transforms/CMakeLists.txt
+++ b/stablehlo/transforms/CMakeLists.txt
@@ -20,6 +20,10 @@ set(LLVM_TARGET_DEFINITIONS ChloDecompositionPatterns.td)
 mlir_tablegen(ChloDecompositionPatterns.h.inc --gen-rewriters)
 add_public_tablegen_target(ChloDecompositionPatternsIncGen)
 
+set(LLVM_TARGET_DEFINITIONS StablehloLegalizeDeprecatedOpsPatterns.td)
+mlir_tablegen(StablehloLegalizeDeprecatedOpsPatterns.h.inc --gen-rewriters)
+add_public_tablegen_target(StablehloLegalizeDeprecatedOpsPatternsIncGen)
+
 add_mlir_dialect_library(StablehloPasses
   PARTIAL_SOURCES_INTENDED
   ChloLegalizeToStablehlo.cpp
@@ -27,8 +31,9 @@ add_mlir_dialect_library(StablehloPasses
   ShapeLegalizeToStablehlo.cpp
   StablehloAggressiveSimplification.cpp
   StablehloCanonicalizeDynamism.cpp
-  StablehloLegalizeCompositeToCall.cpp
   StablehloInstrumentWithProbe.cpp
+  StablehloLegalizeCompositeToCall.cpp
+  StablehloLegalizeDeprecatedOps.cpp
   StablehloLegalizeToVhlo.cpp
   StablehloRefineArguments.cpp
   StablehloRefineShapes.cpp
@@ -37,6 +42,7 @@ add_mlir_dialect_library(StablehloPasses
 
   DEPENDS
   ChloDecompositionPatternsIncGen
+  StablehloLegalizeDeprecatedOpsPatternsIncGen
   PassesIncGen
 
   LINK_LIBS PUBLIC

--- a/stablehlo/transforms/Passes.h
+++ b/stablehlo/transforms/Passes.h
@@ -66,6 +66,10 @@ void populateStablehloCanonicalizationPatterns(MLIRContext *context,
                                                RewritePatternSet *patterns,
                                                PatternBenefit benefit = 1);
 
+/// Collection of patterns to upgrade deprecated ops to long-term supported ops.
+void populateStablehloLegalizeDeprecatedOpsPatterns(
+    MLIRContext *context, RewritePatternSet *patterns);
+
 /// Collection of shape dialect to StableHLO patterns.
 void populateShapeToStablehloPatterns(MLIRContext *context,
                                       RewritePatternSet *patterns);

--- a/stablehlo/transforms/Passes.td
+++ b/stablehlo/transforms/Passes.td
@@ -145,6 +145,21 @@ def ShapeLegalizeToStablehloPass : Pass<"shape-legalize-to-stablehlo", "func::Fu
   let dependentDialects = ["mlir::stablehlo::StablehloDialect"];
 }
 
+def StablehloLegalizeDeprecatedOpsPass : Pass<"stablehlo-legalize-deprecated-ops", "func::FuncOp"> {
+  let summary = "Legalize deprecated ops to well-supported ops.";
+  let description = [{
+    The StableHLO v1.0 Opset Deprecations RFC (#2283) proposes to remove
+    several redundant ops. This pass helps to evaluate the impact of these op
+    removals in various compilation pipelines by legalizing them to their
+    long-term supported counterparts.
+  }];
+  let dependentDialects = ["mlir::stablehlo::StablehloDialect"];
+  let options = [
+    Option<"failOnUnusedOps", "fail-on-unused", "bool", /*default=*/"true",
+           "Fail on (mostly) unused ops that are deprecated without any fallback.">,
+  ];
+}
+
 def StablehloLegalizeCompositeToCallPass :
     Pass<"stablehlo-legalize-composite-to-call", "func::FuncOp"> {
   let summary = "Replaces composite ops with a call to their decomposition";

--- a/stablehlo/transforms/StablehloLegalizeDeprecatedOps.cpp
+++ b/stablehlo/transforms/StablehloLegalizeDeprecatedOps.cpp
@@ -1,0 +1,162 @@
+/* Copyright 2023 The StableHLO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// Implements composite inlining.
+
+#include <cassert>
+#include <cstdint>
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/PatternMatch.h"
+#include "stablehlo/dialect/StablehloOps.h"
+#include "stablehlo/transforms/Passes.h"
+
+namespace mlir {
+namespace stablehlo {
+
+#define GEN_PASS_DEF_STABLEHLOLEGALIZEDEPRECATEDOPSPASS
+#include "stablehlo/transforms/Passes.h.inc"
+
+namespace {
+
+struct StablehloLegalizeDeprecatedOpsPass final
+    : impl::StablehloLegalizeDeprecatedOpsPassBase<
+          StablehloLegalizeDeprecatedOpsPass> {
+  StablehloLegalizeDeprecatedOpsPass()
+      : StablehloLegalizeDeprecatedOpsPassBase<
+            StablehloLegalizeDeprecatedOpsPass>() {};
+  StablehloLegalizeDeprecatedOpsPass(
+      const StablehloLegalizeDeprecatedOpsPassOptions &opts)
+      : StablehloLegalizeDeprecatedOpsPassBase<
+            StablehloLegalizeDeprecatedOpsPass>(opts) {};
+
+  LogicalResult initialize(MLIRContext *context) override {
+    target = std::make_shared<ConversionTarget>(*context);
+    target->addIllegalOp<BroadcastOp, CreateTokenOp, CrossReplicaSumOp, DotOp,
+                         UnaryEinsumOp>();
+
+    if (failOnUnusedOps) {
+      // Deprecated ops to be removed with no replacements
+      target->addIllegalOp<MapOp, RngOp, TraceOp>();
+    }
+
+    target->addLegalDialect<StablehloDialect>();
+
+    RewritePatternSet patterns_(context);
+    populateStablehloLegalizeDeprecatedOpsPatterns(context, &patterns_);
+    patterns = std::move(patterns_);
+
+    return success();
+  }
+
+  void runOnOperation() override {
+    if (failed(applyPartialConversion(getOperation(), *target, patterns))) {
+      return signalPassFailure();
+    }
+  }
+
+ private:
+  std::shared_ptr<ConversionTarget> target;
+  FrozenRewritePatternSet patterns;
+};
+
+///////////
+// Patterns
+///////////
+
+struct CrossReplicaSumToAllReducePattern
+    : public OpRewritePattern<CrossReplicaSumOp> {
+  using OpRewritePattern<CrossReplicaSumOp>::OpRewritePattern;
+  LogicalResult matchAndRewrite(CrossReplicaSumOp crossReplicaSumOp,
+                                PatternRewriter &rewriter) const override {
+    auto allReduceOp = rewriter.replaceOpWithNewOp<AllReduceOp>(
+        crossReplicaSumOp, crossReplicaSumOp.getType(),
+        crossReplicaSumOp.getOperand(), crossReplicaSumOp.getReplicaGroups(),
+        /*channel_handle=*/ChannelHandleAttr(),
+        /*use_global_device_ids=*/false);
+
+    auto *block = rewriter.createBlock(&allReduceOp.getComputation());
+    auto elementType =
+        RankedTensorType::get({}, allReduceOp.getType().getElementType());
+    auto location = allReduceOp.getComputation().getLoc();
+    block->addArguments({elementType, elementType}, {location, location});
+    auto addOp = rewriter.create<AddOp>(location, block->getArgument(0),
+                                        block->getArgument(1));
+    rewriter.create<ReturnOp>(location, addOp.getResult());
+    return success();
+  }
+};
+
+///////////////////////
+// DRR helper functions
+///////////////////////
+
+DenseElementsAttr getScalarOfType(Type ty, int64_t rawValue) {
+  RankedTensorType scalarTy = RankedTensorType::get({}, ty);
+
+  if (auto floatTy = mlir::dyn_cast<FloatType>(ty)) {
+    APFloat value(floatTy.getFloatSemantics(), rawValue);
+    return DenseElementsAttr::get(scalarTy, value);
+  }
+  if (auto intTy = mlir::dyn_cast<IntegerType>(ty)) {
+    APInt value(intTy.getWidth(), static_cast<int64_t>(rawValue),
+                /*isSigned=*/true);
+    return DenseElementsAttr::get(scalarTy, value);
+  }
+  if (auto complexTy = mlir::dyn_cast<ComplexType>(ty)) {
+    if (auto floatTy = mlir::cast<FloatType>(complexTy.getElementType())) {
+      APFloat real(floatTy.getFloatSemantics(), rawValue);
+      APFloat imag = APFloat::getZero(floatTy.getFloatSemantics());
+      return DenseElementsAttr::get(scalarTy,
+                                    std::complex<APFloat>(real, imag));
+    }
+  }
+  llvm_unreachable("unsupported type");
+}
+
+DotDimensionNumbersAttr getDefaultDotDimensionNumbers(mlir::Value dotOpLhs) {
+  return DotDimensionNumbersAttr::get(
+      dotOpLhs.getContext(),
+      /*lhsBatchingDimensions=*/{},
+      /*rhsBatchingDimensions=*/{},
+      /*lhsContractingDimensions=*/
+      {cast<ShapedType>(dotOpLhs.getType()).getRank() - 1},
+      /*rhsContractingDimensions=*/{0});
+}
+
+DenseI64ArrayAttr getBroadcastDimensions(RankedTensorType resultType,
+                                         DenseI64ArrayAttr broadcastSizes) {
+  int64_t operandRank = resultType.getRank() - broadcastSizes.size();
+  SmallVector<int64_t> broadcastDimensions;
+  for (int64_t i = 0; i < operandRank; ++i) {
+    broadcastDimensions.push_back(i + broadcastSizes.size());
+  }
+  return DenseI64ArrayAttr::get(resultType.getContext(), broadcastDimensions);
+}
+
+#include "stablehlo/transforms/StablehloLegalizeDeprecatedOpsPatterns.h.inc"
+}  // namespace
+
+void populateStablehloLegalizeDeprecatedOpsPatterns(
+    MLIRContext *context, RewritePatternSet *patterns) {
+  populateWithGenerated(*patterns);
+  patterns->add<CrossReplicaSumToAllReducePattern>(context);
+}
+
+}  // namespace stablehlo
+}  // namespace mlir

--- a/stablehlo/transforms/StablehloLegalizeDeprecatedOpsPatterns.td
+++ b/stablehlo/transforms/StablehloLegalizeDeprecatedOpsPatterns.td
@@ -1,0 +1,56 @@
+/* Copyright 2024 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This is the canonicalize pattern definition file.
+
+include "mlir/IR/OpBase.td"
+include "stablehlo/dialect/StablehloOps.td"
+
+def UnaryToBinaryEinsumEq : NativeCodeCall<
+  "$_builder.getStringAttr(\",\" + $0.getValue().str())">;
+
+def GetI64DenseElementsAttr : NativeCodeCall<
+  "$0.mapValues($_builder.getI64Type(), [](llvm::APInt x) { return x.sext(64); })">;
+
+def GetDefaultDotDimensionNumbers : NativeCodeCall<
+  "getDefaultDotDimensionNumbers($0)">;
+
+def GetDefaultBroadcastDimensions : NativeCodeCall<
+  "getBroadcastDimensions(cast<RankedTensorType>($0.getType()), cast<DenseI64ArrayAttr>($1))">;
+
+
+// Here, the element type can be any integer or float type. But, note that only
+// 32 bit integers are supported for the value.
+class GetScalarOfType<int value> : NativeCodeCall<
+  "getScalarOfType(getElementTypeOrSelf($0)," # value # ")">;
+
+def BroadcastToBroadcastInDim : Pat<
+  (StableHLO_BroadcastOp:$result $operand, $broadcast_sizes),
+  (StableHLO_BroadcastInDimOp $operand, (GetDefaultBroadcastDimensions $result, $broadcast_sizes))>;
+
+def CreateTokenToAfterAll : Pat<
+  (StableHLO_CreateTokenOp),
+  (StableHLO_AfterAllOp (NativeCodeCall<"ValueRange{}">))>;
+
+// def CrossReplicaSumToAllReduce : <Declared in cpp>
+
+def DotToDotGeneral : Pat<
+  (StableHLO_DotOp $lhs, $rhs, $precision_config),
+  (StableHLO_DotGeneralOp $lhs, $rhs, (GetDefaultDotDimensionNumbers $lhs), $precision_config)>;
+
+def UnaryEinsumToEinsum : Pat<
+  (StableHLO_UnaryEinsumOp $operand, $equation),
+  (StableHLO_EinsumOp (StableHLO_ConstantOp (GetScalarOfType<1> $operand)),
+                $operand, (UnaryToBinaryEinsumEq $equation))>;


### PR DESCRIPTION
This pass is intended to be used to test the blast radius of the proposed deprecation changes in #2283 and help with migration of passes and other tooling.

Still todo - patterns for the following:
- Einsum pattern
- TorchIndexSelect pattern
- RNG pattern (if possible)
- RealDynamicSliceOp (requires dynamic_slice update first)
