### PR TITLE
Spec dynamic_pad

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2647,7 +2647,7 @@ op, but the result shape is specified dynamically via `output_shape`.
 
 | Label | Name             | Type                                         | Constraints |
 |-------|------------------|----------------------------------------------|-------------|
-| (I1)  | `output_shape`   | 1-dimensional tensor of type `si64` | (C1), (C2)  |
+| (I1)  | `output_shape`   | 1-dimensional tensor of type `si64`          | (C1), (C2)  |
 | (I2)  | `iota_dimension` | `si64`                                       | (C1)        |
 
 #### Outputs
@@ -2685,8 +2685,8 @@ op, but the result shape is specified dynamically via `output_shape`.
 
 This operation is functionally identical to
 [pad](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#pad)
-op, but the amounts of padding are specified dynamically via `edge_padding_low`,
-`edge_padding_high` and `interior_padding`.
+op, but with `edge_padding_low`, `edge_padding_high` and `interior_padding`
+specified dynamically as values.
 
 #### Inputs
 
@@ -2722,9 +2722,9 @@ op, but the amounts of padding are specified dynamically via `edge_padding_low`,
 //            [4, 5, 6]
 //           ]
 // %padding_value: 0
-// %edge_padding_low = [0, 1]
-// %edge_padding_high = [2, 1]
-// %interior_padding = [1, 2]
+// %edge_padding_low: [0, 1]
+// %edge_padding_high: [2, 1]
+// %interior_padding: [1, 2]
 %result = "stablehlo.dynamic_pad"(%operand, %padding_value,
   %edge_padding_low, %edge_padding_high, %interior_padding
 ) : (tensor<2x3xi32>, tensor<i32>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> tensor<5x9xi32>
@@ -2737,7 +2737,7 @@ op, but the amounts of padding are specified dynamically via `edge_padding_low`,
 //          ]
 ```
 
-&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/pad.mlir)
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/dynamic_pad.mlir)
 
 ### dynamic_reshape
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2647,7 +2647,7 @@ op, but the result shape is specified dynamically via `output_shape`.
 
 | Label | Name             | Type                                         | Constraints |
 |-------|------------------|----------------------------------------------|-------------|
-| (I1)  | `output_shape`   | 1-dimensional tensor of type `si64`          | (C1), (C2)  |
+| (I1)  | `output_shape`   | 1-dimensional tensor of integer type         | (C1), (C2)  |
 | (I2)  | `iota_dimension` | `si64`                                       | (C1)        |
 
 #### Outputs
@@ -2694,9 +2694,9 @@ specified dynamically as values.
 |-------|---------------------|-----------------------------------------------------|------------------|
 | (I1)  | `operand`           | tensor or per-tensor quantized tensor               | (C1), (C2), (C4) |
 | (I2)  | `padding_value`     | 0-dimensional tensor or per-tensor quantized tensor | (C1)             |
-| (I3)  | `edge_padding_low`  | 1-dimensional tensor of type `si64`                 | (C1), (C4)       |
-| (I4)  | `edge_padding_high` | 1-dimensional tensor of type `si64`                 | (C1), (C4)       |
-| (I5)  | `interior_padding`  | 1-dimensional tensor of type `si64`                 | (C2-C4)          |
+| (I3)  | `edge_padding_low`  | 1-dimensional tensor of integer type                | (C1), (C4)       |
+| (I4)  | `edge_padding_high` | 1-dimensional tensor of integer type                | (C1), (C4)       |
+| (I5)  | `interior_padding`  | 1-dimensional tensor of integer type                | (C2-C4)          |
 
 #### Outputs
 
@@ -2752,7 +2752,7 @@ op, but the result shape is specified dynamically via `output_shape`.
 | Label | Name           | Type                                         | Constraints |
 |-------|----------------|----------------------------------------------|-------------|
 | (I1)  | `operand`      | tensor or quantized tensor                   | (C1-C3)     |
-| (I2)  | `output_shape` | 1-dimensional tensor of type `si64`          | (C4)        |
+| (I2)  | `output_shape` | 1-dimensional tensor of integer type         | (C4)        |
 
 #### Outputs
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -332,8 +332,7 @@ in StableHLO programs. In the meanwhile, here is the list of these operations:
   `trace` ([#604](https://github.com/openxla/stablehlo/issues/604)).
 * "Dynamism" category of StableHLO operations - they were bootstrapped from
    MHLO,and we are in the process of speccing them: `dynamic_broadcast_in_dim`,
-  `dynamic_conv`, `dynamic_gather`, `dynamic_iota`, `dynamic_pad`, `dynamic_reshape`,
-  `real_dynamic_slice`, `set_dimension_size`
+  `dynamic_conv`, `dynamic_gather`, `real_dynamic_slice`, `set_dimension_size`.
   ([#8](https://github.com/openxla/stablehlo/issues/8)).
 * Shape computations, including `arith`, `shape` and `tensor` operations
   ([#8](https://github.com/openxla/stablehlo/issues/8)).
@@ -2648,7 +2647,7 @@ op, but the result shape is specified dynamically via `output_shape`.
 
 | Label | Name             | Type                                         | Constraints |
 |-------|------------------|----------------------------------------------|-------------|
-| (I1)  | `output_shape`   | 1-dimensional tensor constant of type `si64` | (C1), (C2)  |
+| (I1)  | `output_shape`   | 1-dimensional tensor of type `si64` | (C1), (C2)  |
 | (I2)  | `iota_dimension` | `si64`                                       | (C1)        |
 
 #### Outputs
@@ -2680,6 +2679,66 @@ op, but the result shape is specified dynamically via `output_shape`.
 
 &nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/dynamic_iota.mlir)
 
+### dynamic_pad
+
+#### Semantics
+
+This operation is functionally identical to
+[pad](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#pad)
+op, but the amounts of padding are specified dynamically via `edge_padding_low`,
+`edge_padding_high` and `interior_padding`.
+
+#### Inputs
+
+| Label | Name                | Type                                                | Constraints      |
+|-------|---------------------|-----------------------------------------------------|------------------|
+| (I1)  | `operand`           | tensor or per-tensor quantized tensor               | (C1), (C2), (C4) |
+| (I2)  | `padding_value`     | 0-dimensional tensor or per-tensor quantized tensor | (C1)             |
+| (I3)  | `edge_padding_low`  | 1-dimensional tensor of type `si64`                 | (C1), (C4)       |
+| (I4)  | `edge_padding_high` | 1-dimensional tensor of type `si64`                 | (C1), (C4)       |
+| (I5)  | `interior_padding`  | 1-dimensional tensor of type `si64`                 | (C2-C4)          |
+
+#### Outputs
+
+| Name     | Type                                  | Constraints |
+|----------|---------------------------------------|-------------|
+| `result` | tensor or per-tensor quantized tensor | (C3-C6)     |
+
+#### Constraints
+
+* (C1) `element_type(operand) = element_type(padding_value) =
+  element_type(result)`.
+* (C2) `size(edge_padding_low) = size(edge_padding_high) =
+  size(interior_padding) = rank(operand)`.
+* (C3) `0 <= interior_padding`.
+* (C4) `shape(result) = shape(operand) + edge_padding_low +
+  max(shape(operand) - 1, 0) * interior_padding + edge_padding_high`.
+
+#### Examples
+
+```mlir
+// %operand: [
+//            [1, 2, 3],
+//            [4, 5, 6]
+//           ]
+// %padding_value: 0
+// %edge_padding_low = [0, 1]
+// %edge_padding_high = [2, 1]
+// %interior_padding = [1, 2]
+%result = "stablehlo.dynamic_pad"(%operand, %padding_value,
+  %edge_padding_low, %edge_padding_high, %interior_padding
+) : (tensor<2x3xi32>, tensor<i32>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> tensor<5x9xi32>
+// %result: [
+//           [0, 1, 0, 0, 2, 0, 0, 3, 0],
+//           [0, 0, 0, 0, 0, 0, 0, 0, 0],
+//           [0, 4, 0, 0, 5, 0, 0, 6, 0],
+//           [0, 0, 0, 0, 0, 0, 0, 0, 0],
+//           [0, 0, 0, 0, 0, 0, 0, 0, 0]
+//          ]
+```
+
+&nbsp;[More Examples](https://github.com/openxla/stablehlo/tree/main/stablehlo/tests/interpret/pad.mlir)
+
 ### dynamic_reshape
 
 #### Semantics
@@ -2693,7 +2752,7 @@ op, but the result shape is specified dynamically via `output_shape`.
 | Label | Name           | Type                                         | Constraints |
 |-------|----------------|----------------------------------------------|-------------|
 | (I1)  | `operand`      | tensor or quantized tensor                   | (C1-C3)     |
-| (I2)  | `output_shape` | 1-dimensional tensor constant of type `si64` | (C4)        |
+| (I2)  | `output_shape` | 1-dimensional tensor of type `si64`          | (C4)        |
 
 #### Outputs
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -82,7 +82,7 @@ one of the following tracking labels.
 | dynamic_conv             | no            | revisit      | no             | no              | no          |
 | dynamic_gather           | no            | revisit      | revisit        | no              | no          |
 | dynamic_iota             | yes           | yes          | infeasible     | yes             | revisit     |
-| dynamic_pad              | no            | revisit      | no             | yes             | no          |
+| dynamic_pad              | yes           | yes          | infeasible     | yes             | revisit     |
 | dynamic_reshape          | yes           | yes          | infeasible     | yes             | revisit     |
 | dynamic_slice            | yes           | yes          | yes            | yes             | yes         |
 | dynamic_update_slice     | yes           | yes          | yes            | yes             | yes         |

--- a/stablehlo/dialect/Base.td
+++ b/stablehlo/dialect/Base.td
@@ -166,6 +166,8 @@ def HLO_PredTensor : RankedTensorOf<[HLO_Pred]>;
 
 def HLO_Tensor : RankedTensorOf<[HLO_Float, HLO_Pred, HLO_Int, HLO_Complex, HLO_QuantizedInt]>;
 
+def HLO_ScalarTensor: 0DTensorOf<[HLO_Float, HLO_Pred, HLO_Int, HLO_Complex, HLO_QuantizedInt]>;
+
 def HLO_NonQuantizedTensor : RankedTensorOf<[HLO_Float, HLO_Pred, HLO_Int, HLO_Complex]>;
 
 def HLO_TensorOrPerAxisQuantizedTensor : RankedTensorOf<[HLO_Float, HLO_Pred, HLO_Int, HLO_Complex, HLO_QuantizedInt, HLO_PerAxisQuantizedInt],

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2950,7 +2950,7 @@ def StableHLO_PadOp: StableHLO_ShapedInterfaceOp<"pad",
   }];
   let arguments = (ins
     HLO_Tensor:$operand /*pad_i1*/,
-    HLO_Tensor:$padding_value /*pad_i2*/,
+    HLO_ScalarTensor:$padding_value /*pad_i2*/,
     GenericDenseI64ArrayAttr:$edge_padding_low /*pad_i3*/,
     GenericDenseI64ArrayAttr:$edge_padding_high /*pad_i4*/,
     GenericDenseI64ArrayAttr:$interior_padding /*pad_i5*/
@@ -3419,37 +3419,36 @@ def StableHLO_RealDynamicSliceOp: StableHLO_ShapedInterfaceOp<
 
 def StableHLO_DynamicPadOp: StableHLO_ShapedInterfaceOp<"dynamic_pad",
       [ConditionallySpeculatable, NoMemoryEffect,
-      AllElementTypesMatch<["operand", "padding_value", "result"]>,
-      AllTypesMatch<["edge_padding_low", "edge_padding_high", "interior_padding"]>]> {
+      AllElementTypesMatch<["operand", "padding_value", "result"]> /*dynamic_pad_c1*/,
+      AllTypesMatch<["edge_padding_low", "edge_padding_high", "interior_padding"]> /*dynamic_pad_c2*/,
+      AllRanksMatch<["operand", "result"]> /*dynamic_pad_c4*/]> {
   let summary = "DynamicPad operation";
   let description = [{
-    This operation is a work in progress, so it is not yet included in
-    the StableHLO specification: https://github.com/openxla/stablehlo/issues/8.
+    This operation is functionally identical to
+    [pad](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#pad)
+    op, but the amounts of padding are specified dynamically via `edge_padding_low`,
+    `edge_padding_high` and `interior_padding`.
 
-    Informally, this operation does the same thing as PadOp except
-    that `edge_padding_low`, `edge_padding_high` and `interior_padding` are
-    specified dynamically:
-    https://github.com/openxla/stablehlo/blob/main/docs/spec.md#pad
+    See: https://github.com/openxla/stablehlo/blob/main/docs/spec.md#dynamic_pad
 
     Example:
     ```mlir
+    %edge_padding_low = stablehlo.constant dense<[0, 1]> : tensor<2xi32>
+    %edge_padding_high = stablehlo.constant dense<[2, 1]> : tensor<2xi32>
+    %interior_padding = stablehlo.constant dense<[1, 2]> : tensor<2xi32>
     %result = stablehlo.dynamic_pad %operand, %padding_value,
                 %edge_padding_low, %edge_padding_high, %interior_padding
-           : (tensor<?x?xf32>, tensor<f32>, tensor<2xindex>, tensor<2xindex>, tensor<2xindex>) -> tensor<?x?xf32>
+                : (tensor<2x3xi32>, tensor<i32>, tensor<2xi32>, tensor<2xi32>, tensor<2xi32>) -> tensor<5x9xi32>
     ```
   }];
   let arguments = (ins
-    HLO_Tensor:$operand,
-    HLO_Tensor:$padding_value,
-    HLO_DimensionTensor:$edge_padding_low,
-    HLO_DimensionTensor:$edge_padding_high,
-    HLO_DimensionTensor:$interior_padding
+    HLO_Tensor:$operand /*dynamic_pad_i1*/,
+    HLO_ScalarTensor:$padding_value /*dynamic_pad_i2*/,
+    HLO_StaticDimensionTensor:$edge_padding_low /*dynamic_pad_i3*/,
+    HLO_StaticDimensionTensor:$edge_padding_high /*dynamic_pad_i4*/,
+    HLO_StaticDimensionTensor:$interior_padding /*dynamic_pad_i5*/
   );
   let results = (outs HLO_Tensor:$result);
-  let description = [{
-    Dynamically Pads the `operand`, with amount of padding added at
-    low-end/high-end/interior is passed through input tensors.
-  }];
   let hasVerifier = 1;
 
   let assemblyFormat = "operands attr-dict `:` functional-type(operands, results)";

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -3426,8 +3426,9 @@ def StableHLO_DynamicPadOp: StableHLO_ShapedInterfaceOp<"dynamic_pad",
   let description = [{
     This operation is functionally identical to
     [pad](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#pad)
-    op, but the amounts of padding are specified dynamically via `edge_padding_low`,
-    `edge_padding_high` and `interior_padding`.
+    https://github.com/openxla/stablehlo/pull/2306#discussion_r1595669709
+    op, but with `edge_padding_low`, `edge_padding_high` and `interior_padding`
+    specified dynamically as values.
 
     See: https://github.com/openxla/stablehlo/blob/main/docs/spec.md#dynamic_pad
 

--- a/stablehlo/reference/Index.cpp
+++ b/stablehlo/reference/Index.cpp
@@ -17,7 +17,6 @@ limitations under the License.
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Error.h"
-#include "stablehlo/reference/Tensor.h"
 
 namespace mlir {
 namespace stablehlo {

--- a/stablehlo/reference/Index.cpp
+++ b/stablehlo/reference/Index.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Error.h"
+#include "stablehlo/reference/Tensor.h"
 
 namespace mlir {
 namespace stablehlo {

--- a/stablehlo/reference/Ops.h
+++ b/stablehlo/reference/Ops.h
@@ -91,10 +91,6 @@ Tensor dotGeneralOp(const Tensor &lhs, const Tensor &rhs,
                     const Axes &lhsContractingDimensions,
                     const Axes &rhsContractingDimensions,
                     ShapedType resultType);
-Tensor dynamicIotaOp(Axis iotaDimension, const Tensor &outputShape,
-                     ShapedType resultType);
-Tensor dynamicReshapeOp(const Tensor &operand, const Tensor &outputShape,
-                        ShapedType resultType);
 Tensor dynamicSliceOp(const Tensor &operand, ArrayRef<Tensor> startIndices,
                       const Sizes &sliceSizes, ShapedType resultType);
 Tensor dynamicUpdateSliceOp(const Tensor &operand, const Tensor &update,

--- a/stablehlo/reference/Tensor.cpp
+++ b/stablehlo/reference/Tensor.cpp
@@ -24,6 +24,7 @@ limitations under the License.
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/Support/DebugStringHelper.h"
 #include "stablehlo/reference/Errors.h"
+#include "stablehlo/reference/Index.h"
 #include "stablehlo/reference/Types.h"
 
 namespace mlir {
@@ -559,6 +560,23 @@ DenseElementsAttr makeDenseElementsAttr(Tensor tensor) {
   }
 
   llvm::report_fatal_error("Only FloatType and IntType are handled currently.");
+}
+
+Sizes makeSizes(Tensor tensor) {
+  if (tensor.getRank() != 1 || !isa<IntegerType>(tensor.getElementType())) {
+    std::string str;
+    llvm::raw_string_ostream os(str);
+    os << "makeSizes(Tensor) only accepts integer tensors of rank 1, but got: ";
+    tensor.print(os);
+    llvm::report_fatal_error(str.c_str());
+  }
+  SmallVector<int64_t> values;
+  values.reserve(tensor.getNumElements());
+  for (auto it = tensor.index_begin(), end = tensor.index_end(); it != end;
+       it++) {
+    values.push_back(tensor.get(*it).getIntegerValue().getSExtValue());
+  }
+  return Sizes(values);
 }
 
 }  // namespace stablehlo

--- a/stablehlo/reference/Tensor.h
+++ b/stablehlo/reference/Tensor.h
@@ -144,6 +144,9 @@ Tensor makeTensor(DenseElementsAttr attr);
 /// Creates a DenseElementsAttr from a Tensor.
 DenseElementsAttr makeDenseElementsAttr(Tensor tensor);
 
+/// Creates a Sizes from a Tensor.
+Sizes makeSizes(Tensor tensor);
+
 }  // namespace stablehlo
 }  // namespace mlir
 

--- a/stablehlo/tests/interpret/dynamic_pad.mlir
+++ b/stablehlo/tests/interpret/dynamic_pad.mlir
@@ -1,0 +1,24 @@
+// RUN: stablehlo-translate --interpret -split-input-file %s
+
+func.func @dynamic_pad() {
+  %operand = stablehlo.constant dense<[[0, 0, 0, 0],
+                                       [0, 1, 2, 0],
+                                       [0, 3, 4, 0],
+                                       [0, 5, 6, 0],
+                                       [0, 0, 0, 0]]> : tensor<5x4xi64>
+  %padding_value = stablehlo.constant dense<-1> : tensor<i64>
+  %low = stablehlo.constant dense<[1, -1]> : tensor<2xi64>
+  %high = stablehlo.constant dense<[1, -1]> : tensor<2xi64>
+  %interior = stablehlo.constant dense<[0, 1]> : tensor<2xi64>
+  %result = stablehlo.dynamic_pad %operand, %padding_value, %low, %high, %interior
+    : (tensor<5x4xi64>, tensor<i64>, tensor<2xi64>, tensor<2xi64>, tensor<2xi64>) -> tensor<7x5xi64>
+  check.expect_eq_const %result, dense<[
+    [-1, -1, -1, -1, -1],
+    [-1,  0, -1,  0, -1],
+    [-1,  1, -1,  2, -1],
+    [-1,  3, -1,  4, -1],
+    [-1,  5, -1,  6, -1],
+    [-1,  0, -1,  0, -1],
+    [-1, -1, -1, -1, -1]]> : tensor<7x5xi64>
+  func.return
+}


### PR DESCRIPTION
This includes:
- Adding partial support to the interpreter (only when the result is static)
- Cleaning up and completing the verifier
- Updating the ODS
- Adding relevant tests

I made a few drive-by fixes to related logic/ops as well.

Constraint coverage:

```
I1. operand is tensor or per-tensor quantized tensor: ODS
I2. padding_value is 0-dimensional tensor or per-tensor quantized tensor: ODS
I3. edge_padding_low is integer tensor: ODS
I4. edge_padding_high is integer tensor: ODS
I5. interior_padding is integer tensor: ODS
C1. element_type(operand) = element_type(padding_value) = element_type(result): ODS
C2. size(edge_padding_low) = size(edge_padding_high) = size(interior_padding) = rank(operand): ODS + verifier
C3. 0 <= interior_padding: verifier
C4. shape(result) = shape(operand) + edge_padding_low + max(shape(operand) - 1, 0) * interior_padding + edge_padding_high: verifier
```
ref https://github.com/openxla/stablehlo/issues/2267
Fixes #2292