### PR TITLE
support get_smaller_version in python binding

### DIFF
--- a/stablehlo/api/PortableApi.cpp
+++ b/stablehlo/api/PortableApi.cpp
@@ -37,6 +37,20 @@ void loadSerializationDialects(MLIRContext& context) {
 }
 }  // namespace
 
+LogicalResult getSmallerVersion(const std::string& version1,
+                                const std::string& version2,
+                                std::string& result) {
+  auto v1 = mlir::vhlo::Version::fromString(version1);
+  auto v2 = mlir::vhlo::Version::fromString(version2);
+  if (failed(v1) || failed(v2)) return failure();
+
+  if (*v1 < *v2)
+    result = (*v1).toString();
+  else
+    result = (*v2).toString();
+  return success();
+}
+
 std::string getCurrentVersion() {
   return mlir::vhlo::Version::getCurrentVersion().toString();
 }

--- a/stablehlo/api/PortableApi.h
+++ b/stablehlo/api/PortableApi.h
@@ -29,6 +29,11 @@ namespace stablehlo {
 /// Increments on all meaningful changes to this file.
 inline int64_t getApiVersion() { return 7; }
 
+// Get the smaller version between version1 and version2.
+LogicalResult getSmallerVersion(const std::string& version1,
+                                const std::string& version2,
+                                std::string& result);
+
 // Get the current StableHLO version.
 //
 // This value can be used as the `targetVersion` argument to

--- a/stablehlo/integrations/python/PortableApi.cpp
+++ b/stablehlo/integrations/python/PortableApi.cpp
@@ -31,6 +31,19 @@ void AddPortableApi(py::module& m) {
 
   m.def("get_api_version", []() { return getApiVersion(); });
 
+  m.def(
+      "get_smaller_version",
+      [](std::string version1, std::string version2) -> py::str {
+        std::string result;
+        if (failed(getSmallerVersion(version1, version2, result))) {
+          PyErr_SetString(PyExc_ValueError,
+                          "failed to convert version to stablehlo version");
+          return "";
+        }
+        return result;
+      },
+      py::arg("version1"), py::arg("version2"));
+
   //
   // Serialization APIs.
   //

--- a/stablehlo/integrations/python/tests/stablehlo.py
+++ b/stablehlo/integrations/python/tests/stablehlo.py
@@ -283,6 +283,11 @@ def test_reference_api():
     expected = arg + arg
     assert (actual == expected).all()
 
+@run
+def test_get_smaller_version():
+  curr_version = stablehlo.get_current_version()
+  min_version = stablehlo.get_minimum_version()
+  assert stablehlo.get_smaller_version(curr_version, min_version) == min_version
 
 @run
 def test_serialization_apis():


### PR DESCRIPTION
Support `get_smaller_version(version1, version2)` in stablehlo's python binding.
Example usage:
```python
version = get_smaller_version(frontend_compiler.get_current_version(), backend_compiler.get_current_version())
serialize_portable_artifact(module, version)
```