### PR TITLE
Use BroadcastOp linalg lowerings for simple BroadcastInDimOps

### DIFF
--- a/stablehlo/conversions/linalg/tests/miscellaneous.mlir
+++ b/stablehlo/conversions/linalg/tests/miscellaneous.mlir
@@ -520,6 +520,25 @@ func.func @broadcast(%arg: tensor<4x?x16xf32>) -> tensor<4x2x1x4x?x16xf32> {
 
 // -----
 
+// CHECK-DAG: #[[OPERAND_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d3, d4, d5)>
+// CHECK-DAG: #[[RESULT_MAP:.+]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d1, d2, d3, d4, d5)>
+// CHECK: func @broadcast
+func.func @broadcast_in_dim_as_broadcast(%arg: tensor<4x3x16xf32>) -> tensor<4x2x1x4x3x16xf32> {
+  %0 = stablehlo.broadcast_in_dim %arg, dims = [3, 4, 5] : (tensor<4x3x16xf32>) -> tensor<4x2x1x4x3x16xf32>
+  func.return %0: tensor<4x2x1x4x3x16xf32>
+}
+// CHECK: %{{.*}} = tensor.empty() : tensor<4x2x1x4x3x16xf32>
+// CHECK: linalg.generic {{{.*}}indexing_maps = [#[[OPERAND_MAP]], #[[RESULT_MAP]]]
+// CHECK-NEXT: ^bb0(%[[OPERAND:.*]]: f32, %{{.*}}: f32):
+// CHECK-NEXT:   linalg.yield %[[OPERAND]] : f32
+
+// CHECK-PRIMITIVE-LABEL: func @broadcast
+// CHECK-PRIMITIVE: %{{.*}} = tensor.empty() : tensor<4x2x1x4x3x16xf32>
+// CHECK-PRIMITIVE: linalg.broadcast
+// CHECK-PRIMITIVE:   dimensions = [0, 1, 2]
+
+// -----
+
 // CHECK: #[[RESULT_MAP:.*]] = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK: func @iota_f32
 func.func @iota_f32() -> tensor<7x10xf32> {

--- a/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
@@ -429,8 +429,8 @@ int64_t getBroadcastSizes(BroadcastInDimOp op) {
 
 template <typename OpTy>
 LogicalResult lowerSimpleBroadcast(ConversionPatternRewriter &rewriter,
-                               const TypeConverter *typeConverter, OpTy op,
-                               typename OpTy::Adaptor adaptor) {
+                                   const TypeConverter *typeConverter, OpTy op,
+                                   typename OpTy::Adaptor adaptor) {
   auto resultTy = typeConverter->convertType<ShapedType>(op.getType());
   if (!resultTy)
     return rewriter.notifyMatchFailure(op, "type conversion failed");

--- a/stablehlo/dialect/StablehloOps.h
+++ b/stablehlo/dialect/StablehloOps.h
@@ -144,6 +144,11 @@ ParseResult parseWindowAttributes(OpAsmParser &parser, Attribute &windowStrides,
 namespace mlir {
 namespace stablehlo {
 
+// Returns the broadcast_dimensions for a BroadcastInDimOp from the
+// result_type and broadcast_sizes from a BroadcastOp.
+DenseI64ArrayAttr getBroadcastDimensionsFromBroadcastSizes(
+    RankedTensorType resultType, DenseI64ArrayAttr broadcastSizes);
+
 // Returns the dimension numbers for a DotGeneral op that can be expressed as
 // a DotOp, given the LHS of such an operation.
 DotDimensionNumbersAttr getDefaultDotDimensionNumbers(mlir::Value lhs);

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1944,6 +1944,11 @@ def StableHLO_BroadcastInDimOp : StableHLO_Op<"broadcast_in_dim",
     $operand `,` `dims` `=` custom<DenseI64Array>($broadcast_dimensions)
       attr-dict `:` functional-type(operands, results)
   }];
+
+  let extraClassDeclaration = commonClassDeclaration # [{
+    /// Determines if this BroadcastInDim instance can be expressed as a Broadcast.
+    bool isSimpleBroadcast();
+  }];
 }
 
 def StableHLO_DynamicBroadcastInDimOp : StableHLO_ShapedInterfaceOp<

--- a/stablehlo/transforms/StablehloLegalizeDeprecatedOps.cpp
+++ b/stablehlo/transforms/StablehloLegalizeDeprecatedOps.cpp
@@ -122,15 +122,6 @@ DenseElementsAttr getScalarOfType(Type ty, int64_t rawValue) {
   llvm::report_fatal_error("unsupported type");
 }
 
-DenseI64ArrayAttr getBroadcastDimensions(RankedTensorType resultType,
-                                         DenseI64ArrayAttr broadcastSizes) {
-  int64_t operandRank = resultType.getRank() - broadcastSizes.size();
-  auto broadcastDimensions =
-      llvm::map_to_vector(llvm::seq(operandRank),
-                          [&](int64_t i) { return i + broadcastSizes.size(); });
-  return DenseI64ArrayAttr::get(resultType.getContext(), broadcastDimensions);
-}
-
 #include "stablehlo/transforms/StablehloLegalizeDeprecatedOpsPatterns.h.inc"
 }  // namespace
 

--- a/stablehlo/transforms/StablehloLegalizeDeprecatedOpsPatterns.td
+++ b/stablehlo/transforms/StablehloLegalizeDeprecatedOpsPatterns.td
@@ -28,7 +28,7 @@ def GetDefaultDotDimensionNumbers : NativeCodeCall<
   "getDefaultDotDimensionNumbers($0)">;
 
 def GetDefaultBroadcastDimensions : NativeCodeCall<
-  "getBroadcastDimensions(cast<RankedTensorType>($0.getType()), cast<DenseI64ArrayAttr>($1))">;
+  "getBroadcastDimensionsFromBroadcastSizes(cast<RankedTensorType>($0.getType()), cast<DenseI64ArrayAttr>($1))">;
 
 
 // Here, the element type can be any integer or float type. But, note that only


### PR DESCRIPTION
In a similar vein as #2314, this PR eases the process of deprecating BroadcastOp by reusing the BroadcastOp lowerings for BroadcastInDimOp ops derived from BroadcastOp ops.

Unfortunately, BroadcastInDimOp requires a static result type, so not all Broadcast ops can be converted through the deprecated op legalization.

#2311