### PR TITLE
Fix legalization of quantized Min/Max op to Int ops 

### DIFF
--- a/stablehlo/tests/stablehlo_legalize_quant_to_int.mlir
+++ b/stablehlo/tests/stablehlo_legalize_quant_to_int.mlir
@@ -1966,8 +1966,8 @@ func.func @dynamic_broadcast(
 
 // -----
 
-// CHECK-LABEL: func @max
-func.func @max(
+// CHECK-LABEL: func @max_per_tensor_same_quant_parameters
+func.func @max_per_tensor_same_quant_parameters(
     %arg0: tensor<1x2x!quant.uniform<i8:f32, 2.000000e+00:3>>
   ) -> tensor<1x2x!quant.uniform<i8:f32, 2.000000e+00:3>> {
   // CHECK: stablehlo.maximum
@@ -1981,8 +1981,8 @@ func.func @max(
 
 // -----
 
-// CHECK-LABEL: func @max_per_channel
-func.func @max_per_channel(
+// CHECK-LABEL: func @max_per_channel_same_quant_parameters
+func.func @max_per_channel_same_quant_parameters(
     %arg0: tensor<1x2x!quant.uniform<i8:f32, 2.000000e+00:3>>
   ) -> tensor<1x2x!quant.uniform<i8:f32, 2.000000e+00:3>> {
   // CHECK: stablehlo.maximum
@@ -1996,8 +1996,26 @@ func.func @max_per_channel(
 
 // -----
 
-// CHECK-LABEL: func @min
-func.func @min(
+func.func @max_per_tensor_diff_quant_parameters(%arg0: tensor<!quant.uniform<i8:f32,1.0:0>>, %arg1: tensor<!quant.uniform<i8:f32,2.0:1>>) ->  tensor<!quant.uniform<i8:f32,3.0:2>> {
+  // expected-error@+2 {{stablehlo.maximum with different quantization parameters for operands and results is not supported.}}
+  // expected-error@+1 {{failed to legalize operation 'stablehlo.maximum' that was explicitly marked illegal}}
+  %0 = "stablehlo.maximum"(%arg0, %arg1) : (tensor<!quant.uniform<i8:f32,1.0:0>>, tensor<!quant.uniform<i8:f32,2.0:1>>) -> tensor<!quant.uniform<i8:f32,3.0:2>>
+  func.return %0 : tensor<!quant.uniform<i8:f32,3.0:2>>
+}
+
+// -----
+
+func.func @min_per_tensor_diff_quant_parameters(%arg0: tensor<!quant.uniform<i8:f32,1.0:0>>, %arg1: tensor<!quant.uniform<i8:f32,2.0:1>>) ->  tensor<!quant.uniform<i8:f32,3.0:2>> {
+  // expected-error@+2 {{stablehlo.minimum with different quantization parameters for operands and results is not supported.}}
+  // expected-error@+1 {{failed to legalize operation 'stablehlo.minimum' that was explicitly marked illegal}}
+  %0 = "stablehlo.minimum"(%arg0, %arg1) : (tensor<!quant.uniform<i8:f32,1.0:0>>, tensor<!quant.uniform<i8:f32,2.0:1>>) -> tensor<!quant.uniform<i8:f32,3.0:2>>
+  func.return %0 : tensor<!quant.uniform<i8:f32,3.0:2>>
+}
+
+// -----
+
+// CHECK-LABEL: func @min_per_tensor_same_quant_parameters
+func.func @min_per_tensor_same_quant_parameters(
     %arg0: tensor<1x2x!quant.uniform<i8:f32, 2.000000e+00:3>>
   ) -> tensor<1x2x!quant.uniform<i8:f32, 2.000000e+00:3>> {
   // CHECK: stablehlo.minimum
@@ -2011,8 +2029,8 @@ func.func @min(
 
 // -----
 
-// CHECK-LABEL: func @min_per_channel
-func.func @min_per_channel(
+// CHECK-LABEL: func @min_per_channel_same_quant_parameters
+func.func @min_per_channel_same_quant_parameters(
     %arg0: tensor<1x2x!quant.uniform<i8:f32, 2.000000e+00:3>>
   ) -> tensor<1x2x!quant.uniform<i8:f32, 2.000000e+00:3>> {
   // CHECK: stablehlo.minimum

--- a/stablehlo/transforms/StablehloLegalizeQuantToInt.cpp
+++ b/stablehlo/transforms/StablehloLegalizeQuantToInt.cpp
@@ -1247,6 +1247,18 @@ class ConvertGenericOp : public ConversionPattern {
       return failure();
     }
 
+    if (isa<stablehlo::MinOp, stablehlo::MaxOp>(op)) {
+      auto lhsType = getPerTensorType(op->getOperandTypes()[0]);
+      auto rhsType = getPerTensorType(op->getOperandTypes()[1]);
+      auto resultType = getPerTensorType(op->getResultTypes()[0]);
+      if (lhsType != rhsType || lhsType != resultType) {
+        op->emitError(op->getName().getStringRef() +
+                      " with different quantization parameters for operands and"
+                      " results is not supported.");
+        return failure();
+      }
+    }
+
     // Determine new result type: use storage type for uq types; use original
     // type otherwise.
     SmallVector<Type, 4> newResultTypes;

--- a/stablehlo/transforms/StablehloLegalizeQuantToInt.cpp
+++ b/stablehlo/transforms/StablehloLegalizeQuantToInt.cpp
@@ -1248,14 +1248,15 @@ class ConvertGenericOp : public ConversionPattern {
     }
 
     if (isa<stablehlo::MinOp, stablehlo::MaxOp>(op)) {
+      // Min/max only support per-tensor quantization.
       auto lhsType = getPerTensorType(op->getOperandTypes()[0]);
       auto rhsType = getPerTensorType(op->getOperandTypes()[1]);
       auto resultType = getPerTensorType(op->getResultTypes()[0]);
       if (lhsType != rhsType || lhsType != resultType) {
-        op->emitError(op->getName().getStringRef() +
-                      " with different quantization parameters for operands and"
-                      " results is not supported.");
-        return failure();
+        return op->emitError(
+            op->getName().getStringRef() +
+            " with different quantization parameters for operands and"
+            " results is not supported.");
       }
     }
 


### PR DESCRIPTION
## Problem

Consider the following quantized stablehlo max operation

```
func.func @max_per_tensor_diff_quant_parameters(%arg0: tensor<!quant.uniform<i8:f32,1.0:0>>, %arg1: tensor<!quant.uniform<i8:f32,2.0:1>>) ->  tensor<!quant.uniform<i8:f32,3.0:2>> {
  %0 = "stablehlo.maximum"(%arg0, %arg1) : (tensor<!quant.uniform<i8:f32,1.0:0>>, tensor<!quant.uniform<i8:f32,2.0:1>>) -> tensor<!quant.uniform<i8:f32,3.0:2>>
  func.return %0 : tensor<!quant.uniform<i8:f32,3.0:2>>
}
```

Note that the quantization parameters (scales and zps) for operands and results are different.  

Currently [--stablehlo-legalize-quant-to-int](https://github.com/openxla/stablehlo/blob/main/stablehlo/transforms/StablehloLegalizeQuantToInt.cpp) legalizes this as follows:

```
func.func @max_per_tensor_diff_quant_parameters(%arg0: tensor<i8>, %arg1:  tensor<i8>) ->   tensor<i8> { 
  %0 = stablehlo.maximum %arg0, %arg1:  tensor<i8>
  func.return %0 :  tensor<i8>
```

which only makes sense when the quantization parameters is same for all operands and results, otherwise it is buggy ([why](reason)). 

## Proposed solution

The PR adds a check to allow the legalization only when  "the quantization parameters is same for all operands and results". Else error out.

### Appendix: Reason that it is a problem
Consider `a` and `b` are the input quantized values with  scale/ zp as `[s1, z1]` and `[s2, z2]` resp, and `c` is the output with scal/zp as `[s3, z3]`


we have from the semantics of the operation
```
(c - z3)*s3 = max[ (a-z1)*s1, (a-z2)*s2 ] 
```

Only if `z1=z2=z3`, and `s1=s2=s3`, we can simplify the above as `c = Max(a,b)` which is what the current legalization is doing.


