### PR TITLE
Rename tosa.div to tosa.int_div, tosa.div is deprecated

### DIFF
--- a/stablehlo/conversions/tosa/tests/binary.mlir
+++ b/stablehlo/conversions/tosa/tests/binary.mlir
@@ -45,17 +45,9 @@ func.func @concatenate(%arg0 : tensor<3x3xf32>, %arg1 : tensor<3x3xf32>) -> tens
 
 // CHECK-LABEL: @divide
 func.func @divide(%arg0 : tensor<10xi32>, %arg1 : tensor<10xi32>) -> tensor<10xi32> {
-  // CHECK: tosa.div
+  // CHECK: tosa.int_div
   %0 = "stablehlo.divide"(%arg0, %arg1) : (tensor<10xi32>, tensor<10xi32>) -> tensor<10xi32>
   return %0 : tensor<10xi32>
-}
-
-// CHECK-LABEL: @divide_f32
-func.func @divide_f32(%arg0 : tensor<10xf32>, %arg1 : tensor<10xf32>) -> tensor<10xf32> {
-  // tosa.div only supports i32, so this should not legalize.
-  // CHECK: stablehlo.divide
-  %0 = "stablehlo.divide"(%arg0, %arg1) : (tensor<10xf32>, tensor<10xf32>) -> tensor<10xf32>
-  return %0 : tensor<10xf32>
 }
 
 // CHECK-LABEL: @dot_vector_vector

--- a/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.pdll
+++ b/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.pdll
@@ -125,7 +125,7 @@ Pattern =>
 Pattern =>
   replace op<stablehlo.divide>(input0 : Value<_: Tosa_Int32Tensor>,
                           input1 : Value<_: Tosa_Int32Tensor>)
-     with op<tosa.div>(input0, input1);
+     with op<tosa.int_div>(input0, input1);
 Pattern =>
   replace op<stablehlo.maximum>(input0 : Value<_: Tosa_Tensor>,
                            input1 : Value<_: Tosa_Tensor>)


### PR DESCRIPTION
Back porting from the integrate. 

official deprecation note : https://discuss.mlplatform.org/t/renaming-tosa-operator-div-to-intdiv/205

tosa.int_div supports only int, removed f32 test 