### PR TITLE
dynamic_broadcast_in_dim  followup cleanup

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2683,11 +2683,9 @@ If not specified, all dimensions are assumed to be possibly expanding.
     zero_points(operand)[0] for i in
     range(dim(result, quantization_dimension(result)))`.
 * (C7) `size(output_dimensions) = rank(result)`.
-* (C8) `is_unique(known_expanding_dimensions)`.
-* (C9) `is_unique(known_non_expanding_dimensions)`.
-* (C10) `is_unique(known_expanding_dimensions + known_non_expanding_dimensions)`.
-* (C11) `0 <= known_expanding_dimensions < rank(operand)`.
-* (C12) `0 <= known_non_expanding_dimensions < rank(operand)`.
+* (C8) `is_unique(known_expanding_dimensions + known_non_expanding_dimensions)`.
+* (C9) `0 <= known_expanding_dimensions < rank(operand)`.
+* (C10) `0 <= known_non_expanding_dimensions < rank(operand)`.
 
 #### Examples
 

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -3991,14 +3991,13 @@ LogicalResult verifyDynamicBroadcastInDimOp(
   collectExpansionBehaviorDims(knownExpandingDimensions);
   collectExpansionBehaviorDims(knownNonexpandingDimensions);
 
-  // dynamic_broadcast_in_dim_c8, dynamic_broadcast_in_dim_c9,
-  // dynamic_broadcast_in_dim_c10
+  // dynamic_broadcast_in_dim_c8
   if (knownExpansionBehavior.size() != numKnownExpansionBehavior)
     return emitOptionalError(
         location,
         "duplicate expansion hint for at least one operand dimension");
 
-  // dynamic_broadcast_in_dim_c11, dynamic_broadcast_in_dim_c12
+  // dynamic_broadcast_in_dim_c9, dynamic_broadcast_in_dim_c10
   for (int64_t i : knownExpansionBehavior)
     if (i < 0 || i >= operandType.getRank())
       return emitOptionalError(location, "hint for expanding dimension ", i,

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1117,7 +1117,7 @@ func.func @dynamic_broadcast_in_dim_c7_output_dimensions_mismatching_size(%arg0:
 
 // -----
 
-func.func @dynamic_broadcast_in_dim_c8_c9_c10(%arg0: tensor<?x?xi32>, %shape: tensor<3xi64>) -> tensor<?x?x?xi32> {
+func.func @dynamic_broadcast_in_dim_c8(%arg0: tensor<?x?xi32>, %shape: tensor<3xi64>) -> tensor<?x?x?xi32> {
   // expected-error@+1 {{duplicate expansion hint for at least one operand dimension}}
   %0 = "stablehlo.dynamic_broadcast_in_dim"(%arg0, %shape) {
     broadcast_dimensions = array<i64: 1, 2>,
@@ -1128,7 +1128,7 @@ func.func @dynamic_broadcast_in_dim_c8_c9_c10(%arg0: tensor<?x?xi32>, %shape: te
 
 // -----
 
-func.func @dynamic_broadcast_in_dim_c11_c12(%arg0: tensor<?x?xi32>, %shape: tensor<3xi64>) -> tensor<?x?x?xi32> {
+func.func @dynamic_broadcast_in_dim_c9_c10(%arg0: tensor<?x?xi32>, %shape: tensor<3xi64>) -> tensor<?x?x?xi32> {
   // expected-error@+1 {{hint for expanding dimension 3 does not refer to a valid operand dimension}}
   %0 = "stablehlo.dynamic_broadcast_in_dim"(%arg0, %shape) {
     broadcast_dimensions = array<i64: 1, 2>,


### PR DESCRIPTION
Separate constraints are not required, C8 is taking care of C9, C10. Same verifier check is applicable.