### PR TITLE
Regenerated pass documentation to fix bazel build failure at head

### DIFF
--- a/docs/generated/stablehlo_passes.md
+++ b/docs/generated/stablehlo_passes.md
@@ -12,6 +12,10 @@ An experimental pass that legalizes shape-related ops to StableHLO ops.
 Bringing shape and data computations together via an optional pass will
 make it possible for the StableHLO ecosystem to potentially leverage the
 compilation pipelines that use StableHLO operations to model dynamism.
+### `-stablehlo-aggressive-folder`
+
+_Folds StableHLO operations_
+
 ### `-stablehlo-aggressive-simplification`
 
 _Canonicalizes StableHLO operations_


### PR DESCRIPTION
documentation is outdated after https://github.com/openxla/stablehlo/pull/2253

Validated that  the change actually fixes the failure


Follow up: why https://github.com/openxla/stablehlo/pull/2253 CI check did not complain? 