### PR TITLE
Don't apply `stablehlo-legalize-to-linalg` pass on ModuelOp.

### DIFF
--- a/stablehlo/conversions/linalg/transforms/Passes.td
+++ b/stablehlo/conversions/linalg/transforms/Passes.td
@@ -20,7 +20,7 @@ limitations under the License.
 include "mlir/Pass/PassBase.td"
 
 def StablehloLegalizeToLinalgPass
-    : Pass<"stablehlo-legalize-to-linalg", "mlir::ModuleOp"> {
+    : Pass<"stablehlo-legalize-to-linalg"> {
   let summary = "Legalize StableHLO to LinAlg";
   let dependentDialects = [
     "mlir::bufferization::BufferizationDialect",


### PR DESCRIPTION
Anchoring `stablehlo-legalize-to-linalg` on ModuleOp doesn't serve any specific purpose at this point. However, this makes it difficult to use this pass in any way for downstream stablehlo users. This change removes ModuleOp anchor from `stablehlo-legalize-to-linalg` pass.