### PR TITLE
Revert "Fix asan build issue (#2108)"

### DIFF
--- a/.github/workflows/buildAndTestCMake.yml
+++ b/.github/workflows/buildAndTestCMake.yml
@@ -74,13 +74,6 @@ jobs:
           CMAKE_BUILD_TYPE: Release
           MLIR_ENABLE_BINDINGS_PYTHON: ON
 
-    - name: Fix kernel mmap rnd bits
-      # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
-      # high-entropy ASLR in much newer kernels that GitHub runners are
-      # using leading to random crashes: https://reviews.llvm.org/D148280
-      # TODO: remove this once https://github.com/actions/runner-images/issues/9491 is fixed
-      run: sudo sysctl vm.mmap_rnd_bits=28
-
     - name: Build and Test StableHLO (with AddressSanitizer)
       shell: bash
       run: |


### PR DESCRIPTION
This reverts commit 538b1e11ca83fd5f14390e73a54c41af8f7ee87d.

The underlying issue was fixed in upstream in https://github.com/actions/runner-images/pull/9513 (https://github.com/actions/runner-images/issues/9491)