### PR TITLE
Use correct license for LegalizeCompositeToCall

### DIFF
--- a/stablehlo/transforms/StablehloLegalizeCompositeToCall.cpp
+++ b/stablehlo/transforms/StablehloLegalizeCompositeToCall.cpp
@@ -1,10 +1,17 @@
-// Copyright 2024 The StableHLO Authors
-//
-// Licensed under the Apache License, Version 2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+/* Copyright 2024 The StableHLO Authors.
 
-// Implements composite inlining.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
 
 #include <cassert>
 


### PR DESCRIPTION
This was added with the wrong license a while ago. I think I copied the license from StablehloAggressiveSimplication.cpp and changed the authorship and year, but didn't realize that the actual license designation was wrong.