### PR TITLE
Revert bytecode changes from #2259

### DIFF
--- a/stablehlo/dialect/StablehloBytecode.cpp
+++ b/stablehlo/dialect/StablehloBytecode.cpp
@@ -511,8 +511,6 @@ void StablehloBytecodeInterface::write(GatherDimensionNumbersAttr attr,
   writer.writeVarInt(stablehlo_encoding::kGatherDimensionNumbers);
   writer.writeSignedVarInts(attr.getOffsetDims());
   writer.writeSignedVarInts(attr.getCollapsedSliceDims());
-  writer.writeSignedVarInts(attr.getOperandBatchingDims());
-  writer.writeSignedVarInts(attr.getStartIndicesBatchingDims());
   writer.writeSignedVarInts(attr.getStartIndexMap());
   writer.writeSignedVarInt(attr.getIndexVectorDim());
 }
@@ -622,8 +620,6 @@ void StablehloBytecodeInterface::write(ScatterDimensionNumbersAttr attr,
   writer.writeVarInt(stablehlo_encoding::kScatterDimensionNumbersAttr);
   writer.writeSignedVarInts(attr.getUpdateWindowDims());
   writer.writeSignedVarInts(attr.getInsertedWindowDims());
-  writer.writeSignedVarInts(attr.getInputBatchingDims());
-  writer.writeSignedVarInts(attr.getScatterIndicesBatchingDims());
   writer.writeSignedVarInts(attr.getScatterDimsToOperandDims());
   writer.writeSignedVarInt(attr.getIndexVectorDim());
 }

--- a/stablehlo/dialect/StablehloBytecode.cpp
+++ b/stablehlo/dialect/StablehloBytecode.cpp
@@ -502,7 +502,7 @@ StablehloBytecodeInterface::readGatherDimensionNumbersAttr(
 
   return GatherDimensionNumbersAttr::get(
       getContext(), offsetDims, collapsedSliceDims,
-      /*startIndicesBatchingDims=*/{}, /*startIndicesBatchingDims=*/{},
+      /*operandBatchingDims=*/{}, /*startIndicesBatchingDims=*/{},
       startIndexMap, indexVectorDim);
 }
 

--- a/stablehlo/dialect/StablehloBytecode.cpp
+++ b/stablehlo/dialect/StablehloBytecode.cpp
@@ -491,21 +491,19 @@ GatherDimensionNumbersAttr
 StablehloBytecodeInterface::readGatherDimensionNumbersAttr(
     DialectBytecodeReader &reader) const {
   LOG_READ_CALL;
-  llvm::SmallVector<int64_t> offsetDims, collapsedSliceDims,
-      operandBatchingDims, startIndicesBatchingDims, startIndexMap;
+  llvm::SmallVector<int64_t> offsetDims, collapsedSliceDims, startIndexMap;
   int64_t indexVectorDim;
 
   if (failed(reader.readSignedVarInts(offsetDims)) ||
       failed(reader.readSignedVarInts(collapsedSliceDims)) ||
-      failed(reader.readSignedVarInts(operandBatchingDims)) ||
-      failed(reader.readSignedVarInts(startIndicesBatchingDims)) ||
       failed(reader.readSignedVarInts(startIndexMap)) ||
       failed(reader.readSignedVarInt(indexVectorDim)))
     return GatherDimensionNumbersAttr();
 
   return GatherDimensionNumbersAttr::get(
-      getContext(), offsetDims, collapsedSliceDims, operandBatchingDims,
-      startIndicesBatchingDims, startIndexMap, indexVectorDim);
+      getContext(), offsetDims, collapsedSliceDims,
+      /*startIndicesBatchingDims=*/{}, /*startIndicesBatchingDims=*/{},
+      startIndexMap, indexVectorDim);
 }
 
 void StablehloBytecodeInterface::write(GatherDimensionNumbersAttr attr,
@@ -604,20 +602,19 @@ StablehloBytecodeInterface::readScatterDimensionNumbersAttr(
     DialectBytecodeReader &reader) const {
   LOG_READ_CALL;
   llvm::SmallVector<int64_t> updateWindowDims, insertedWindowDims,
-      inputBatchingDims, scatterIndicesBatchingDims, scatterDimsToOperandDims;
+      scatterDimsToOperandDims;
   int64_t indexVectorDim;
 
   if (failed(reader.readSignedVarInts(updateWindowDims)) ||
       failed(reader.readSignedVarInts(insertedWindowDims)) ||
-      failed(reader.readSignedVarInts(inputBatchingDims)) ||
-      failed(reader.readSignedVarInts(scatterIndicesBatchingDims)) ||
       failed(reader.readSignedVarInts(scatterDimsToOperandDims)) ||
       failed(reader.readSignedVarInt(indexVectorDim)))
     return ScatterDimensionNumbersAttr();
 
   return ScatterDimensionNumbersAttr::get(
-      getContext(), updateWindowDims, insertedWindowDims, inputBatchingDims,
-      scatterIndicesBatchingDims, scatterDimsToOperandDims, indexVectorDim);
+      getContext(), updateWindowDims, insertedWindowDims,
+      /*inputBatchingDims=*/{}, /*scatterIndicesBatchingDims=*/{},
+      scatterDimsToOperandDims, indexVectorDim);
 }
 
 void StablehloBytecodeInterface::write(ScatterDimensionNumbersAttr attr,

--- a/stablehlo/tests/ops_stablehlo_roundtrip.mlir
+++ b/stablehlo/tests/ops_stablehlo_roundtrip.mlir
@@ -361,22 +361,6 @@ func.func @test_fft(%arg0: tensor<3x9xf32>) -> tensor<3x5xcomplex<f32>> {
   func.return %0 : tensor<3x5xcomplex<f32>>
 }
 
-func.func @test_gather(%arg0: tensor<5x200x100x300xf32>, %arg1: tensor<5x10x2xi32>) -> tensor<5x10x300xf32> {
-  %0 = "stablehlo.gather"(%arg0, %arg1) {
-    dimension_numbers = #stablehlo.gather<
-      offset_dims = [2],
-      collapsed_slice_dims = [1, 2],
-      operand_batching_dims = [0],
-      start_indices_batching_dims = [0],
-      start_index_map = [1,2],
-      index_vector_dim = 2,
-    >,
-    indices_are_sorted = true,
-    slice_sizes = array<i64: 1, 1, 1, 300>
-  } : (tensor<5x200x100x300xf32>, tensor<5x10x2xi32>) -> tensor<5x10x300xf32>
-  func.return %0 : tensor<5x10x300xf32>
-}
-
 func.func @test_set_get_dimension_size(%arg: tensor<4x2xf32>, %size: tensor<i32>) -> tensor<i32> {
   %0 = "stablehlo.set_dimension_size"(%arg, %size) {dimension = 1 : i64} : (tensor<4x2xf32>, tensor<i32>) -> tensor<4x2xf32>
   %1 = "stablehlo.get_dimension_size"(%0) {dimension = 1 : i64} : (tensor<4x2xf32>) -> tensor<i32>
@@ -600,36 +584,6 @@ func.func @test_rng_bit_generator(%arg: tensor<3xui64>) -> tuple<tensor<3xui64>,
   %1 = "stablehlo.tuple"(%0#0, %0#1) : (tensor<3xui64>, tensor<2x2xui32>) -> tuple<tensor<3xui64>, tensor<2x2xui32>>
   func.return %1 : tuple<tensor<3xui64>, tensor<2x2xui32>>
 }
-
-func.func @test_scatter(%input_tensor: tensor<5x200x100x300xf32>, %scatter_indices: tensor<5x10x2xi32>, %updates: tensor<5x10x300xf32>) -> tensor<5x200x100x300xf32> {
-  %0 = "stablehlo.scatter" (%input_tensor, %scatter_indices, %updates) ({
-  ^bb0(%lhs: tensor<f32>, %rhs: tensor<f32>):
-    %add = stablehlo.add %lhs, %rhs : tensor<f32>
-    "stablehlo.return"(%add) : (tensor<f32>) -> ()
-  }) {
-    scatter_dimension_numbers = #stablehlo.scatter<
-      update_window_dims = [2],
-      inserted_window_dims = [1, 2],
-      input_batching_dims = [0],
-      scatter_indices_batching_dims = [0],
-      scatter_dims_to_operand_dims = [1, 2],
-      index_vector_dim = 2
-    >,
-    indices_are_sorted = true,
-    unique_indices = true
-  } : (tensor<5x200x100x300xf32>, tensor<5x10x2xi32>, tensor<5x10x300xf32>) -> tensor<5x200x100x300xf32>
-  func.return %0 : tensor<5x200x100x300xf32>
-}
-
-func.func @test_scatter2(%arg0: tensor<200x100x300xf32>, %arg1: tensor<10x2xi64>, %arg2: tensor<10x300xf32>) -> (tensor<200x100x300xf32>, tensor<200x100x300xf32>) {
-    %0:2 = "stablehlo.scatter"(%arg0, %arg0, %arg1, %arg2, %arg2) ({
-    ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>, %arg5: tensor<f32>, %arg6: tensor<f32>):
-      %2 = stablehlo.add %arg3, %arg4 : tensor<f32>
-      %3 = stablehlo.add %arg5, %arg6 : tensor<f32>
-      "stablehlo.return"(%2, %3) : (tensor<f32>, tensor<f32>) -> ()
-    }) {indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0, 1], scatter_dims_to_operand_dims = [0, 1], index_vector_dim = 1>, unique_indices = false} : (tensor<200x100x300xf32>, tensor<200x100x300xf32>, tensor<10x2xi64>, tensor<10x300xf32>, tensor<10x300xf32>) -> (tensor<200x100x300xf32>, tensor<200x100x300xf32>)
-    return %0#0, %0#1 : tensor<200x100x300xf32>, tensor<200x100x300xf32>
-  }
 
 func.func @test_select(%arg0: tensor<i1>, %arg1: tensor<2x3xi32>, %arg2: tensor<2x3xi32>) -> tensor<2x3xi32> {
   %0 = "stablehlo.select"(%arg0, %arg1, %arg2) : (tensor<i1>, tensor<2x3xi32>, tensor<2x3xi32>) -> tensor<2x3xi32>


### PR DESCRIPTION
The bytecode changes are causing issues due to some StableHLO consumers using StableHLO directly rather than VHLO.

Temporarily remove the relevant roundtrip tests as well since this breaks round-tripping.