### PR TITLE
Remove dynamic_{iota,reshape} from list of ops to spec

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -332,8 +332,8 @@ in StableHLO programs. In the meanwhile, here is the list of these operations:
   `trace` ([#604](https://github.com/openxla/stablehlo/issues/604)).
 * "Dynamism" category of StableHLO operations - they were bootstrapped from
    MHLO,and we are in the process of speccing them: `dynamic_broadcast_in_dim`,
-  `dynamic_conv`, `dynamic_gather`, `dynamic_iota`, `dynamic_pad`, `dynamic_reshape`,
-  `real_dynamic_slice`, `set_dimension_size`
+  `dynamic_conv`, `dynamic_gather`, `dynamic_pad`, `real_dynamic_slice`,
+  `set_dimension_size`.
   ([#8](https://github.com/openxla/stablehlo/issues/8)).
 * Shape computations, including `arith`, `shape` and `tensor` operations
   ([#8](https://github.com/openxla/stablehlo/issues/8)).


### PR DESCRIPTION
These ops were specced in https://github.com/openxla/stablehlo/pull/2270 and https://github.com/openxla/stablehlo/pull/2284.