### PR TITLE
Cleanup StableHLO bytecode patches used for temporary pjrt compatibility

### DIFF
--- a/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
@@ -840,7 +840,6 @@ struct TransposeOpToTransposeConverter final
     Value emptyTensor =
         getEmptyTensorFor(rewriter, loc, resultTy, op, adaptor.getOperands());
 
-    // TODO(#2216) Cleanup Attribute -> DenseArrayAttr
     rewriter.replaceOpWithNewOp<linalg::TransposeOp>(
         op, adaptor.getOperand(), emptyTensor, op.getPermutationAttr(),
         linalg::getPrunedAttributeList(op));

--- a/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
@@ -842,8 +842,7 @@ struct TransposeOpToTransposeConverter final
 
     // TODO(#2216) Cleanup Attribute -> DenseArrayAttr
     rewriter.replaceOpWithNewOp<linalg::TransposeOp>(
-        op, adaptor.getOperand(), emptyTensor,
-        dyn_cast_or_null<DenseI64ArrayAttr>(op.getPermutationAttr()),
+        op, adaptor.getOperand(), emptyTensor, op.getPermutationAttr(),
         linalg::getPrunedAttributeList(op));
     return success();
   }

--- a/stablehlo/dialect/AssemblyFormat.cpp
+++ b/stablehlo/dialect/AssemblyFormat.cpp
@@ -693,41 +693,39 @@ ParseResult parseWhileOp(OpAsmParser& parser, OperationState& result) {
 //===----------------------------------------------------------------------===//
 
 void printSliceRanges(OpAsmPrinter& p, Operation* op,
-                      Attribute startIndicesAttr, Attribute limitIndicesAttr,
-                      Attribute stridesAttr) {
-  auto startIndices = cast<DenseI64ArrayAttr>(startIndicesAttr);
-  auto limitIndices = cast<DenseI64ArrayAttr>(limitIndicesAttr);
-  auto strides = cast<DenseI64ArrayAttr>(stridesAttr);
+                      ArrayRef<int64_t> startIndices,
+                      ArrayRef<int64_t> limitIndices,
+                      ArrayRef<int64_t> strides) {
   p << "[";
   // Let's be safe if we're printing invalid IR somehow: this can't be parsed
   // back!
   if (startIndices.size() != limitIndices.size() ||
       startIndices.size() != strides.size()) {
     p << "start_indices: ";
-    llvm::interleaveComma(startIndices.asArrayRef(), p);
+    llvm::interleaveComma(startIndices, p);
     p << ", limit_indices: ";
-    llvm::interleaveComma(limitIndices.asArrayRef(), p);
+    llvm::interleaveComma(limitIndices, p);
     p << ", strides: ";
-    llvm::interleaveComma(strides.asArrayRef(), p);
+    llvm::interleaveComma(strides, p);
     p << "]";
     return;
   }
 
-  llvm::interleaveComma(
-      llvm::zip(startIndices.asArrayRef(), limitIndices.asArrayRef(),
-                strides.asArrayRef()),
-      p, [&](std::tuple<int64_t, int64_t, int64_t> pack) {
-        auto [start, limit, stride] = pack;
-        p << start << ":" << limit;
-        if (stride != 1) {
-          p << ":" << stride;
-        }
-      });
+  llvm::interleaveComma(llvm::zip(startIndices, limitIndices, strides), p,
+                        [&](std::tuple<int64_t, int64_t, int64_t> pack) {
+                          auto [start, limit, stride] = pack;
+                          p << start << ":" << limit;
+                          if (stride != 1) {
+                            p << ":" << stride;
+                          }
+                        });
   p << "]";
 }
 
-ParseResult parseSliceRanges(OpAsmParser& parser, Attribute& startIndices,
-                             Attribute& limitIndices, Attribute& strides) {
+ParseResult parseSliceRanges(OpAsmParser& parser,
+                             DenseI64ArrayAttr& startIndices,
+                             DenseI64ArrayAttr& limitIndices,
+                             DenseI64ArrayAttr& strides) {
   if (parser.parseLSquare()) return failure();
   // Parse groups of comma-separated: `start`:`limit`[:`stride`]
   // If the stride isn't provided it'll be 1.
@@ -755,17 +753,6 @@ ParseResult parseSliceRanges(OpAsmParser& parser, Attribute& startIndices,
   strides = parser.getBuilder().getDenseI64ArrayAttr(stride);
 
   return success();
-}
-
-void printDenseI64Array(OpAsmPrinter& p, Operation* op, Attribute attr) {
-  cast<DenseI64ArrayAttr>(attr).print(p);
-}
-
-ParseResult parseDenseI64Array(OpAsmParser& parser, Attribute& attr) {
-  if ((attr = DenseI64ArrayAttr::parse(parser, Type{}))) {
-    return success();
-  }
-  return failure();
 }
 
 ParseResult dimSizeFromString(AsmParser& parser, int64_t& result) {

--- a/stablehlo/dialect/AssemblyFormat.h
+++ b/stablehlo/dialect/AssemblyFormat.h
@@ -219,13 +219,16 @@ ParseResult parseWhileOp(OpAsmParser& parser, OperationState& result);
 // Attribute Printers and Parsers
 //===----------------------------------------------------------------------===//
 
-// TODO(#2216) Cleanup Attribute -> DenseArrayAttr for print/parse.
 // SliceRanges - Used to print multi-dimensional ranges for slice.
-void printSliceRanges(OpAsmPrinter& p, Operation* op, Attribute startIndices,
-                      Attribute limitIndices, Attribute strides);
+void printSliceRanges(OpAsmPrinter& p, Operation* op,
+                      ArrayRef<int64_t> startIndices,
+                      ArrayRef<int64_t> limitIndices,
+                      ArrayRef<int64_t> strides);
 
-ParseResult parseSliceRanges(OpAsmParser& parser, Attribute& startIndices,
-                             Attribute& limitIndices, Attribute& strides);
+ParseResult parseSliceRanges(OpAsmParser& parser,
+                             DenseI64ArrayAttr& startIndices,
+                             DenseI64ArrayAttr& limitIndices,
+                             DenseI64ArrayAttr& strides);
 
 // GenericI64DenseArray - Used to print an attr that can be either
 //

--- a/stablehlo/dialect/StablehloAttrs.td
+++ b/stablehlo/dialect/StablehloAttrs.td
@@ -25,24 +25,6 @@ def StableHLO_Dims : ArrayRefParameter<"int64_t", "Dimension"> {
   let printer = "printDimSizes($_printer, $_self)";
 }
 
-def GenericDenseI64ArrayAttr : Attr<DenseI64ArrayAttr.predicate, "DenseI64ArrayAttr with generic Attribute storage"> {
-  let storageType = "Attribute";
-  let valueType = DenseI64ArrayAttr.valueType;
-  let returnType = "::llvm::ArrayRef<int64_t>";
-  let baseAttr = DenseI64ArrayAttr;
-  let convertFromStorage = "cast<DenseI64ArrayAttr>($_self).asArrayRef()";
-  let constBuilderCall = "$_builder.getDenseI64ArrayAttr($0)";
-}
-
-def GenericDenseBoolArrayAttr : Attr<DenseBoolArrayAttr.predicate, "DenseBoolArrayAttr with generic Attribute storage"> {
-  let storageType = "Attribute";
-  let valueType = DenseBoolArrayAttr.valueType;
-  let returnType = "::llvm::ArrayRef<bool>";
-  let convertFromStorage = "cast<DenseBoolArrayAttr>($_self).asArrayRef()";
-  let constBuilderCall = "$_builder.getDenseBoolArrayAttr($0)";
-}
-
-
 def StableHLO_ScatterDimensionNumbers : AttrDef<StableHLO_Dialect, "ScatterDimensionNumbers"> {
   let mnemonic = "scatter";
   let summary = "Attribute that models the dimension information for scatter";

--- a/stablehlo/dialect/StablehloBytecode.cpp
+++ b/stablehlo/dialect/StablehloBytecode.cpp
@@ -491,19 +491,21 @@ GatherDimensionNumbersAttr
 StablehloBytecodeInterface::readGatherDimensionNumbersAttr(
     DialectBytecodeReader &reader) const {
   LOG_READ_CALL;
-  llvm::SmallVector<int64_t> offsetDims, collapsedSliceDims, startIndexMap;
+  llvm::SmallVector<int64_t> offsetDims, collapsedSliceDims,
+      operandBatchingDims, startIndicesBatchingDims, startIndexMap;
   int64_t indexVectorDim;
 
   if (failed(reader.readSignedVarInts(offsetDims)) ||
       failed(reader.readSignedVarInts(collapsedSliceDims)) ||
+      failed(reader.readSignedVarInts(operandBatchingDims)) ||
+      failed(reader.readSignedVarInts(startIndicesBatchingDims)) ||
       failed(reader.readSignedVarInts(startIndexMap)) ||
       failed(reader.readSignedVarInt(indexVectorDim)))
     return GatherDimensionNumbersAttr();
 
   return GatherDimensionNumbersAttr::get(
-      getContext(), offsetDims, collapsedSliceDims,
-      /*operandBatchingDims=*/{}, /*startIndicesBatchingDims=*/{},
-      startIndexMap, indexVectorDim);
+      getContext(), offsetDims, collapsedSliceDims, operandBatchingDims,
+      startIndicesBatchingDims, startIndexMap, indexVectorDim);
 }
 
 void StablehloBytecodeInterface::write(GatherDimensionNumbersAttr attr,
@@ -511,6 +513,8 @@ void StablehloBytecodeInterface::write(GatherDimensionNumbersAttr attr,
   writer.writeVarInt(stablehlo_encoding::kGatherDimensionNumbers);
   writer.writeSignedVarInts(attr.getOffsetDims());
   writer.writeSignedVarInts(attr.getCollapsedSliceDims());
+  writer.writeSignedVarInts(attr.getOperandBatchingDims());
+  writer.writeSignedVarInts(attr.getStartIndicesBatchingDims());
   writer.writeSignedVarInts(attr.getStartIndexMap());
   writer.writeSignedVarInt(attr.getIndexVectorDim());
 }
@@ -600,19 +604,20 @@ StablehloBytecodeInterface::readScatterDimensionNumbersAttr(
     DialectBytecodeReader &reader) const {
   LOG_READ_CALL;
   llvm::SmallVector<int64_t> updateWindowDims, insertedWindowDims,
-      scatterDimsToOperandDims;
+      inputBatchingDims, scatterIndicesBatchingDims, scatterDimsToOperandDims;
   int64_t indexVectorDim;
 
   if (failed(reader.readSignedVarInts(updateWindowDims)) ||
       failed(reader.readSignedVarInts(insertedWindowDims)) ||
+      failed(reader.readSignedVarInts(inputBatchingDims)) ||
+      failed(reader.readSignedVarInts(scatterIndicesBatchingDims)) ||
       failed(reader.readSignedVarInts(scatterDimsToOperandDims)) ||
       failed(reader.readSignedVarInt(indexVectorDim)))
     return ScatterDimensionNumbersAttr();
 
   return ScatterDimensionNumbersAttr::get(
-      getContext(), updateWindowDims, insertedWindowDims,
-      /*inputBatchingDims=*/{}, /*scatterIndicesBatchingDims=*/{},
-      scatterDimsToOperandDims, indexVectorDim);
+      getContext(), updateWindowDims, insertedWindowDims, inputBatchingDims,
+      scatterIndicesBatchingDims, scatterDimsToOperandDims, indexVectorDim);
 }
 
 void StablehloBytecodeInterface::write(ScatterDimensionNumbersAttr attr,
@@ -620,6 +625,8 @@ void StablehloBytecodeInterface::write(ScatterDimensionNumbersAttr attr,
   writer.writeVarInt(stablehlo_encoding::kScatterDimensionNumbersAttr);
   writer.writeSignedVarInts(attr.getUpdateWindowDims());
   writer.writeSignedVarInts(attr.getInsertedWindowDims());
+  writer.writeSignedVarInts(attr.getInputBatchingDims());
+  writer.writeSignedVarInts(attr.getScatterIndicesBatchingDims());
   writer.writeSignedVarInts(attr.getScatterDimsToOperandDims());
   writer.writeSignedVarInt(attr.getIndexVectorDim());
 }

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -2590,7 +2590,6 @@ LogicalResult UniformQuantizeOp::verify() {
 
 using mlir::hlo::parseComplexOpType;
 using mlir::hlo::parseCustomCallTarget;
-using mlir::hlo::parseDenseI64Array;
 using mlir::hlo::parseDotDimensionNumbers;
 using mlir::hlo::parseExponentMantissa;
 using mlir::hlo::parsePairwiseOpType;
@@ -2602,7 +2601,6 @@ using mlir::hlo::parseVariadicOperandWithAttribute;
 using mlir::hlo::parseVariadicSameOperandsAndResultType;
 using mlir::hlo::printComplexOpType;
 using mlir::hlo::printCustomCallTarget;
-using mlir::hlo::printDenseI64Array;
 using mlir::hlo::printDotDimensionNumbers;
 using mlir::hlo::printExponentMantissa;
 using mlir::hlo::printPairwiseOpType;
@@ -3291,11 +3289,11 @@ void printWindowPadding(OpAsmPrinter& p, DenseElementsAttr padding) {
 }  // namespace
 
 void printWindowAttributes(OpAsmPrinter& p, Operation* /*op*/,
-                           std::optional<Attribute> windowStrides,
+                           std::optional<DenseI64ArrayAttr> windowStrides,
                            std::optional<DenseIntElementsAttr> padding,
-                           std::optional<Attribute> lhsDilation,
-                           std::optional<Attribute> rhsDilation,
-                           std::optional<Attribute> windowReversal) {
+                           std::optional<DenseI64ArrayAttr> lhsDilation,
+                           std::optional<DenseI64ArrayAttr> rhsDilation,
+                           std::optional<DenseBoolArrayAttr> windowReversal) {
   using pair_t = std::pair<Attribute, StringRef>;
   std::array<pair_t, 5> printedAttributes = {{
       {windowStrides ? *windowStrides : nullptr, "stride"},
@@ -3327,20 +3325,12 @@ void printWindowAttributes(OpAsmPrinter& p, Operation* /*op*/,
   });
 }
 
-void printWindowAttributes(OpAsmPrinter& p, Operation* /*op*/,
-                           std::optional<Attribute> windowStrides,
-                           std::optional<Attribute> lhsDilation,
-                           std::optional<Attribute> rhsDilation,
-                           std::optional<Attribute> windowReversal) {
-  printWindowAttributes(p, nullptr, windowStrides, /*padding=*/{}, lhsDilation,
-                        rhsDilation, windowReversal);
-}
-
-ParseResult parseWindowAttributes(OpAsmParser& parser, Attribute& windowStrides,
+ParseResult parseWindowAttributes(OpAsmParser& parser,
+                                  DenseI64ArrayAttr& windowStrides,
                                   DenseIntElementsAttr& padding,
-                                  Attribute& lhsDilation,
-                                  Attribute& rhsDilation,
-                                  Attribute& windowReversal) {
+                                  DenseI64ArrayAttr& lhsDilation,
+                                  DenseI64ArrayAttr& rhsDilation,
+                                  DenseBoolArrayAttr& windowReversal) {
   StringRef attributeName;
 
   llvm::StringSet<> allowedAttributeNames{
@@ -3417,15 +3407,6 @@ ParseResult parseWindowAttributes(OpAsmParser& parser, Attribute& windowStrides,
     if (parser.parseOptionalComma().failed()) break;
   }
   return success();
-}
-
-ParseResult parseWindowAttributes(OpAsmParser& parser, Attribute& windowStrides,
-                                  Attribute& lhsDilation,
-                                  Attribute& rhsDilation,
-                                  Attribute& windowReversal) {
-  auto padding = parser.getBuilder().getI64TensorAttr({});
-  return parseWindowAttributes(parser, windowStrides, padding, lhsDilation,
-                               rhsDilation, windowReversal);
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.h
+++ b/stablehlo/dialect/StablehloOps.h
@@ -120,33 +120,19 @@ void printConvolutionDimensions(AsmPrinter &p, Operation *,
 ParseResult parseConvolutionDimensions(AsmParser &parser,
                                        ConvDimensionNumbersAttr &dimNums);
 
-// TODO(#2216) Cleanup Attribute -> DenseArrayAttr for print/parse.
-// Custom formatting for convolution window attributes.
 void printWindowAttributes(OpAsmPrinter &p, Operation *op,
-                           std::optional<Attribute> windowStrides,
+                           std::optional<DenseI64ArrayAttr> windowStrides,
                            std::optional<DenseIntElementsAttr> padding,
-                           std::optional<Attribute> lhsDilation,
-                           std::optional<Attribute> rhsDilation,
-                           std::optional<Attribute> windowReversal);
+                           std::optional<DenseI64ArrayAttr> lhsDilation,
+                           std::optional<DenseI64ArrayAttr> rhsDilation,
+                           std::optional<DenseBoolArrayAttr> windowReversal);
 
-// TODO(#2216) Cleanup Attribute -> DenseArrayAttr for print/parse.
-// Custom formatting for convolution window attributes.
-void printWindowAttributes(OpAsmPrinter &p, Operation *op,
-                           std::optional<Attribute> windowStrides,
-                           std::optional<Attribute> lhsDilation,
-                           std::optional<Attribute> rhsDilation,
-                           std::optional<Attribute> windowReversal);
-
-ParseResult parseWindowAttributes(OpAsmParser &parser, Attribute &windowStrides,
+ParseResult parseWindowAttributes(OpAsmParser &parser,
+                                  DenseI64ArrayAttr &windowStrides,
                                   DenseIntElementsAttr &padding,
-                                  Attribute &lhsDilation,
-                                  Attribute &rhsDilation,
-                                  Attribute &windowReversal);
-
-ParseResult parseWindowAttributes(OpAsmParser &parser, Attribute &windowStrides,
-                                  Attribute &lhsDilation,
-                                  Attribute &rhsDilation,
-                                  Attribute &windowReversal);
+                                  DenseI64ArrayAttr &lhsDilation,
+                                  DenseI64ArrayAttr &rhsDilation,
+                                  DenseBoolArrayAttr &windowReversal);
 
 }  // end namespace stablehlo
 }  // end namespace mlir

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -1518,7 +1518,7 @@ def StableHLO_ReduceOp: StableHLO_ShapedInterfaceOp<"reduce", [
   let arguments = (ins
     Variadic<HLO_Tensor>:$inputs, /*reduce_i1*/
     Variadic<HLO_Tensor>:$init_values, /*reduce_i2*/
-    GenericDenseI64ArrayAttr:$dimensions /*reduce_i3*/
+    DenseI64ArrayAttr:$dimensions /*reduce_i3*/
   );
   let regions = (region SizedRegion<1>:$body /*reduce_i4*/);
 
@@ -1669,9 +1669,9 @@ def StableHLO_SliceOp: StableHLO_Op<
 
   let arguments = (ins
     HLO_Tensor:$operand,
-    GenericDenseI64ArrayAttr:$start_indices,
-    GenericDenseI64ArrayAttr:$limit_indices,
-    GenericDenseI64ArrayAttr:$strides
+    DenseI64ArrayAttr:$start_indices,
+    DenseI64ArrayAttr:$limit_indices,
+    DenseI64ArrayAttr:$strides
   );
 
   let assemblyFormat = [{
@@ -1702,15 +1702,14 @@ def StableHLO_DynamicSliceOp: StableHLO_Op<"dynamic_slice",
   let arguments = (ins
     HLO_Tensor:$operand /*dynamic_slice_i1*/,
     Variadic<HLO_ScalarIntTensor>:$start_indices /*dynamic_slice_i2*/,
-    GenericDenseI64ArrayAttr:$slice_sizes /*dynamic_slice_i3*/
+    DenseI64ArrayAttr:$slice_sizes /*dynamic_slice_i3*/
   );
 
   let results = (outs HLO_Tensor:$result);
 
   let assemblyFormat = [{
     $operand `,` custom<VariadicOperandWithAttribute>($start_indices)
-      `sizes` `=` custom<DenseI64Array>($slice_sizes)
-      attr-dict `:` functional-type(operands, results)
+      `sizes` `=` $slice_sizes attr-dict `:` functional-type(operands, results)
   }];
 }
 
@@ -1904,13 +1903,13 @@ def StableHLO_BroadcastOp : StableHLO_ShapedInterfaceOp<"broadcast",
   }];
   let arguments = (ins
     HLO_Tensor:$operand,
-    GenericDenseI64ArrayAttr:$broadcast_sizes
+    DenseI64ArrayAttr:$broadcast_sizes
   );
 
   let results = (outs HLO_TensorOrPerAxisQuantizedTensor);
 
   let assemblyFormat = [{
-    $operand `,` `sizes` `=` custom<DenseI64Array>($broadcast_sizes)
+    $operand `,` `sizes` `=` $broadcast_sizes
       attr-dict `:` functional-type(operands, results)
   }];
 }
@@ -1933,7 +1932,7 @@ def StableHLO_BroadcastInDimOp : StableHLO_Op<"broadcast_in_dim",
   }];
   let arguments = (ins
     HLO_TensorOrPerAxisQuantizedTensor:$operand /*broadcast_in_dim_i1*/,
-    GenericDenseI64ArrayAttr:$broadcast_dimensions /*broadcast_in_dim_i2*/
+    DenseI64ArrayAttr:$broadcast_dimensions /*broadcast_in_dim_i2*/
   );
 
   let results = (outs HLO_StaticShapeTensorOrPerAxisQuantizedTensor);
@@ -1941,7 +1940,7 @@ def StableHLO_BroadcastInDimOp : StableHLO_Op<"broadcast_in_dim",
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    $operand `,` `dims` `=` custom<DenseI64Array>($broadcast_dimensions)
+    $operand `,` `dims` `=` $broadcast_dimensions
       attr-dict `:` functional-type(operands, results)
   }];
 
@@ -1984,9 +1983,9 @@ def StableHLO_DynamicBroadcastInDimOp : StableHLO_ShapedInterfaceOp<
   let arguments = (ins
     HLO_TensorOrPerAxisQuantizedTensor:$operand /*dynamic_broadcast_in_dim_i1*/,
     HLO_StaticDimensionTensor:$output_dimensions /*dynamic_broadcast_in_dim_i2*/,
-    GenericDenseI64ArrayAttr:$broadcast_dimensions /*dynamic_broadcast_in_dim_i3*/,
-    OptionalAttr<GenericDenseI64ArrayAttr>:$known_expanding_dimensions /*dynamic_broadcast_in_dim_i4*/,
-    OptionalAttr<GenericDenseI64ArrayAttr>:$known_nonexpanding_dimensions /*dynamic_broadcast_in_dim_i5*/
+    DenseI64ArrayAttr:$broadcast_dimensions /*dynamic_broadcast_in_dim_i3*/,
+    OptionalAttr<DenseI64ArrayAttr>:$known_expanding_dimensions /*dynamic_broadcast_in_dim_i4*/,
+    OptionalAttr<DenseI64ArrayAttr>:$known_nonexpanding_dimensions /*dynamic_broadcast_in_dim_i5*/
   );
 
   let results = (outs HLO_TensorOrPerAxisQuantizedTensor);
@@ -2004,7 +2003,7 @@ def StableHLO_DynamicBroadcastInDimOp : StableHLO_ShapedInterfaceOp<
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    $operand `,` $output_dimensions `,` `dims` `=` custom<DenseI64Array>($broadcast_dimensions)
+    $operand `,` $output_dimensions `,` `dims` `=` $broadcast_dimensions
       attr-dict `:` functional-type(operands, results)
   }];
 
@@ -2264,15 +2263,15 @@ def StableHLO_ConvolutionOp : StableHLO_Op<"convolution",
     HLO_Tensor:$lhs, /*convolution_i1*/
     HLO_TensorOrPerAxisQuantizedTensor:$rhs, /*convolution_i2*/
     // Default value: one for each of the spatial dimension.
-    OptionalAttr<GenericDenseI64ArrayAttr>:$window_strides, /*convolution_i3*/
+    OptionalAttr<DenseI64ArrayAttr>:$window_strides, /*convolution_i3*/
     // Default value: two zeros for each of the spatial dimension.
     OptionalAttr<I64ElementsAttr>:$padding, /*convolution_i4*/
     // Default value: one for each of the spatial dimension.
-    OptionalAttr<GenericDenseI64ArrayAttr>:$lhs_dilation, /*convolution_i5*/
+    OptionalAttr<DenseI64ArrayAttr>:$lhs_dilation, /*convolution_i5*/
     // Default value: one for each of the spatial dimension.
-    OptionalAttr<GenericDenseI64ArrayAttr>:$rhs_dilation, /*convolution_i6*/
+    OptionalAttr<DenseI64ArrayAttr>:$rhs_dilation, /*convolution_i6*/
     // Default value: false for each of the spatial dimension.
-    OptionalAttr<GenericDenseBoolArrayAttr>:$window_reversal, /*convolution_i7*/
+    OptionalAttr<DenseBoolArrayAttr>:$window_reversal, /*convolution_i7*/
     StableHLO_ConvDimensionNumbers:$dimension_numbers, /*convolution_i8...convolution_i16*/
     I64Attr:$feature_group_count, /*convolution_i17*/
     I64Attr:$batch_group_count, /*convolution_i18*/
@@ -2533,13 +2532,13 @@ def StableHLO_FftOp: StableHLO_Op<"fft",
   let arguments = (ins
     HLO_FpOrComplexTensor:$operand,
     StableHLO_FftTypeAttr:$fft_type,
-    GenericDenseI64ArrayAttr:$fft_length
+    DenseI64ArrayAttr:$fft_length
   );
 
   let results = (outs HLO_FpOrComplexTensor);
 
   let assemblyFormat = [{
-    $operand `,` `type` `=` $fft_type `,` `length` `=` custom<DenseI64Array>($fft_length)
+    $operand `,` `type` `=` $fft_type `,` `length` `=` $fft_length
       attr-dict `:` functional-type(operands, results)
   }];
 
@@ -2581,7 +2580,7 @@ def StableHLO_GatherOp: StableHLO_Op<"gather",
     HLO_Tensor:$operand /*gather_i1*/,
     HLO_IntTensor:$start_indices /*gather_i2*/,
     StableHLO_GatherDimensionNumbers:$dimension_numbers /*gather_i3...gather_i8*/,
-    GenericDenseI64ArrayAttr:$slice_sizes /*gather_i9*/,
+    DenseI64ArrayAttr:$slice_sizes /*gather_i9*/,
     DefaultValuedOptionalAttr<BoolAttr, "false">:$indices_are_sorted /*gather_i10*/
   );
 
@@ -2646,7 +2645,7 @@ def StableHLO_MapOp: StableHLO_ShapedInterfaceOp<"map",
   }];
   let arguments = (ins
     Variadic<HLO_Tensor>:$inputs /*map_i1*/,
-    GenericDenseI64ArrayAttr:$dimensions /*map_i2*/
+    DenseI64ArrayAttr:$dimensions /*map_i2*/
   );
   let regions = (region SizedRegion<1>:$computation /*map_i3*/);
   let results = (outs HLO_Tensor);
@@ -2834,8 +2833,8 @@ def StableHLO_SelectAndScatterOp: StableHLO_Op<"select_and_scatter",
     HLO_Tensor:$operand, /*select_and_scatter_i1*/
     HLO_Tensor:$source, /*select_and_scatter_i2*/
     HLO_Tensor:$init_value, /*select_and_scatter_i3*/
-    OptionalAttr<GenericDenseI64ArrayAttr>:$window_dimensions, /*select_and_scatter_i4*/
-    OptionalAttr<GenericDenseI64ArrayAttr>:$window_strides, /*select_and_scatter_i5*/
+    OptionalAttr<DenseI64ArrayAttr>:$window_dimensions, /*select_and_scatter_i4*/
+    OptionalAttr<DenseI64ArrayAttr>:$window_strides, /*select_and_scatter_i5*/
     OptionalAttr<I64ElementsAttr>:$padding /*select_and_scatter_i6*/
   );
 
@@ -2943,7 +2942,7 @@ def StableHLO_ReverseOp: StableHLO_ShapedInterfaceOp<"reverse",
   }];
   let arguments = (ins
     HLO_Tensor:$operand,
-    GenericDenseI64ArrayAttr:$dimensions
+    DenseI64ArrayAttr:$dimensions
   );
 
   let hasVerifier = 1;
@@ -2951,7 +2950,7 @@ def StableHLO_ReverseOp: StableHLO_ShapedInterfaceOp<"reverse",
   let results = (outs HLO_Tensor:$result);
 
   let assemblyFormat = [{
-    $operand `,` `dims` `=` custom<DenseI64Array>($dimensions)
+    $operand `,` `dims` `=` $dimensions
       attr-dict `:` custom<SameOperandsAndResultType>(type($operand), type($result))
   }];
 }
@@ -2980,18 +2979,18 @@ def StableHLO_PadOp: StableHLO_ShapedInterfaceOp<"pad",
   let arguments = (ins
     HLO_Tensor:$operand /*pad_i1*/,
     HLO_ScalarTensor:$padding_value /*pad_i2*/,
-    GenericDenseI64ArrayAttr:$edge_padding_low /*pad_i3*/,
-    GenericDenseI64ArrayAttr:$edge_padding_high /*pad_i4*/,
-    GenericDenseI64ArrayAttr:$interior_padding /*pad_i5*/
+    DenseI64ArrayAttr:$edge_padding_low /*pad_i3*/,
+    DenseI64ArrayAttr:$edge_padding_high /*pad_i4*/,
+    DenseI64ArrayAttr:$interior_padding /*pad_i5*/
   );
 
   let results = (outs HLO_Tensor);
 
   let assemblyFormat = [{
     $operand `,` $padding_value `,`
-      `low` `=` custom<DenseI64Array>($edge_padding_low) `,`
-      `high` `=` custom<DenseI64Array>($edge_padding_high) `,`
-      `interior` `=` custom<DenseI64Array>($interior_padding)
+      `low` `=` $edge_padding_low `,`
+      `high` `=` $edge_padding_high `,`
+      `interior` `=` $interior_padding
       attr-dict `:` functional-type(operands, results)
   }];
 }
@@ -3015,14 +3014,14 @@ def StableHLO_TransposeOp: StableHLO_ShapedInterfaceOp<"transpose",
   }];
   let arguments = (ins
     HLO_TensorOrPerAxisQuantizedTensor:$operand,
-    GenericDenseI64ArrayAttr:$permutation
+    DenseI64ArrayAttr:$permutation
   );
   let results = (outs HLO_TensorOrPerAxisQuantizedTensor:$result);
 
   let hasVerifier = 1;
 
   let assemblyFormat = [{
-    $operand `,` `dims` `=` custom<DenseI64Array>($permutation)
+    $operand `,` `dims` `=` $permutation
       attr-dict `:` functional-type(operands, results)
   }];
 
@@ -3102,13 +3101,13 @@ def StableHLO_ReduceWindowOp: StableHLO_Op<"reduce_window", [
   let arguments = (ins
     Variadic<HLO_Tensor>:$inputs /*reduce_window_i1*/,
     Variadic<HLO_Tensor>:$init_values /*reduce_window_i2*/,
-    GenericDenseI64ArrayAttr:$window_dimensions /*reduce_window_i3*/,
+    DenseI64ArrayAttr:$window_dimensions /*reduce_window_i3*/,
     // If strides or dilations attributes are missing then the default value is
     // one for each of the operand dimensions. Similarly, padding values are zero
     // for both low and high in each of the dimensions, if not specified.
-    OptionalAttr<GenericDenseI64ArrayAttr>:$window_strides /*reduce_window_i4*/,
-    OptionalAttr<GenericDenseI64ArrayAttr>:$base_dilations /*reduce_window_i5*/,
-    OptionalAttr<GenericDenseI64ArrayAttr>:$window_dilations /*reduce_window_i6*/,
+    OptionalAttr<DenseI64ArrayAttr>:$window_strides /*reduce_window_i4*/,
+    OptionalAttr<DenseI64ArrayAttr>:$base_dilations /*reduce_window_i5*/,
+    OptionalAttr<DenseI64ArrayAttr>:$window_dilations /*reduce_window_i6*/,
     OptionalAttr<I64ElementsAttr>:$padding /*reduce_window_i7*/
   );
 
@@ -3530,10 +3529,10 @@ def StableHLO_DynamicConvOp : StableHLO_Op<"dynamic_conv",
        HLO_Tensor:$lhs, /*dynamic_conv_i1*/
        HLO_Tensor:$rhs, /*dynamic_conv_i2*/
        HLO_Static2DIntTensor:$padding, /*dynamic_conv_i3*/
-       OptionalAttr<GenericDenseI64ArrayAttr>:$window_strides, /*dynamic_conv_i4*/
-       OptionalAttr<GenericDenseI64ArrayAttr>:$lhs_dilation, /*dynamic_conv_i5*/
-       OptionalAttr<GenericDenseI64ArrayAttr>:$rhs_dilation, /*dynamic_conv_i6*/
-       OptionalAttr<GenericDenseBoolArrayAttr>:$window_reversal, /*dynamic_conv_i7*/
+       OptionalAttr<DenseI64ArrayAttr>:$window_strides, /*dynamic_conv_i4*/
+       OptionalAttr<DenseI64ArrayAttr>:$lhs_dilation, /*dynamic_conv_i5*/
+       OptionalAttr<DenseI64ArrayAttr>:$rhs_dilation, /*dynamic_conv_i6*/
+       OptionalAttr<DenseBoolArrayAttr>:$window_reversal, /*dynamic_conv_i7*/
        StableHLO_ConvDimensionNumbers:$dimension_numbers, /*dynamic_conv_i8...dynamic_conv_i16*/
        I64Attr:$feature_group_count, /*dynamic_conv_i17*/
        I64Attr:$batch_group_count, /*dynamic_conv_i18*/

--- a/stablehlo/transforms/StablehloAggressiveSimplification.cpp
+++ b/stablehlo/transforms/StablehloAggressiveSimplification.cpp
@@ -819,9 +819,9 @@ struct UnusedResultReduceOpCanon final
       newInitVals.push_back(op.getOperand(i + numOperandPairs));
     }
 
-    auto newOp = rewriter.create<ReduceOp>(
-        op.getLoc(), newInputs, newInitVals,
-        cast<DenseI64ArrayAttr>(op.getDimensionsAttr()), newElementTypes);
+    auto newOp =
+        rewriter.create<ReduceOp>(op.getLoc(), newInputs, newInitVals,
+                                  op.getDimensionsAttr(), newElementTypes);
     Block *newReducerBlock = rewriter.createBlock(&newOp.getBody());
 
     IRMapping mapper;


### PR DESCRIPTION
Several hacks/patches were put in place to preserve StableHLO compatibility for PJRT plugins.

Recently PJRT was switched to send VHLO, meaning we can clean up all these patch fixes.

Closes #2216