### PR TITLE
Take rank into account when checking if a DotGeneralOp is simple

### DIFF
--- a/stablehlo/conversions/linalg/transforms/StablehloToLinalgDotProduct.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloToLinalgDotProduct.cpp
@@ -186,6 +186,11 @@ struct DotGeneralOpConversion final
       if (succeeded(lowerDotOp<DotGeneralOp, linalg::DotOp>(
               rewriter, getTypeConverter(), op, adaptor)))
         return success();
+      std::string str;
+      llvm::raw_string_ostream os(str);
+      os << "supposedly simple DotGeneralOp could not be converted: ";
+      op.print(os);
+      llvm::report_fatal_error(str.c_str());
     }
 
     // Get various dimension iterator information

--- a/stablehlo/conversions/linalg/transforms/StablehloToLinalgDotProduct.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloToLinalgDotProduct.cpp
@@ -186,11 +186,6 @@ struct DotGeneralOpConversion final
       if (succeeded(lowerDotOp<DotGeneralOp, linalg::DotOp>(
               rewriter, getTypeConverter(), op, adaptor)))
         return success();
-      std::string str;
-      llvm::raw_string_ostream os(str);
-      os << "supposedly simple DotGeneralOp could not be converted: ";
-      op.print(os);
-      llvm::report_fatal_error(str.c_str());
     }
 
     // Get various dimension iterator information

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -646,8 +646,11 @@ DotDimensionNumbersAttr getDefaultDotDimensionNumbers(mlir::Value lhs) {
 }
 
 bool DotGeneralOp::isSimpleDot() {
-  return getDotDimensionNumbersAttr() ==
-         getDefaultDotDimensionNumbers(getLhs());
+  auto lhsRank = cast<ShapedType>(getLhs().getType()).getRank();
+  auto rhsRank = cast<ShapedType>(getRhs().getType()).getRank();
+  return lhsRank <= 2 && rhsRank <= 2 &&
+         getDotDimensionNumbersAttr() ==
+             getDefaultDotDimensionNumbers(getLhs());
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
When the rank of either `lhs` or `rhs` is greater than 2, `isSimpleDot` may produce an incorrect result because of how `getDefaultDotDimensionNumbers` is implemented.