### PR TITLE
Add verifier for missing constraint for UniformQuantize Op

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2563,6 +2563,10 @@ ParseResult WhileOp::parse(OpAsmParser& parser, OperationState& result) {
   return hlo::parseWhileOp(parser, result);
 }
 
+//===----------------------------------------------------------------------===//
+// UniformDequantizeOp
+//===----------------------------------------------------------------------===//
+
 LogicalResult UniformDequantizeOp::inferReturnTypeComponents(
     MLIRContext*, std::optional<Location> location, ValueShapeRange operands,
     DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
@@ -2571,6 +2575,14 @@ LogicalResult UniformDequantizeOp::inferReturnTypeComponents(
                                        regions);
   return hlo::inferUniformDequantizeOp(location, adaptor.getOperand(),
                                        inferredReturnShapes);
+}
+
+//===----------------------------------------------------------------------===//
+// UniformQuantizeOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult UniformQuantizeOp::verify() {
+  return hlo::verifyUniformQuantizeOp(getLoc(), getOperand(), getResult());
 }
 
 }  // namespace stablehlo

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -3333,6 +3333,8 @@ def StableHLO_UniformQuantizeOp : StableHLO_UnaryElementwiseOp<"uniform_quantize
     %result = stablehlo.uniform_quantize %operand : (tensor<2xf32>) -> tensor<2x!quant.uniform<i8:f32:0, {0.1:-30,0.5:-20}>>
     ```
   }];
+
+  let hasVerifier = 1;
 }
 
 def StableHLO_UniformDequantizeOp : StableHLO_UnaryElementwiseOp<"uniform_dequantize",

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -3525,6 +3525,27 @@ LogicalResult inferUniformQuantizeOp(
   return success();
 }
 
+LogicalResult verifyUniformQuantizeOp(std::optional<Location> location,
+                                      Value operand, Value result) {
+  auto resultExpressedType =
+      cast<quant::QuantizedType>(getElementTypeOrSelf(result))
+          .getExpressedType();
+  auto operandElementType = getElementTypeOrSelf(operand);
+  auto exprectedResultExpressedType =
+      isa<FloatType>(operandElementType)
+          ? operandElementType
+          : cast<quant::QuantizedType>(operandElementType).getExpressedType();
+
+  // uniform_quantize_c2
+  if (resultExpressedType != exprectedResultExpressedType) {
+    return emitOptionalError(
+        location, "Expressed type of result expected to be ",
+        exprectedResultExpressedType, ", but got ", resultExpressedType);
+  }
+
+  return success();
+}
+
 LogicalResult inferWhileOp(std::optional<Location>, ValueRange operand,
                            SmallVectorImpl<Type>& inferredReturnTypes) {
   // while_c3

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -564,6 +564,9 @@ LogicalResult verifyTransposeOp(std::optional<Location> location,
                                 Type operandType, ArrayRef<int64_t> permutation,
                                 Type resultType);
 
+LogicalResult verifyUniformQuantizeOp(std::optional<Location> location,
+                                      Value operand, Value result);
+
 LogicalResult verifyWhileOp(std::optional<Location> location,
                             ValueRange operand, Region& cond, Region& body);
 }  // end namespace hlo

--- a/stablehlo/tests/ops_stablehlo_quantized.mlir
+++ b/stablehlo/tests/ops_stablehlo_quantized.mlir
@@ -1307,3 +1307,19 @@ func.func @quantized_element_type_c14(%arg0: tensor<1x5x2x!quant.uniform<i8<-128
   %0 = stablehlo.add %arg0,  %arg0 : tensor<1x5x2x!quant.uniform<i8<-128:127>:f32:1, {0.1:-30,0.1:-30 }>>
   func.return
 }
+
+// -----
+
+func.func @uniform_quantized_c1(%arg0: tensor<2xf32>) {
+  // expected-error@+1 {{Expressed type of result expected to be 'f32', but got 'f64'}}
+  %0 = "stablehlo.uniform_quantize"(%arg0) : (tensor<2xf32>) -> tensor<2x!quant.uniform<i8:f64, 0.1>>
+  func.return
+}
+
+// -----
+
+func.func @uniform_quantized_c1(%arg0: tensor<2x!quant.uniform<i8:f32, 0.1>>) {
+  // expected-error@+1 {{Expressed type of result expected to be 'f32', but got 'f64'}}
+  %0 = "stablehlo.uniform_quantize"(%arg0) : (tensor<2x!quant.uniform<i8:f32, 0.1>>) -> tensor<2x!quant.uniform<i8:f64, 0.1>>
+  func.return
+}


### PR DESCRIPTION
Here is the constraint this PR is adding verifier for
```
(C2) expressed_type(result) = is_float(operand) ? element_type(operand) : expressed_type(operand).
```

[link](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#constraints-96)

Note: Per the guidelines [(P3) Maintain verification code in verifiers and shape functions
](https://github.com/openxla/stablehlo/blob/main/docs/type_inference.md#p3-maintain-verification-code-in-verifiers-and-shape-functions), we are adding the logic in the verifier (not in the type inference) as the element type for this op cannot be inferred. 