### PR TITLE
Remove redundant rank checks in linalg lowerings

### DIFF
--- a/stablehlo/conversions/linalg/transforms/LegalizeToLinalgUtils.cpp
+++ b/stablehlo/conversions/linalg/transforms/LegalizeToLinalgUtils.cpp
@@ -100,14 +100,6 @@ Value coerceTensorShape(OpBuilder &builder, Location loc,
       value);
 }
 
-LogicalResult verifyHloOpBufferOrTensorSemantics(Operation *op) {
-  auto isRankedTensor = [](Value val) {
-    return isa<RankedTensorType>(val.getType());
-  };
-  if (!llvm::all_of(op->getOperands(), isRankedTensor)) return failure();
-  return success(llvm::all_of(op->getResults(), isRankedTensor));
-}
-
 Value fillTensorWithZeros(OpBuilder &builder, Location loc, Value tensor) {
   auto type = cast<ShapedType>(tensor.getType());
   Value zero;

--- a/stablehlo/conversions/linalg/transforms/LegalizeToLinalgUtils.h
+++ b/stablehlo/conversions/linalg/transforms/LegalizeToLinalgUtils.h
@@ -77,10 +77,6 @@ Value getEmptyTensorFor(OpBuilder &b, Location loc, ShapedType resultType,
 Value coerceTensorShape(OpBuilder &builder, Location loc,
                         TypedValue<ShapedType> value, ShapedType targetType);
 
-/// Verifies |op|'s semantics by checking if all operands and results have
-/// ranged tensor types.
-LogicalResult verifyHloOpBufferOrTensorSemantics(Operation *op);
-
 /// Fills |tensor| with a zero constant of the matching type. Returns the new
 /// value.
 Value fillTensorWithZeros(OpBuilder &builder, Location loc, Value tensor);

--- a/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
@@ -352,10 +352,6 @@ struct DataMovementOpConverter : OpConversionPattern<OpTy> {
   LogicalResult matchAndRewrite(
       OpTy op, typename OpTy::Adaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    if (failed(verifyHloOpBufferOrTensorSemantics(op)))
-      return rewriter.notifyMatchFailure(
-          op, "failed to verify hlo buffer or tensor semantics");
-
     ShapedType resultType = getHloOpResultType(op);
     resultType =
         this->getTypeConverter()->template convertType<ShapedType>(resultType);
@@ -842,8 +838,6 @@ struct BitcastConvertConverter final
   LogicalResult matchAndRewrite(
       mlir::stablehlo::BitcastConvertOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
-    if (failed(verifyHloOpBufferOrTensorSemantics(op))) return failure();
-
     auto inputType =
         llvm::cast<RankedTensorType>(adaptor.getOperand().getType());
     auto outputType =
@@ -1044,7 +1038,6 @@ struct ReshapeOpConverter final
       mlir::stablehlo::ReshapeOp reshapeOp,
       mlir::stablehlo::ReshapeOp::Adaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
-    if (failed(verifyHloOpBufferOrTensorSemantics(reshapeOp))) return failure();
     Value operand = adaptor.getOperand();
     auto operandType = llvm::cast<ShapedType>(operand.getType());
     Type elemType = operandType.getElementType();
@@ -1583,8 +1576,6 @@ struct MapOpToGenericConverter final
   LogicalResult matchAndRewrite(
       mlir::stablehlo::MapOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
-    if (failed(verifyHloOpBufferOrTensorSemantics(op))) return failure();
-
     auto resultType = getTypeConverter()->convertType<ShapedType>(op.getType());
     if (!resultType)
       return rewriter.notifyMatchFailure(op, "type conversion failed");
@@ -1636,8 +1627,6 @@ struct MapOpToMapConverter final : OpConversionPattern<mlir::stablehlo::MapOp> {
   LogicalResult matchAndRewrite(
       mlir::stablehlo::MapOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
-    if (failed(verifyHloOpBufferOrTensorSemantics(op))) return failure();
-
     auto resultType = getTypeConverter()->convertType<ShapedType>(op.getType());
     if (!resultType)
       return rewriter.notifyMatchFailure(op, "type conversion failed");

--- a/stablehlo/conversions/linalg/transforms/StablehloToLinalgDotProduct.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloToLinalgDotProduct.cpp
@@ -94,9 +94,6 @@ struct DotOpConversion final : OpConversionPattern<mlir::stablehlo::DotOp> {
   LogicalResult matchAndRewrite(
       mlir::stablehlo::DotOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    if (failed(verifyHloOpBufferOrTensorSemantics(op))) {
-      return failure();
-    }
     if (getDotOperationType(op) != op_type) return failure();
 
     Location loc = op.getLoc();
@@ -126,9 +123,6 @@ struct DotGeneralBatchMatMulOpConversion final
   LogicalResult matchAndRewrite(
       mlir::stablehlo::DotGeneralOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    if (failed(verifyHloOpBufferOrTensorSemantics(op))) {
-      return failure();
-    }
     if (op.getType().getRank() != 3) {
       return rewriter.notifyMatchFailure(op, "expected a batch matmul");
     }
@@ -183,10 +177,6 @@ struct DotGeneralOpConversion final
   LogicalResult matchAndRewrite(
       mlir::stablehlo::DotGeneralOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    if (failed(verifyHloOpBufferOrTensorSemantics(op))) {
-      return failure();
-    }
-
     // Get various dimension iterator information
     mlir::stablehlo::DotDimensionNumbersAttr dimNumbers =
         op.getDotDimensionNumbers();


### PR DESCRIPTION
Operands and results are enforced to be ranked by ODS.