### PR TITLE
fix linalg_passes link

### DIFF
--- a/stablehlo/conversions/linalg/transforms/CMakeLists.txt
+++ b/stablehlo/conversions/linalg/transforms/CMakeLists.txt
@@ -35,6 +35,7 @@ add_mlir_library(StablehloLinalgTransforms
 
   LINK_LIBS PUBLIC
   ChloOps
+  StablehloBase
   StablehloOps
   MLIRArithDialect
   MLIRBufferizationDialect

--- a/stablehlo/conversions/linalg/transforms/CMakeLists.txt
+++ b/stablehlo/conversions/linalg/transforms/CMakeLists.txt
@@ -34,6 +34,8 @@ add_mlir_library(StablehloLinalgTransforms
   Core
 
   LINK_LIBS PUBLIC
+  ChloOps
+  StablehloOps
   MLIRArithDialect
   MLIRBufferizationDialect
   MLIRComplexDialect


### PR DESCRIPTION
As a follow-up on my previous [PR](https://github.com/openxla/stablehlo/pull/2387), The linalg_passes also needs to link `ChloOps` and `StablehloOps`. They are already included in [`BUILD.bazel`](https://github.com/openxla/stablehlo/blob/main/BUILD.bazel#L477,L479) so only the `CMake` file needs modification.