### PR TITLE
Align canonicalization of stablehlo.broadcast_in_dim with XLA

### DIFF
--- a/stablehlo/tests/chlo/chlo_legalize_to_stablehlo_broadcast.mlir
+++ b/stablehlo/tests/chlo/chlo_legalize_to_stablehlo_broadcast.mlir
@@ -95,9 +95,8 @@ func.func @selectv2_pred_scalar(%arg0: tensor<i1>, %arg1: tensor<2xi32>, %arg2: 
 
 // CHECK-LABEL: func @selectv2_broadcast_then
 func.func @selectv2_broadcast_then(%arg0: tensor<i1>, %arg1: tensor<8x1xi32>, %arg2: tensor<2x8x8xi32>) -> tensor<2x8x8xi32> {
-  // CHECK: [[R0:%.*]] = stablehlo.reshape %arg1 : (tensor<8x1xi32>) -> tensor<1x8x1xi32>
-  // CHECK-NEXT: [[BROADCAST:%.*]] = stablehlo.broadcast_in_dim [[R0]], dims = [0, 1, 2] : (tensor<1x8x1xi32>) -> tensor<2x8x8xi32>
-  // CHECK-NEXT: stablehlo.select %arg0, [[BROADCAST]], %arg2
+  // CHECK-NEXT: %[[BROADCAST:.*]] = stablehlo.broadcast_in_dim %arg1, dims = [1, 2] : (tensor<8x1xi32>) -> tensor<2x8x8xi32>
+  // CHECK-NEXT: stablehlo.select %arg0, %[[BROADCAST]], %arg2
   %0 = "chlo.broadcast_select"(%arg0, %arg1, %arg2) : (tensor<i1>, tensor<8x1xi32>, tensor<2x8x8xi32>) -> tensor<2x8x8xi32>
   func.return %0: tensor<2x8x8xi32>
 }
@@ -106,9 +105,8 @@ func.func @selectv2_broadcast_then(%arg0: tensor<i1>, %arg1: tensor<8x1xi32>, %a
 
 // CHECK-LABEL: func @selectv2_broadcast_else
 func.func @selectv2_broadcast_else(%arg0: tensor<i1>, %arg1: tensor<2x8x8xi32>, %arg2: tensor<8x1xi32>) -> tensor<2x8x8xi32> {
-  // CHECK: [[R0:%.*]] = stablehlo.reshape %arg2 : (tensor<8x1xi32>) -> tensor<1x8x1xi32>
-  // CHECK-NEXT: [[BROADCAST:%.*]] = stablehlo.broadcast_in_dim [[R0]], dims = [0, 1, 2] : (tensor<1x8x1xi32>) -> tensor<2x8x8xi32>
-  // CHECK-NEXT: stablehlo.select %arg0, %arg1, [[BROADCAST]]
+  // CHECK-NEXT: %[[BROADCAST:.*]] = stablehlo.broadcast_in_dim %arg2, dims = [1, 2] : (tensor<8x1xi32>) -> tensor<2x8x8xi32>
+  // CHECK-NEXT: stablehlo.select %arg0, %arg1, %[[BROADCAST]]
   %0 = "chlo.broadcast_select"(%arg0, %arg1, %arg2) : (tensor<i1>, tensor<2x8x8xi32>, tensor<8x1xi32>) -> tensor<2x8x8xi32>
   func.return %0: tensor<2x8x8xi32>
 }
@@ -117,9 +115,8 @@ func.func @selectv2_broadcast_else(%arg0: tensor<i1>, %arg1: tensor<2x8x8xi32>, 
 
 // CHECK-LABEL: func @selectv2_broadcast_pred
 func.func @selectv2_broadcast_pred(%arg0: tensor<1xi1>, %arg1: tensor<2x8x8xi32>, %arg2: tensor<2x8x8xi32>) -> tensor<2x8x8xi32> {
-  // CHECK: [[R0:%.*]] = stablehlo.reshape %arg0 : (tensor<1xi1>) -> tensor<1x1x1xi1>
-  // CHECK-NEXT: [[BROADCAST:%.*]] = stablehlo.broadcast_in_dim [[R0]], dims = [0, 1, 2] : (tensor<1x1x1xi1>) -> tensor<2x8x8xi1>
-  // CHECK-NEXT: stablehlo.select [[BROADCAST]], %arg1, %arg2
+  // CHECK-NEXT: %[[BROADCAST:.*]] = stablehlo.broadcast_in_dim %arg0, dims = [2] : (tensor<1xi1>) -> tensor<2x8x8xi1>
+  // CHECK-NEXT: stablehlo.select %[[BROADCAST]], %arg1, %arg2
   %0 = "chlo.broadcast_select"(%arg0, %arg1, %arg2) : (tensor<1xi1>, tensor<2x8x8xi32>, tensor<2x8x8xi32>) -> tensor<2x8x8xi32>
   func.return %0: tensor<2x8x8xi32>
 }
@@ -128,9 +125,8 @@ func.func @selectv2_broadcast_pred(%arg0: tensor<1xi1>, %arg1: tensor<2x8x8xi32>
 
 // CHECK-LABEL: func @selectv2_broadcast_tensor_pred
 func.func @selectv2_broadcast_tensor_pred(%arg0: tensor<3xi1>, %arg1: tensor<2x3xf16>, %arg2: tensor<2x3xf16>) -> tensor<2x3xf16> {
-  // CHECK: [[R0:%.*]] = stablehlo.reshape %arg0 : (tensor<3xi1>) -> tensor<1x3xi1>
-  // CHECK-NEXT: [[BROADCAST:%.*]] = stablehlo.broadcast_in_dim [[R0]], dims = [0, 1] : (tensor<1x3xi1>) -> tensor<2x3xi1>
-  // CHECK-NEXT: stablehlo.select [[BROADCAST]], %arg1, %arg2
+  // CHECK-NEXT: %[[BROADCAST:.*]] = stablehlo.broadcast_in_dim %arg0, dims = [1] : (tensor<3xi1>) -> tensor<2x3xi1>
+  // CHECK-NEXT: stablehlo.select %[[BROADCAST]], %arg1, %arg2
   %0 = "chlo.broadcast_select"(%arg0, %arg1, %arg2) : (tensor<3xi1>, tensor<2x3xf16>, tensor<2x3xf16>) -> tensor<2x3xf16>
   func.return %0: tensor<2x3xf16>
 }

--- a/stablehlo/tests/chlo/chlo_legalize_to_stablehlo_broadcast.mlir
+++ b/stablehlo/tests/chlo/chlo_legalize_to_stablehlo_broadcast.mlir
@@ -95,8 +95,9 @@ func.func @selectv2_pred_scalar(%arg0: tensor<i1>, %arg1: tensor<2xi32>, %arg2: 
 
 // CHECK-LABEL: func @selectv2_broadcast_then
 func.func @selectv2_broadcast_then(%arg0: tensor<i1>, %arg1: tensor<8x1xi32>, %arg2: tensor<2x8x8xi32>) -> tensor<2x8x8xi32> {
-  // CHECK-NEXT: %[[BROADCAST:.*]] = stablehlo.broadcast_in_dim %arg1, dims = [1, 2] : (tensor<8x1xi32>) -> tensor<2x8x8xi32>
-  // CHECK-NEXT: stablehlo.select %arg0, %[[BROADCAST]], %arg2
+  // CHECK: [[R0:%.*]] = stablehlo.reshape %arg1 : (tensor<8x1xi32>) -> tensor<1x8x1xi32>
+  // CHECK-NEXT: [[BROADCAST:%.*]] = stablehlo.broadcast_in_dim [[R0]], dims = [0, 1, 2] : (tensor<1x8x1xi32>) -> tensor<2x8x8xi32>
+  // CHECK-NEXT: stablehlo.select %arg0, [[BROADCAST]], %arg2
   %0 = "chlo.broadcast_select"(%arg0, %arg1, %arg2) : (tensor<i1>, tensor<8x1xi32>, tensor<2x8x8xi32>) -> tensor<2x8x8xi32>
   func.return %0: tensor<2x8x8xi32>
 }
@@ -105,8 +106,9 @@ func.func @selectv2_broadcast_then(%arg0: tensor<i1>, %arg1: tensor<8x1xi32>, %a
 
 // CHECK-LABEL: func @selectv2_broadcast_else
 func.func @selectv2_broadcast_else(%arg0: tensor<i1>, %arg1: tensor<2x8x8xi32>, %arg2: tensor<8x1xi32>) -> tensor<2x8x8xi32> {
-  // CHECK-NEXT: %[[BROADCAST:.*]] = stablehlo.broadcast_in_dim %arg2, dims = [1, 2] : (tensor<8x1xi32>) -> tensor<2x8x8xi32>
-  // CHECK-NEXT: stablehlo.select %arg0, %arg1, %[[BROADCAST]]
+  // CHECK: [[R0:%.*]] = stablehlo.reshape %arg2 : (tensor<8x1xi32>) -> tensor<1x8x1xi32>
+  // CHECK-NEXT: [[BROADCAST:%.*]] = stablehlo.broadcast_in_dim [[R0]], dims = [0, 1, 2] : (tensor<1x8x1xi32>) -> tensor<2x8x8xi32>
+  // CHECK-NEXT: stablehlo.select %arg0, %arg1, [[BROADCAST]]
   %0 = "chlo.broadcast_select"(%arg0, %arg1, %arg2) : (tensor<i1>, tensor<2x8x8xi32>, tensor<8x1xi32>) -> tensor<2x8x8xi32>
   func.return %0: tensor<2x8x8xi32>
 }
@@ -115,8 +117,9 @@ func.func @selectv2_broadcast_else(%arg0: tensor<i1>, %arg1: tensor<2x8x8xi32>, 
 
 // CHECK-LABEL: func @selectv2_broadcast_pred
 func.func @selectv2_broadcast_pred(%arg0: tensor<1xi1>, %arg1: tensor<2x8x8xi32>, %arg2: tensor<2x8x8xi32>) -> tensor<2x8x8xi32> {
-  // CHECK-NEXT: %[[BROADCAST:.*]] = stablehlo.broadcast_in_dim %arg0, dims = [2] : (tensor<1xi1>) -> tensor<2x8x8xi1>
-  // CHECK-NEXT: stablehlo.select %[[BROADCAST]], %arg1, %arg2
+  // CHECK: [[R0:%.*]] = stablehlo.reshape %arg0 : (tensor<1xi1>) -> tensor<1x1x1xi1>
+  // CHECK-NEXT: [[BROADCAST:%.*]] = stablehlo.broadcast_in_dim [[R0]], dims = [0, 1, 2] : (tensor<1x1x1xi1>) -> tensor<2x8x8xi1>
+  // CHECK-NEXT: stablehlo.select [[BROADCAST]], %arg1, %arg2
   %0 = "chlo.broadcast_select"(%arg0, %arg1, %arg2) : (tensor<1xi1>, tensor<2x8x8xi32>, tensor<2x8x8xi32>) -> tensor<2x8x8xi32>
   func.return %0: tensor<2x8x8xi32>
 }
@@ -125,8 +128,9 @@ func.func @selectv2_broadcast_pred(%arg0: tensor<1xi1>, %arg1: tensor<2x8x8xi32>
 
 // CHECK-LABEL: func @selectv2_broadcast_tensor_pred
 func.func @selectv2_broadcast_tensor_pred(%arg0: tensor<3xi1>, %arg1: tensor<2x3xf16>, %arg2: tensor<2x3xf16>) -> tensor<2x3xf16> {
-  // CHECK-NEXT: %[[BROADCAST:.*]] = stablehlo.broadcast_in_dim %arg0, dims = [1] : (tensor<3xi1>) -> tensor<2x3xi1>
-  // CHECK-NEXT: stablehlo.select %[[BROADCAST]], %arg1, %arg2
+  // CHECK: [[R0:%.*]] = stablehlo.reshape %arg0 : (tensor<3xi1>) -> tensor<1x3xi1>
+  // CHECK-NEXT: [[BROADCAST:%.*]] = stablehlo.broadcast_in_dim [[R0]], dims = [0, 1] : (tensor<1x3xi1>) -> tensor<2x3xi1>
+  // CHECK-NEXT: stablehlo.select [[BROADCAST]], %arg1, %arg2
   %0 = "chlo.broadcast_select"(%arg0, %arg1, %arg2) : (tensor<3xi1>, tensor<2x3xf16>, tensor<2x3xf16>) -> tensor<2x3xf16>
   func.return %0: tensor<2x3xf16>
 }

--- a/stablehlo/tests/stablehlo_aggressive_simplification.mlir
+++ b/stablehlo/tests/stablehlo_aggressive_simplification.mlir
@@ -353,7 +353,7 @@ func.func @broadcast_in_dim_transpose(%arg0: tensor<3x3xi32>)
   %3 = stablehlo.broadcast_in_dim %arg0, dims = [0, 1] : (tensor<3x3xi32>) -> tensor<3x3xi32>
   %4 = stablehlo.broadcast_in_dim %arg0, dims = [1, 0] : (tensor<3x3xi32>) -> tensor<3x3xi32>
 
-  // CHECK-DAG:  [[R4:%.+]] = stablehlo.transpose [[ARG0]], dims = [1, 0] : (tensor<3x3xi32>) -> tensor<3x3xi32>
+  // CHECK: [[R4:%.+]] = stablehlo.transpose [[ARG0]], dims = [1, 0] : (tensor<3x3xi32>) -> tensor<3x3xi32>
 
   // CHECK-NEXT: return [[ARG0]], [[R4]]
   return %3, %4 : tensor<3x3xi32>, tensor<3x3xi32>

--- a/stablehlo/tests/stablehlo_aggressive_simplification.mlir
+++ b/stablehlo/tests/stablehlo_aggressive_simplification.mlir
@@ -324,10 +324,10 @@ func.func @select_into_minmax2(%arg0: tensor<i32>, %arg1: tensor<i32>, %arg2: te
 
 // -----
 
-// CHECK-LABEL: func.func @broadcast_in_dim
+// CHECK-LABEL: func.func @broadcast_in_dim_splat
 // CHECK-SAME:   ([[ARG0:%.+]]: tensor<3x3xi32>)
-func.func @broadcast_in_dim(%arg0: tensor<3x3xi32>)
-  -> (tensor<6xi32>, tensor<3xf32>, tensor<3x3xi32>, tensor<3x3xi32>, tensor<3x3xi32>, tensor<3x3x1xi32>, tensor<3x2x3x3xi32>) {
+func.func @broadcast_in_dim_splat(%arg0: tensor<3x3xi32>)
+  -> (tensor<6xi32>, tensor<3xf32>, tensor<3x3xi32>) {
   %c0 = stablehlo.constant dense<5> : tensor<i32>
   %c1 = stablehlo.constant dense<3.0> : tensor<f32>
   %c2 = stablehlo.constant dense<1> : tensor<1x3xi32>
@@ -336,23 +336,57 @@ func.func @broadcast_in_dim(%arg0: tensor<3x3xi32>)
   %1 = stablehlo.broadcast_in_dim %c1, dims = [] : (tensor<f32>) -> tensor<3xf32>
   %2 = stablehlo.broadcast_in_dim %c2, dims = [1, 0] : (tensor<1x3xi32>) -> tensor<3x3xi32>
 
-  %3 = stablehlo.broadcast_in_dim %arg0, dims = [0, 1] : (tensor<3x3xi32>) -> tensor<3x3xi32>
-  %4 = stablehlo.broadcast_in_dim %arg0, dims = [1, 0] : (tensor<3x3xi32>) -> tensor<3x3xi32>
-  %5 = stablehlo.broadcast_in_dim %arg0, dims = [0, 1] : (tensor<3x3xi32>) -> tensor<3x3x1xi32>
-
-  %6 = stablehlo.broadcast_in_dim %arg0, dims = [1, 0] : (tensor<3x3xi32>) -> tensor<3x3x2xi32>
-  %7 = stablehlo.broadcast_in_dim %6, dims = [0, 2, 1] : (tensor<3x3x2xi32>) -> tensor<3x2x3x3xi32>
-
   // CHECK-DAG:  [[R0:%.+]] = stablehlo.constant dense<5> : tensor<6xi32>
   // CHECK-DAG:  [[R1:%.+]] = stablehlo.constant dense<3.000000e+00> : tensor<3xf32>
   // CHECK-DAG:  [[R2:%.+]] = stablehlo.constant dense<1> : tensor<3x3xi32>
 
+  // CHECK-NEXT: return [[R0]], [[R1]], [[R2]]
+  return %0, %1, %2 : tensor<6xi32>, tensor<3xf32>, tensor<3x3xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @broadcast_in_dim_transpose
+// CHECK-SAME:   ([[ARG0:%.+]]: tensor<3x3xi32>)
+func.func @broadcast_in_dim_transpose(%arg0: tensor<3x3xi32>)
+  -> (tensor<3x3xi32>, tensor<3x3xi32>) {
+  %3 = stablehlo.broadcast_in_dim %arg0, dims = [0, 1] : (tensor<3x3xi32>) -> tensor<3x3xi32>
+  %4 = stablehlo.broadcast_in_dim %arg0, dims = [1, 0] : (tensor<3x3xi32>) -> tensor<3x3xi32>
+
   // CHECK-DAG:  [[R4:%.+]] = stablehlo.transpose [[ARG0]], dims = [1, 0] : (tensor<3x3xi32>) -> tensor<3x3xi32>
-  // CHECK-DAG:  [[R5:%.+]] = stablehlo.reshape [[ARG0]] : (tensor<3x3xi32>) -> tensor<3x3x1xi32>
+
+  // CHECK-NEXT: return [[ARG0]], [[R4]]
+  return %3, %4 : tensor<3x3xi32>, tensor<3x3xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @broadcast_in_dim_nested
+// CHECK-SAME:   ([[ARG0:%.+]]: tensor<3x3xi32>)
+func.func @broadcast_in_dim_nested(%arg0: tensor<3x3xi32>)
+  -> (tensor<3x2x3x3xi32>) {
+  %6 = stablehlo.broadcast_in_dim %arg0, dims = [1, 0] : (tensor<3x3xi32>) -> tensor<3x3x2xi32>
+  %7 = stablehlo.broadcast_in_dim %6, dims = [0, 2, 1] : (tensor<3x3x2xi32>) -> tensor<3x2x3x3xi32>
   // CHECK-DAG:  [[R6:%.+]] = stablehlo.broadcast_in_dim [[ARG0]], dims = [2, 0] : (tensor<3x3xi32>) -> tensor<3x2x3x3xi32>
 
-  // CHECK-NEXT: return [[R0]], [[R1]], [[R2]], [[ARG0]], [[R4]], [[R5]], [[R6]]
-  return %0, %1, %2, %3, %4, %5, %7 : tensor<6xi32>, tensor<3xf32>, tensor<3x3xi32>, tensor<3x3xi32>, tensor<3x3xi32>, tensor<3x3x1xi32>, tensor<3x2x3x3xi32>
+  // CHECK-NEXT: return [[R6]]
+  return %7 : tensor<3x2x3x3xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @broadcast_in_dim_reshape
+// CHECK-SAME:   ([[ARG0:%.+]]: tensor<3x6xi32>)
+func.func @broadcast_in_dim_reshape(%arg0: tensor<3x6xi32>)
+  -> (tensor<1x3x6xi32>, tensor<3x6x1xi32>) {
+  %0 = stablehlo.broadcast_in_dim %arg0, dims = [1, 2] : (tensor<3x6xi32>) -> tensor<1x3x6xi32>
+  %5 = stablehlo.broadcast_in_dim %arg0, dims = [0, 1] : (tensor<3x6xi32>) -> tensor<3x6x1xi32>
+
+  // CHECK-DAG:  [[R0:%.+]] = stablehlo.reshape [[ARG0]] : (tensor<3x6xi32>) -> tensor<1x3x6xi32>
+  // CHECK-DAG:  [[R5:%.+]] = stablehlo.reshape [[ARG0]] : (tensor<3x6xi32>) -> tensor<3x6x1xi32>
+
+  // CHECK-NEXT: return [[R0]], [[R5]]
+  return %0, %5 : tensor<1x3x6xi32>, tensor<3x6x1xi32>
 }
 
 // -----

--- a/stablehlo/tests/stablehlo_aggressive_simplification.mlir
+++ b/stablehlo/tests/stablehlo_aggressive_simplification.mlir
@@ -367,10 +367,9 @@ func.func @broadcast_in_dim_nested(%arg0: tensor<3x3xi32>)
   -> (tensor<3x2x3x3xi32>) {
   %6 = stablehlo.broadcast_in_dim %arg0, dims = [1, 0] : (tensor<3x3xi32>) -> tensor<3x3x2xi32>
   %7 = stablehlo.broadcast_in_dim %6, dims = [0, 2, 1] : (tensor<3x3x2xi32>) -> tensor<3x2x3x3xi32>
-  // CHECK:  [[R0:%.+]] = stablehlo.reshape [[ARG0]] : (tensor<3x3xi32>) -> tensor<3x1x3x1xi32>
-  // CHECK:  [[R1:%.+]] = stablehlo.broadcast_in_dim [[R0]], dims = [2, 1, 0, 3] : (tensor<3x1x3x1xi32>) -> tensor<3x2x3x3xi32>
+  // CHECK-DAG:  [[R6:%.+]] = stablehlo.broadcast_in_dim [[ARG0]], dims = [2, 0] : (tensor<3x3xi32>) -> tensor<3x2x3x3xi32>
 
-  // CHECK-NEXT: return [[R1]]
+  // CHECK-NEXT: return [[R6]]
   return %7 : tensor<3x2x3x3xi32>
 }
 
@@ -388,37 +387,6 @@ func.func @broadcast_in_dim_reshape(%arg0: tensor<3x6xi32>)
 
   // CHECK-NEXT: return [[R0]], [[R5]]
   return %0, %5 : tensor<1x3x6xi32>, tensor<3x6x1xi32>
-}
-
-// -----
-
-// CHECK-LABEL: func.func @broadcast_in_dim_expand_dims
-// CHECK-SAME:   ([[ARG1:%.+]]: tensor<128xf32>, [[ARG2:%.+]]: tensor<32x64xf32>, [[ARG3:%.+]]: tensor<32x64x16xf32>)
-func.func @broadcast_in_dim_expand_dims(
-  %arg1 : tensor<128xf32>,
-  %arg2 : tensor<32x64xf32>,
-  %arg3 : tensor<32x64x16xf32>
-) -> (tensor<1x128x128xf32>, tensor<4x64x32x2xf32>, tensor<4x64x32x2x16xf32>, tensor<4x16x32x2x8x64xf32>) {
-
-  %1 = stablehlo.broadcast_in_dim %arg1, dims = [2] : (tensor<128xf32>) -> tensor<1x128x128xf32>
-  %2 = stablehlo.broadcast_in_dim %arg2, dims = [2, 1] : (tensor<32x64xf32>) -> tensor<4x64x32x2xf32>
-  %3 = stablehlo.broadcast_in_dim %arg3, dims = [2, 1, 4] : (tensor<32x64x16xf32>) -> tensor<4x64x32x2x16xf32>
-  %4 = stablehlo.broadcast_in_dim %arg3, dims = [2, 5, 1] : (tensor<32x64x16xf32>) -> tensor<4x16x32x2x8x64xf32>
-
-  // CHECK: [[R10:%.*]] = stablehlo.reshape [[ARG1]] : (tensor<128xf32>) -> tensor<1x1x128xf32>
-  // CHECK: [[R1:%.*]] = stablehlo.broadcast_in_dim [[R10]], dims = [0, 1, 2] : (tensor<1x1x128xf32>) -> tensor<1x128x128xf32>
-
-  // CHECK: [[R20:%.*]] = stablehlo.reshape [[ARG2]] : (tensor<32x64xf32>) -> tensor<1x32x64x1xf32>
-  // CHECK: [[R2:%.*]] = stablehlo.broadcast_in_dim [[R20]], dims = [0, 2, 1, 3] : (tensor<1x32x64x1xf32>) -> tensor<4x64x32x2xf32>
-
-  // CHECK: [[R30:%.*]] = stablehlo.reshape [[ARG3]] : (tensor<32x64x16xf32>) -> tensor<1x32x64x1x16xf32>
-  // CHECK: [[R3:%.*]] = stablehlo.broadcast_in_dim [[R30]], dims = [0, 2, 1, 3, 4] : (tensor<1x32x64x1x16xf32>) -> tensor<4x64x32x2x16xf32>
-
-  // CHECK: [[R40:%.*]] = stablehlo.reshape [[ARG3]] : (tensor<32x64x16xf32>) -> tensor<1x32x64x1x1x16xf32>
-  // CHECK: [[R4:%.*]] = stablehlo.broadcast_in_dim [[R40]], dims = [0, 2, 5, 3, 4, 1] : (tensor<1x32x64x1x1x16xf32>) -> tensor<4x16x32x2x8x64xf32>
-
-  // CHECK: return [[R1]], [[R2]], [[R3]], [[R4]]
-  return %1, %2, %3, %4 : tensor<1x128x128xf32>, tensor<4x64x32x2xf32>, tensor<4x64x32x2x16xf32>, tensor<4x16x32x2x8x64xf32>
 }
 
 // -----
@@ -462,10 +430,9 @@ func.func @convert(%arg0: tensor<2xf32>) -> tensor<2xf32> {
 
 // CHECK-LABEL: func @dynamic_broadcast_in_dim_op_not_actually_dynamic
 func.func @dynamic_broadcast_in_dim_op_not_actually_dynamic(%arg0: tensor<4xf32>, %arg1: tensor<2xi64>) -> tensor<5x4xf32> {
-  // CHECK: [[R0:%.+]] = stablehlo.reshape %arg0 : (tensor<4xf32>) -> tensor<1x4xf32>
-  // CHECK: [[R1:%.+]] = stablehlo.broadcast_in_dim [[R0]], dims = [0, 1] : (tensor<1x4xf32>) -> tensor<5x4xf32>
+  // CHECK: %[[RESULT:.+]] = stablehlo.broadcast_in_dim %arg0, dims = [1] : (tensor<4xf32>) -> tensor<5x4xf32>
   %0 = stablehlo.dynamic_broadcast_in_dim %arg0, %arg1, dims = [1] : (tensor<4xf32>, tensor<2xi64>) -> tensor<5x4xf32>
-  // CHECK: return [[R1]] : tensor<5x4xf32>
+  // CHECK: return %[[RESULT]] : tensor<5x4xf32>
   func.return %0 : tensor<5x4xf32>
 }
 
@@ -474,11 +441,10 @@ func.func @dynamic_broadcast_in_dim_op_not_actually_dynamic(%arg0: tensor<4xf32>
 // CHECK-LABEL: func @dynamic_broadcast_in_dim_op_not_actually_dynamic_constant_shape
 func.func @dynamic_broadcast_in_dim_op_not_actually_dynamic_constant_shape(%arg0: tensor<i32>) -> tensor<4x32xi32> {
   %0 = stablehlo.constant dense<[4, 32]> : tensor<2xi32>
-  // CHECK: [[R0:%.+]] = stablehlo.reshape %arg0 : (tensor<i32>) -> tensor<1x1xi32>
-  // CHECK: [[R1:%.+]] = stablehlo.broadcast_in_dim [[R0]], dims = [0, 1] : (tensor<1x1xi32>) -> tensor<4x32xi32>
+  // CHECK: %[[RESULT:.+]] = stablehlo.broadcast_in_dim %arg0, dims = [] : (tensor<i32>) -> tensor<4x32xi32>
   %1 = stablehlo.dynamic_broadcast_in_dim %arg0, %0, dims = [] : (tensor<i32>, tensor<2xi32>) -> tensor<?x32xi32>
   %2 = stablehlo.dynamic_reshape %1, %0 : (tensor<?x32xi32>, tensor<2xi32>) -> tensor<4x32xi32>
-  // CHECK: return [[R1]] : tensor<4x32xi32>
+  // CHECK: return %[[RESULT]] : tensor<4x32xi32>
   func.return %2 : tensor<4x32xi32>
 }
 
@@ -487,11 +453,10 @@ func.func @dynamic_broadcast_in_dim_op_not_actually_dynamic_constant_shape(%arg0
 // CHECK-LABEL: func @dynamic_broadcast_in_dim_op_not_actually_dynamic_constant_index_shape
 func.func @dynamic_broadcast_in_dim_op_not_actually_dynamic_constant_index_shape(%arg0: tensor<f32>) -> tensor<4x32xf32> {
   %0 = shape.const_shape [4, 32] : tensor<2xindex>
-  // CHECK: [[R0:%.+]] = stablehlo.reshape %arg0 : (tensor<f32>) -> tensor<1x1xf32>
-  // CHECK: [[R1:%.+]] = stablehlo.broadcast_in_dim [[R0]], dims = [0, 1] : (tensor<1x1xf32>) -> tensor<4x32xf32>
+  // CHECK: %[[RESULT:.+]] = stablehlo.broadcast_in_dim %arg0, dims = [] : (tensor<f32>) -> tensor<4x32xf32>
   %1 = stablehlo.dynamic_broadcast_in_dim %arg0, %0, dims = [] : (tensor<f32>, tensor<2xindex>) -> tensor<?x32xf32>
   %2 = stablehlo.dynamic_reshape %1, %0 : (tensor<?x32xf32>, tensor<2xindex>) -> tensor<4x32xf32>
-  // CHECK: return [[R1]] : tensor<4x32xf32>
+  // CHECK: return %[[RESULT]] : tensor<4x32xf32>
   func.return %2 : tensor<4x32xf32>
 }
 
@@ -500,11 +465,10 @@ func.func @dynamic_broadcast_in_dim_op_not_actually_dynamic_constant_index_shape
 // CHECK-LABEL: func @dynamic_broadcast_in_dim_op_not_actually_dynamic_constant_requires_cast
 func.func @dynamic_broadcast_in_dim_op_not_actually_dynamic_constant_requires_cast(%arg0: tensor<f32>) -> tensor<?x?xf32> {
   %0 = shape.const_shape [4, 32] : tensor<2xindex>
-  // CHECK: [[R0:%.+]] = stablehlo.reshape %arg0 : (tensor<f32>) -> tensor<1x1xf32>
-  // CHECK: [[BCAST:%.+]] = stablehlo.broadcast_in_dim [[R0]], dims = [0, 1] : (tensor<1x1xf32>) -> tensor<4x32xf32>
+  // CHECK: %[[BCAST:.+]] = stablehlo.broadcast_in_dim %arg0, dims = [] : (tensor<f32>) -> tensor<4x32xf32>
   %1 = stablehlo.dynamic_broadcast_in_dim %arg0, %0, dims = [] : (tensor<f32>, tensor<2xindex>) -> tensor<?x?xf32>
-  // CHECK: [[R1:%.*]] = tensor.cast [[BCAST]] : tensor<4x32xf32> to tensor<?x?xf32>
-  // CHECK: return [[R1]] : tensor<?x?xf32>
+  // CHECK: %[[RESULT:.*]] = tensor.cast %[[BCAST]] : tensor<4x32xf32> to tensor<?x?xf32>
+  // CHECK: return %[[RESULT]] : tensor<?x?xf32>
   func.return %1 : tensor<?x?xf32>
 }
 

--- a/stablehlo/tests/stablehlo_aggressive_simplification.mlir
+++ b/stablehlo/tests/stablehlo_aggressive_simplification.mlir
@@ -367,7 +367,7 @@ func.func @broadcast_in_dim_nested(%arg0: tensor<3x3xi32>)
   -> (tensor<3x2x3x3xi32>) {
   %6 = stablehlo.broadcast_in_dim %arg0, dims = [1, 0] : (tensor<3x3xi32>) -> tensor<3x3x2xi32>
   %7 = stablehlo.broadcast_in_dim %6, dims = [0, 2, 1] : (tensor<3x3x2xi32>) -> tensor<3x2x3x3xi32>
-  // CHECK-DAG:  [[R6:%.+]] = stablehlo.broadcast_in_dim [[ARG0]], dims = [2, 0] : (tensor<3x3xi32>) -> tensor<3x2x3x3xi32>
+  // CHECK: [[R6:%.+]] = stablehlo.broadcast_in_dim [[ARG0]], dims = [2, 0] : (tensor<3x3xi32>) -> tensor<3x2x3x3xi32>
 
   // CHECK-NEXT: return [[R6]]
   return %7 : tensor<3x2x3x3xi32>

--- a/stablehlo/transforms/StablehloAggressiveSimplification.cpp
+++ b/stablehlo/transforms/StablehloAggressiveSimplification.cpp
@@ -457,8 +457,7 @@ struct BroadcastInDimOpCanon final
 
     // Fold when broadcast is a noop.
     auto dims = op.getBroadcastDimensions();
-    bool isDimsIota = isIotaRange(dims);
-    if (type == operandTy && isDimsIota) {
+    if (type == operandTy && isIotaRange(dims)) {
       rewriter.replaceOp(op, operand);
       return success();
     }
@@ -475,7 +474,7 @@ struct BroadcastInDimOpCanon final
     if (operandTy.hasStaticShape() && type.hasStaticShape() &&
         type.getNumElements() == operandTy.getNumElements()) {
       // BroadcastInDim equivalent to reshape.
-      if (isDimsIota) {
+      if (llvm::is_sorted(dims)) {
         rewriter.replaceOpWithNewOp<mlir::stablehlo::ReshapeOp>(op, type,
                                                                 operand);
         return success();

--- a/stablehlo/transforms/StablehloAggressiveSimplification.cpp
+++ b/stablehlo/transforms/StablehloAggressiveSimplification.cpp
@@ -498,43 +498,6 @@ struct BroadcastInDimOpCanon final
       return success();
     }
 
-    // Canonicalize broadcast_in_dim by reshaping operand to match rank(result)
-    // and expanding dims array to satisfy `size(broadcast_dimensions) =
-    // rank(operand)` constraint.
-    if (operandTy.hasStaticShape() && type.hasStaticShape() &&
-        operandTy.getRank() < type.getRank()) {
-      SmallVector<int64_t> sortedDims(dims);
-      llvm::sort(sortedDims);
-
-      constexpr int64_t expandedDim = -1;
-      constexpr int64_t unitDim = 1;
-      SmallVector<int64_t> newShape(type.getRank(), expandedDim);
-      SmallVector<int64_t> newDims;
-
-      for (auto en : llvm::enumerate(operandTy.getShape())) {
-        newShape[sortedDims[en.index()]] = en.value();
-      }
-
-      size_t oldDimIdx = 0;
-      for (size_t i = 0; i < newShape.size(); ++i) {
-        if (newShape[i] == expandedDim) {
-          newDims.push_back(i);
-          newShape[i] = unitDim;
-        } else {
-          newDims.push_back(dims[oldDimIdx]);
-          ++oldDimIdx;
-        }
-      }
-
-      rewriter.setInsertionPoint(op);
-      auto reshapeOp = rewriter.create<mlir::stablehlo::ReshapeOp>(
-          op.getLoc(),
-          operandTy.cloneWith(newShape, operandTy.getElementType()), operand);
-      rewriter.replaceOpWithNewOp<mlir::stablehlo::BroadcastInDimOp>(
-          op, type, reshapeOp, newDims);
-      return success();
-    }
-
     return failure();
   }
 };


### PR DESCRIPTION
This patch is a two-stage:
1) change `isIotaRange` constraint to `llvm::sorted` in order to enable the rewrite from `broadcast_in_dim` -> `reshape`:
```
  %0 = stablehlo.broadcast_in_dim %arg0, dims = [1, 2] : (tensor<3x6xi32>) -> tensor<1x3x6xi32>
```
is transformed into:
```
  %0 = stablehlo.reshape %arg0 : (tensor<3x6xi32>) -> tensor<1x3x6xi32>
```
(hlo_ops.cpp: BroadcastInDimSimplifier uses same approach)

2) `broadcast_in_dim` operator can be quite complex in its semantics, sometimes functioning as a combination of `transpose` and `broadcast`. In order to simplify analysis and optimization, it can be beneficial to fully expand operand dimensions by ensuring that the size of broadcast_dimensions matches the rank of the result. This can be achieved by reshaping the input operand while preserving the constraint `size(broadcast_dimensions) = rank(operand)` that the size of broadcast_dimensions matches the rank of the operand.

```
    %3 = stablehlo.broadcast_in_dim %arg3, dims = [2, 1, 4] : (tensor<32x64x16xf32>) -> tensor<4x64x32x2x16xf32>
```
is transformed into:
```
  %2 = stablehlo.reshape %arg3 : (tensor<32x64x16xf32>) -> tensor<1x32x64x1x16xf32>
  %3 = stablehlo.broadcast_in_dim %2, dims = [0, 2, 1, 3, 4] : (tensor<1x32x64x1x16xf32>) -> tensor<4x64x32x2x16xf32>
```

Later it can be simplified even more by extracting transpose logic into standalone operation, something like this:
```
  %2 = stablehlo.reshape %arg3 : (tensor<32x64x16xf32>) -> tensor<1x32x64x1x16xf32>
  %3 = stablehlo.transpose %2, dims = [0, 2, 1, 3, 4] : (tensor<1x32x64x1x16xf32>) -> tensor<1x64x32x1x16xf32>
  %4 = stablehlo.broadcast_in_dim %3, dims = [0, 1, 2, 3, 4] : (tensor<1x64x32x1x16xf32>) -> tensor<4x64x32x2x16xf32> 
```
Since `broadcast` is on the way out from stablehlo.

UPD: only patch 1 is accepted.