### PR TITLE
Add Python 3.12 to supported version matrix

### DIFF
--- a/.github/workflows/publishWheelRelease.yml
+++ b/.github/workflows/publishWheelRelease.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.10", "3.11" ]
+        python-version: [ "3.10", "3.11", "3.12" ]
     runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-22.04'  }}
 
     steps:
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.10", "3.11" ]
+        python-version: [ "3.10", "3.11", "3.12" ]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Some folks are asking for 3.12 support: https://discord.com/channels/999073994483433573/999074539138990131/1246155487758520423