### PR TITLE
Update TypeInference.cpp

### DIFF
--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -4118,7 +4118,8 @@ LogicalResult verifyDynamicPadOp(std::optional<Location> location,
   for (auto [i, in, out, low, high, interior] : llvm::enumerate(
            inputType.getShape(), outputType.getShape(), edgePaddingLowValues,
            edgePaddingHighValues, interiorPaddingValues)) {
-    auto want = in + low + std::max(static_cast<long>(in - 1), long(0)) * interior + high;
+    auto want = in + low +
+                std::max(static_cast<long>(in - 1), long(0)) * interior + high;
     if (out != want)
       return emitOptionalError(location, "expected output dimension at index ",
                                i, " to equal ", want, ", but got ", out);

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -4119,7 +4119,8 @@ LogicalResult verifyDynamicPadOp(std::optional<Location> location,
            inputType.getShape(), outputType.getShape(), edgePaddingLowValues,
            edgePaddingHighValues, interiorPaddingValues)) {
     auto want = in + low +
-                std::max(static_cast<long>(in - 1), long(0)) * interior + high;
+                std::max(static_cast<int64_t>(in - 1), int64_t(0)) * interior +
+                high;
     if (out != want)
       return emitOptionalError(location, "expected output dimension at index ",
                                i, " to equal ", want, ", but got ", out);

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -4118,7 +4118,7 @@ LogicalResult verifyDynamicPadOp(std::optional<Location> location,
   for (auto [i, in, out, low, high, interior] : llvm::enumerate(
            inputType.getShape(), outputType.getShape(), edgePaddingLowValues,
            edgePaddingHighValues, interiorPaddingValues)) {
-    auto want = in + low + std::max(in - 1, long(0)) * interior + high;
+    auto want = in + low + std::max(static_cast<long>(in - 1), long(0)) * interior + high;
     if (out != want)
       return emitOptionalError(location, "expected output dimension at index ",
                                i, " to equal ", want, ", but got ", out);


### PR DESCRIPTION
add static cast to int64_t type

Context: I was trying to setup the environment of XLA, and find there was a syntax error which caused by the non consistent type of parameters in std::max() function.

There was an error on Macos Sonoma 14.3 , using LLVM 17.0.6.