### PR TITLE
Don't mark dev-wheel as latest release

### DIFF
--- a/.github/workflows/publishWheelRelease.yml
+++ b/.github/workflows/publishWheelRelease.yml
@@ -131,4 +131,4 @@ jobs:
           removeArtifacts: false
           allowUpdates: true
           replacesArtifacts: true
-          makeLatest: true
+          makeLatest: false


### PR DESCRIPTION
Dev wheels should not be marked as latest release, v1.0 should show up as the latest public release.