### PR TITLE
Add convenience method to CustomCallOp for checking empty backend config

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -518,6 +518,16 @@ mlir::Attribute CustomCallOp::getBackendConfigOrDefault() {
   return StringAttr::get(getContext(), "");
 }
 
+// Returns if the backend config is unset, or if empty dict / string attribute.
+bool CustomCallOp::hasEmptyBackendConfig() {
+  if (!getBackendConfig().has_value()) return true;
+  Attribute backendConfig = getBackendConfigOrDefault();
+  if (auto strAttr = dyn_cast<StringAttr>(backendConfig)) {
+    return strAttr.empty();
+  }
+  return cast<DictionaryAttr>(backendConfig).empty();
+}
+
 //===----------------------------------------------------------------------===//
 // CholeskyOp
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2389,6 +2389,7 @@ def StableHLO_CustomCallOp: StableHLO_Op<"custom_call",
 
   let extraClassDeclaration = commonClassDeclaration # [{
     mlir::Attribute getBackendConfigOrDefault();
+    bool hasEmptyBackendConfig();
   }];
 }
 


### PR DESCRIPTION
This logic is used many times in openxla/xla, so decided to turn it into a method