### PR TITLE
Delete `<optional>` and add `<stdint.h>` from `StablehloAttributes.h`

### DIFF
--- a/stablehlo/integrations/c/StablehloAttributes.h
+++ b/stablehlo/integrations/c/StablehloAttributes.h
@@ -13,9 +13,8 @@ limitations under the License.
 #ifndef STABLEHLO_INTEGRATIONS_C_STABLEHLO_ATTRIBUTES_H
 #define STABLEHLO_INTEGRATIONS_C_STABLEHLO_ATTRIBUTES_H
 
+#include <stdint.h>
 #include <sys/types.h>
-
-#include <optional>
 
 #include "mlir-c/IR.h"
 #include "mlir-c/Support.h"


### PR DESCRIPTION
This is for C builds which doesn't have `optional` defined. And include `<stdint.h>` as that is what defines `int64_t`.