### PR TITLE
Implement Dot Algorithms RFC

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2613,14 +2613,14 @@ TODO: Create an XLA doc which details supported combinations of algorithms.
 | (I4)  | `rhs_batching_dimensions`      | 1-dimensional tensor constant of type `si64`                 | (C1), (C4), (C7), (C9)                         |
 | (I5)  | `lhs_contracting_dimensions`   | 1-dimensional tensor constant of type `si64`                 | (C2), (C3), (C6), (C10)                        |
 | (I6)  | `rhs_contracting_dimensions`   | 1-dimensional tensor constant of type `si64`                 | (C2), (C4), (C8), (C10), (C16)                 |
-| (I7)  | `precision_config`             | variadic number of enums of `DEFAULT`, `HIGH`, and `HIGHEST` | (C11)                                          |
-| (I8)  | `lhs_precision_type`           | FloatType or TensorFloat32                                   |                                                |
-| (I9)  | `rhs_precision_type`           | FloatType or TensorFloat32                                   |                                                |
-| (I10) | `accumulation_type`            | FloatType or TensorFloat32                                   |                                                |
-| (I11) | `lhs_component_count`          | constant of type `si32`                                      | (C21)                                          |
-| (I12) | `rhs_component_count`          | constant of type `si32`                                      | (C22)                                          |
-| (I13) | `num_primitive_operations`     | constant of type `si32`                                      | (C23)                                          |
-| (I14) | `allow_imprecise_accumulation` | constant of type `bool`                                      |                                                |
+| (I7)  | `precision_config`             | variadic number of enums of `DEFAULT`, `HIGH`, and `HIGHEST` | (C11), (C21)                                   |
+| (I8)  | `lhs_precision_type`           | FloatType or TensorFloat32                                   | (C21)                                          |
+| (I9)  | `rhs_precision_type`           | FloatType or TensorFloat32                                   | (C21)                                          |
+| (I10) | `accumulation_type`            | FloatType or TensorFloat32                                   | (C21)                                          |
+| (I11) | `lhs_component_count`          | constant of type `si32`                                      | (C21), (C22)                                   |
+| (I12) | `rhs_component_count`          | constant of type `si32`                                      | (C21), (C23)                                   |
+| (I13) | `num_primitive_operations`     | constant of type `si32`                                      | (C21), (C24)                                   |
+| (I14) | `allow_imprecise_accumulation` | constant of type `bool`                                      | (C21)                                          |
 
 
 #### Outputs
@@ -2661,13 +2661,14 @@ TODO: Create an XLA doc which details supported combinations of algorithms.
       `is_per_tensor_quantized(result)`.
   * If `!is_quantized(lhs)`:
     * (C20) `element_type(lhs) = expressed_type(rhs) = element_type(result)`.
-* (C21) `0 < lhs_component_count`
-* (C22) `0 < rhs_component_count`
-* (C23) `0 < num_primitive_operations`
-* (C24) If `precision_config... != DEFAULT`,
+
+* (C21) If `precision_config... != DEFAULT`,
   then `lhs_precision_type = rhs_precision_type = accumulation_type = element_type(lhs)`
   and `lhs_component_count = rhs_component_count = num_primitive_operations = 1`
   and `allow_imprecise_accumulation = false`.
+* (C22) `0 < lhs_component_count`
+* (C23) `0 < rhs_component_count`
+* (C24) `0 < num_primitive_operations`
 
 #### Examples
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2598,7 +2598,10 @@ Example `DotAlgorithm` attributes:
 In general, it is not guaranteed that the each algorithm is supported on each
 accelerator type by the consumer of the StableHLO. If a given algorithm is not
 supported, an error should be raised as opposed to falling back to an
-alternative.
+alternative. StableHLO verification will prevent some combinations that are not
+known to be supported on any hardware.
+
+TODO: Create an XLA doc which details supported combinations of algorithms.
 
 #### Inputs
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2622,7 +2622,6 @@ TODO: Create an XLA doc which details supported combinations of algorithms.
 | (I13) | `num_primitive_operations`     | constant of type `si32`                                      | (C21), (C24)                                   |
 | (I14) | `allow_imprecise_accumulation` | constant of type `bool`                                      | (C21)                                          |
 
-
 #### Outputs
 
 | Name     | Type                       | Constraints             |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -247,6 +247,7 @@ SignedIntegerType ::= 'si2' | 'si4' | 'si8' | 'si16' | 'si32' | 'si64'
 UnsignedIntegerType ::= 'ui2' | 'ui4' | 'ui8' | 'ui16' | 'ui32' | 'ui64'
 FloatType ::= 'f8E4M3FN' | 'f8E5M2' | 'f8E4M3FNUZ' | 'f8E5M2FNUZ'
             | 'f8E4M3B11FNUZ' | 'bf16' | 'f16' | 'f32' | 'f64'
+TensorFloat32 ::= 'tf32'
 ComplexType ::= 'complex' '<' ComplexElementType '>'
 ComplexElementType ::= 'f32' | 'f64'
 ```
@@ -278,7 +279,9 @@ values of type `tensor<T>`).
   * `f16`, `f32` and `f64` types corresponding to respectively
     `binary16` ("half precision"), `binary32` ("single precision") and
     `binary64` ("double precision") formats described in
-  [the IEEE 754 standard](https://ieeexplore.ieee.org/document/8766229).
+    [the IEEE 754 standard](https://ieeexplore.ieee.org/document/8766229).
+  * `tf32` type corresponds to the [TensorFloat32 format](https://blogs.nvidia.com/blog/tensorfloat-32-precision-format/)
+    and has limited support in StableHLO.
 * **Complex types** represent complex values that have a **real part**
   and an **imaginary part** of the same **element type**. Supported complex
   types are `complex<f32>` (both parts are of type `f32`) and `complex<f64>`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2553,6 +2553,7 @@ defined. As such, all dot algorithm fields may be set to `None` to specify an
 empty dot algorithm, which will instead use the `precision_config` value.
 
 `DotAlgorithm` fields include:
+
 * `lhs_precision_type` and `rhs_precision_type`, the precisions that the LHS and
   RHS of the operation are rounded to. Precision types are independent from the
   storage types of the inputs and the output.
@@ -2605,7 +2606,7 @@ general, it is not guaranteed that each algorithm is supported on each
 accelerator type by the consumer of the StableHLO. If a given algorithm is not
 supported, an error should be raised as opposed to falling back to an
 alternative. StableHLO verification will provide best effort verification,
-preventing algorithms that are not known to be supported on _any_ hardware.
+preventing algorithms that are not known to be supported on *any* hardware.
 
 See [`xla_data.proto > Algorithm`](https://github.com/openxla/xla/blob/e8a707554de6b3d6bfd891583a81ff7020a97b54/xla/xla_data.proto#L1022)
 for some supported algorithm values. Ticket #2483 captures the plan to create a
@@ -2668,8 +2669,9 @@ centralized doc on supported algorithms by backend.
       `is_per_tensor_quantized(result)`.
   * If `!is_quantized(lhs)`:
     * (C20) `element_type(lhs) = expressed_type(rhs) = element_type(result)`.
-* If `!is_empty_algorithm(lhs_precision_type, rhs_precision_type, accumulation_type, lhs_component_count, rhs_component_count, num_primitive_operations allow_imprecise_accumulation)`,
-  then:
+* If `!is_empty_algorithm(lhs_precision_type, rhs_precision_type,
+  accumulation_type, lhs_component_count, rhs_component_count,
+  num_primitive_operations allow_imprecise_accumulation)`:
   * (C21) `precision_config... = DEFAULT`.
   * (C22) `0 < lhs_component_count`.
   * (C23) `0 < rhs_component_count`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2611,9 +2611,9 @@ alternative.
 | (I5)  | `lhs_contracting_dimensions`   | 1-dimensional tensor constant of type `si64`                 | (C2), (C3), (C6), (C10)                        |
 | (I6)  | `rhs_contracting_dimensions`   | 1-dimensional tensor constant of type `si64`                 | (C2), (C4), (C8), (C10), (C16)                 |
 | (I7)  | `precision_config`             | variadic number of enums of `DEFAULT`, `HIGH`, and `HIGHEST` | (C11)                                          |
-| (I8)  | `lhs_precision_type`           | TensorElementType or TensorFloat32                           |                                                |
-| (I9)  | `rhs_precision_type`           | TensorElementType or TensorFloat32                           |                                                |
-| (I10) | `accumulation_type`            | TensorElementType or TensorFloat32                           |                                                |
+| (I8)  | `lhs_precision_type`           | FloatType or TensorFloat32                                   |                                                |
+| (I9)  | `rhs_precision_type`           | FloatType or TensorFloat32                                   |                                                |
+| (I10) | `accumulation_type`            | FloatType or TensorFloat32                                   |                                                |
 | (I11) | `lhs_component_count`          | constant of type `si32`                                      | (C21)                                          |
 | (I12) | `rhs_component_count`          | constant of type `si32`                                      | (C22)                                          |
 | (I13) | `num_primitive_operations`     | constant of type `si32`                                      | (C23)                                          |

--- a/stablehlo/conversions/linalg/tests/dot-product.mlir
+++ b/stablehlo/conversions/linalg/tests/dot-product.mlir
@@ -369,3 +369,14 @@ func.func @not_simple_dot_general(
 // CHECK-SAME: ins(%[[ARG0]], %[[ARG1]] : tensor<2x3x3xf32>, tensor<3x?xf32>)
 // CHECK-SAME: outs({{.*}} : tensor<2x3x?xf32>)
 // CHECK-SAME: {someattr}
+
+// -----
+
+func.func @dot_general_algorithm(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
+  // CHECK: stablehlo.dot_general
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
+    dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>],
+    algorithm = #stablehlo.dot_algorithm<lhs_precision_type = tf32, rhs_precision_type = tf32, accumulation_type = f32, lhs_component_count = 1, rhs_component_count = 1, num_primitive_operations = 1, allow_imprecise_accumulation = false>
+  }> : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>  return %0 : tensor<2x2x2xi64>
+}

--- a/stablehlo/conversions/linalg/tests/dot-product.mlir
+++ b/stablehlo/conversions/linalg/tests/dot-product.mlir
@@ -378,5 +378,6 @@ func.func @dot_general_algorithm(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi
     dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
     precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>],
     algorithm = #stablehlo.dot_algorithm<lhs_precision_type = tf32, rhs_precision_type = tf32, accumulation_type = f32, lhs_component_count = 1, rhs_component_count = 1, num_primitive_operations = 1, allow_imprecise_accumulation = false>
-  }> : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>  return %0 : tensor<2x2x2xi64>
+  }> : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64> 
+  return %0 : tensor<2x2x2xi64>
 }

--- a/stablehlo/conversions/linalg/tests/dot-product.mlir
+++ b/stablehlo/conversions/linalg/tests/dot-product.mlir
@@ -378,6 +378,6 @@ func.func @dot_general_algorithm(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi
     dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
     precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>],
     algorithm = #stablehlo.dot_algorithm<lhs_precision_type = tf32, rhs_precision_type = tf32, accumulation_type = f32, lhs_component_count = 1, rhs_component_count = 1, num_primitive_operations = 1, allow_imprecise_accumulation = false>
-  }> : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64> 
+  }> : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>
   return %0 : tensor<2x2x2xi64>
 }

--- a/stablehlo/conversions/linalg/transforms/StablehloToLinalgDotProduct.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloToLinalgDotProduct.cpp
@@ -142,9 +142,12 @@ struct DotGeneralBatchMatMulOpConversion final
   LogicalResult matchAndRewrite(
       mlir::stablehlo::DotGeneralOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
-    if (op.getType().getRank() != 3) {
+    if (op.getType().getRank() != 3)
       return rewriter.notifyMatchFailure(op, "expected a batch matmul");
-    }
+
+    if (op.getAlgorithm().has_value())
+      return rewriter.notifyMatchFailure(
+          op, "dot algorithms not yet supported in linalg conversion");
 
     mlir::stablehlo::DotDimensionNumbersAttr dimNumbers =
         op.getDotDimensionNumbers();
@@ -196,6 +199,10 @@ struct DotGeneralOpConversion final
   LogicalResult matchAndRewrite(
       mlir::stablehlo::DotGeneralOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const final {
+    if (op.getAlgorithm().has_value())
+      return rewriter.notifyMatchFailure(
+          op, "dot algorithms not yet supported in linalg conversion");
+
     if (op.isSimpleDot()) {
       if (succeeded(lowerDotOp<DotGeneralOp, linalg::MatmulOp>(
               rewriter, getTypeConverter(), op, adaptor)))

--- a/stablehlo/dialect/StablehloAttrs.td
+++ b/stablehlo/dialect/StablehloAttrs.td
@@ -53,6 +53,32 @@ def StableHLO_GatherDimensionNumbers : AttrDef<StableHLO_Dialect, "GatherDimensi
   let hasCustomAssemblyFormat = 1;
 }
 
+def StableHLO_DotAlgorithm : AttrDef<StableHLO_Dialect, "DotAlgorithm"> {
+  let mnemonic = "dot_algorithm";
+  let summary = "Attribute that models the algorithm constraints to use for computing dot.";
+  let parameters = (ins
+      "Type":$lhsPrecisionType,
+      "Type":$rhsPrecisionType,
+      "Type":$accumulationType,
+      "int64_t":$lhsComponentCount,
+      "int64_t":$rhsComponentCount,
+      "int64_t":$numPrimitiveOperations,
+      "bool":$allowImpreciseAccumulation
+  );
+  let assemblyFormat = [{
+    `<`
+      `lhs_precision_type` `=` $lhsPrecisionType `,`
+      `rhs_precision_type` `=` $rhsPrecisionType `,`
+      `accumulation_type` `=` $accumulationType `,`
+      `lhs_component_count` `=` $lhsComponentCount `,`
+      `rhs_component_count` `=` $rhsComponentCount `,`
+      `num_primitive_operations` `=` $numPrimitiveOperations `,`
+      `allow_imprecise_accumulation` `=` $allowImpreciseAccumulation
+    `>`
+  }];
+  //TODO: Gen verifier decl
+}
+
 def StableHLO_DotDimensionNumbers : AttrDef<StableHLO_Dialect, "DotDimensionNumbers"> {
   let mnemonic = "dot";
   let summary = "Attribute that models the dimension information for dot.";

--- a/stablehlo/dialect/StablehloAttrs.td
+++ b/stablehlo/dialect/StablehloAttrs.td
@@ -76,7 +76,7 @@ def StableHLO_DotAlgorithm : AttrDef<StableHLO_Dialect, "DotAlgorithm"> {
       `allow_imprecise_accumulation` `=` $allowImpreciseAccumulation
     `>`
   }];
-  //TODO: Gen verifier decl
+  let genVerifyDecl = 1;
 }
 
 def StableHLO_DotDimensionNumbers : AttrDef<StableHLO_Dialect, "DotDimensionNumbers"> {

--- a/stablehlo/dialect/StablehloBytecode.cpp
+++ b/stablehlo/dialect/StablehloBytecode.cpp
@@ -169,6 +169,17 @@ enum AttributeCode {
   ///     operandTupleIndices: svarint[]
   ///   }
   kOutputOperandAlias = 14,
+
+  ///   DotAlgorithmAttr {
+  ///     lhsPrecisionType : Type
+  ///     rhsPrecisionType : Type
+  ///     accumulationType : Type
+  ///     lhsComponentCount: svarint
+  ///     rhsComponentCount : svarint,
+  ///     numPrimitiveOperations : svarint
+  ///     allowImpreciseAccumulation : svarint
+  ///   }
+  kDotAlgorithmAttr = 15,
 };
 
 /// This enum contains marker codes used to indicate which type is
@@ -221,6 +232,7 @@ class StablehloBytecodeInterface : public BytecodeDialectInterface {
       DialectBytecodeReader &reader) const;
   ConvDimensionNumbersAttr readConvDimensionNumbersAttr(
       DialectBytecodeReader &reader) const;
+  DotAlgorithmAttr readDotAlgorithmAttr(DialectBytecodeReader &reader) const;
   DotDimensionNumbersAttr readDotDimensionNumbersAttr(
       DialectBytecodeReader &reader) const;
   FftTypeAttr readFftTypeAttr(DialectBytecodeReader &reader) const;
@@ -245,6 +257,7 @@ class StablehloBytecodeInterface : public BytecodeDialectInterface {
   void write(ComparisonTypeAttr attr, DialectBytecodeWriter &writer) const;
   void write(ConvDimensionNumbersAttr attr,
              DialectBytecodeWriter &writer) const;
+  void write(DotAlgorithmAttr attr, DialectBytecodeWriter &writer) const;
   void write(DotDimensionNumbersAttr attr, DialectBytecodeWriter &writer) const;
   void write(FftTypeAttr attr, DialectBytecodeWriter &writer) const;
   void write(GatherDimensionNumbersAttr attr,
@@ -302,6 +315,8 @@ Attribute StablehloBytecodeInterface::readAttribute(
       return readComparisonTypeAttr(reader);
     case stablehlo_encoding::kConvDimensionNumbersAttr:
       return readConvDimensionNumbersAttr(reader);
+    case stablehlo_encoding::kDotAlgorithmAttr:
+      return readDotAlgorithmAttr(reader);
     case stablehlo_encoding::kDotDimensionNumbers:
       return readDotDimensionNumbersAttr(reader);
     case stablehlo_encoding::kFftTypeAttr:
@@ -335,14 +350,15 @@ LogicalResult StablehloBytecodeInterface::writeAttribute(
     Attribute attr, DialectBytecodeWriter &writer) const {
   return TypeSwitch<Attribute, LogicalResult>(attr)
       .Case<ChannelHandleAttr, ComparisonDirectionAttr, ComparisonTypeAttr,
-            ConvDimensionNumbersAttr, DotDimensionNumbersAttr, FftTypeAttr,
-            GatherDimensionNumbersAttr, OutputOperandAliasAttr, PrecisionAttr,
-            RngAlgorithmAttr, RngDistributionAttr, ScatterDimensionNumbersAttr,
-            TransposeAttr, TypeExtensionsAttr>([&](auto attr) {
-        LOG_WRITE_CALL;
-        write(attr, writer);
-        return success();
-      })
+            ConvDimensionNumbersAttr, DotAlgorithmAttr, DotDimensionNumbersAttr,
+            FftTypeAttr, GatherDimensionNumbersAttr, OutputOperandAliasAttr,
+            PrecisionAttr, RngAlgorithmAttr, RngDistributionAttr,
+            ScatterDimensionNumbersAttr, TransposeAttr, TypeExtensionsAttr>(
+          [&](auto attr) {
+            LOG_WRITE_CALL;
+            write(attr, writer);
+            return success();
+          })
       .Default([&](Attribute) {
         LOG_NOT_IMPLEMENTED;
         return failure();
@@ -450,6 +466,43 @@ void StablehloBytecodeInterface::write(ConvDimensionNumbersAttr attr,
   writer.writeSignedVarInt(attr.getOutputBatchDimension());
   writer.writeSignedVarInt(attr.getOutputFeatureDimension());
   writer.writeSignedVarInts(attr.getOutputSpatialDimensions());
+}
+
+//===----------------------------------------------------------------------===//
+// DotAlgorithmAttr
+
+DotAlgorithmAttr StablehloBytecodeInterface::readDotAlgorithmAttr(
+    DialectBytecodeReader &reader) const {
+  LOG_READ_CALL;
+  Type lhsPrecisionType, rhsPrecisionType, accumulationType;
+  int64_t lhsComponentCount, rhsComponentCount, numPrimitiveOperations;
+  bool allowImpreciseAccumulation;
+
+  if (failed(reader.readType(lhsPrecisionType)) ||
+      failed(reader.readType(rhsPrecisionType)) ||
+      failed(reader.readType(accumulationType)) ||
+      failed(reader.readSignedVarInt(lhsComponentCount)) ||
+      failed(reader.readSignedVarInt(rhsComponentCount)) ||
+      failed(reader.readSignedVarInt(numPrimitiveOperations)) ||
+      failed(reader.readBool(allowImpreciseAccumulation)))
+    return DotAlgorithmAttr();
+
+  return DotAlgorithmAttr::get(getContext(), lhsPrecisionType, rhsPrecisionType,
+                               accumulationType, lhsComponentCount,
+                               rhsComponentCount, numPrimitiveOperations,
+                               allowImpreciseAccumulation);
+}
+
+void StablehloBytecodeInterface::write(DotAlgorithmAttr attr,
+                                       DialectBytecodeWriter &writer) const {
+  writer.writeVarInt(stablehlo_encoding::kDotAlgorithmAttr);
+  writer.writeType(attr.getLhsPrecisionType());
+  writer.writeType(attr.getRhsPrecisionType());
+  writer.writeType(attr.getAccumulationType());
+  writer.writeSignedVarInt(attr.getLhsComponentCount());
+  writer.writeSignedVarInt(attr.getRhsComponentCount());
+  writer.writeSignedVarInt(attr.getNumPrimitiveOperations());
+  writer.writeOwnedBool(attr.getAllowImpreciseAccumulation());
 }
 
 //===----------------------------------------------------------------------===//

--- a/stablehlo/dialect/StablehloBytecode.cpp
+++ b/stablehlo/dialect/StablehloBytecode.cpp
@@ -174,7 +174,7 @@ enum AttributeCode {
   ///     lhsPrecisionType : Type
   ///     rhsPrecisionType : Type
   ///     accumulationType : Type
-  ///     lhsComponentCount: svarint
+  ///     lhsComponentCount : svarint
   ///     rhsComponentCount : svarint,
   ///     numPrimitiveOperations : svarint
   ///     allowImpreciseAccumulation : svarint

--- a/stablehlo/dialect/StablehloEnums.td
+++ b/stablehlo/dialect/StablehloEnums.td
@@ -44,8 +44,7 @@ def StableHLO_PrecisionAttr : EnumAttr<StableHLO_Dialect, StableHLO_Precision, "
 
 // TODO(b/129153247) See if it's possible to also validate the size.
 def StableHLO_PrecisionConfigAttr:
-    OptionalAttr<
-          TypedArrayAttrBase<StableHLO_PrecisionAttr, "Precision Config attribute">>;
+  TypedArrayAttrBase<StableHLO_PrecisionAttr, "Precision Config attribute">;
 
 //===----------------------------------------------------------------------===//
 // Fast Fourier Transform Type enum definitions.

--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -599,13 +599,20 @@ ParseResult parsePrecisionConfig(OpAsmParser& parser, mlir::ArrayAttr& attr) {
 //===----------------------------------------------------------------------===//
 
 LogicalResult DotGeneralOp::verify() {
+  bool isDefaultPrecisionConfig =
+      !getPrecisionConfig().has_value() ||
+      llvm::all_of(getPrecisionConfig().value(), [](Attribute attr) {
+        return cast<PrecisionAttr>(attr).getValue() == Precision::DEFAULT;
+      });
+  bool hasAlgorithmSpecified = getAlgorithm().has_value();
   return hlo::verifyDotGeneralOp(
       getLoc(), getLhs(), getRhs(),
       getDotDimensionNumbersAttr().getLhsBatchingDimensions(),
       getDotDimensionNumbersAttr().getRhsBatchingDimensions(),
       getDotDimensionNumbersAttr().getLhsContractingDimensions(),
       getDotDimensionNumbersAttr().getRhsContractingDimensions(),
-      getPrecisionConfig(), getResult());
+      getPrecisionConfig(), isDefaultPrecisionConfig, hasAlgorithmSpecified,
+      getResult());
 }
 
 LogicalResult DotGeneralOp::reifyReturnTypeShapes(

--- a/stablehlo/dialect/StablehloOps.td
+++ b/stablehlo/dialect/StablehloOps.td
@@ -2304,7 +2304,7 @@ def StableHLO_ConvolutionOp : StableHLO_Op<"convolution",
     StableHLO_ConvDimensionNumbers:$dimension_numbers, /*convolution_i8...convolution_i16*/
     ConfinedAttr<I64Attr, [IntPositive]>:$feature_group_count, /*convolution_c21, convolution_i17*/
     ConfinedAttr<I64Attr, [IntPositive]>:$batch_group_count, /*convolution_c22, convolution_i18*/
-    StableHLO_PrecisionConfigAttr:$precision_config /*convolution_i19*/
+    OptionalAttr<StableHLO_PrecisionConfigAttr>:$precision_config /*convolution_i19*/
   );
 
   let results = (outs HLO_TensorOrPerAxisQuantizedTensor);
@@ -2437,7 +2437,7 @@ def StableHLO_DotOp: StableHLO_Op<"dot", [Pure]> {
   let arguments = (
     ins HLO_Tensor:$lhs,
     HLO_TensorOrPerAxisQuantizedTensor:$rhs,
-    StableHLO_PrecisionConfigAttr:$precision_config
+    OptionalAttr<StableHLO_PrecisionConfigAttr>:$precision_config
   );
   let results = (outs HLO_TensorOrPerAxisQuantizedTensor);
   let hasVerifier = 1;
@@ -2464,7 +2464,8 @@ def StableHLO_DotGeneralOp: StableHLO_ShapedInterfaceOp<"dot_general",
     %result = stablehlo.dot_general %lhs, %rhs,
       batching_dims = [0] x [0],
       contracting_dims = [2] x [1],
-      precision = [DEFAULT, DEFAULT]
+      precision = [DEFAULT, DEFAULT],
+      algorithm = <lhs_precision_type = tf32, rhs_precision_type = tf32, accumulation_type = f32, lhs_component_count = 1, rhs_component_count = 1, num_primitive_operations = 1, allow_imprecise_accumulation = false>
       : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>
     ```
   }];
@@ -2472,7 +2473,8 @@ def StableHLO_DotGeneralOp: StableHLO_ShapedInterfaceOp<"dot_general",
     HLO_Tensor:$lhs /*dot_general_i1*/,
     HLO_TensorOrPerAxisQuantizedTensor:$rhs /*dot_general_i2*/,
     StableHLO_DotDimensionNumbers:$dot_dimension_numbers /*dot_general_i3, dot_general_i4, dot_general_i5, dot_general_i6*/,
-    StableHLO_PrecisionConfigAttr:$precision_config /*dot_general_i7*/
+    OptionalAttr<StableHLO_PrecisionConfigAttr>:$precision_config /*dot_general_i7*/,
+    OptionalAttr<StableHLO_DotAlgorithm>:$algorithm
   );
 
   let results = (outs HLO_TensorOrPerAxisQuantizedTensor);
@@ -2481,7 +2483,7 @@ def StableHLO_DotGeneralOp: StableHLO_ShapedInterfaceOp<"dot_general",
   // Use empty `` to prevent extra whitespace before precision config.
   let assemblyFormat = [{
     $lhs `,` $rhs `,` custom<DotDimensionNumbers>($dot_dimension_numbers) ``
-    custom<PrecisionConfig>($precision_config) attr-dict
+    custom<PrecisionConfig>($precision_config) (`,` `algorithm` `=` $algorithm^)? attr-dict
       `:` functional-type(operands, results)
   }];
 
@@ -3575,7 +3577,7 @@ def StableHLO_DynamicConvOp : StableHLO_Op<"dynamic_conv",
        StableHLO_ConvDimensionNumbers:$dimension_numbers, /*dynamic_conv_i8...dynamic_conv_i16*/
        ConfinedAttr<I64Attr, [IntPositive]>:$feature_group_count, /*dynamic_conv_c21, dynamic_conv_i17*/
        ConfinedAttr<I64Attr, [IntPositive]>:$batch_group_count, /*dynamic_conv_c22, dynamic_conv_i18*/
-       StableHLO_PrecisionConfigAttr:$precision_config /*dynamic_conv_i19*/
+       OptionalAttr<StableHLO_PrecisionConfigAttr>:$precision_config /*dynamic_conv_i19*/
     );
   let results = (outs HLO_Tensor);
   let hasVerifier = 1;

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -4037,7 +4037,7 @@ LogicalResult verifyDotGeneralOp(std::optional<Location> location, Value lhs,
         location, "inferred shape '", dimSizesToString(inferredShape.getDims()),
         "' ", "is incompatible with return type of operation ", resultType, "");
 
-  // dot_general_c24
+  // dot_general_c21
   if (!isDefaultPrecisionConfig && hasAlgorithmSpecified)
     return emitOptionalError(
         location,
@@ -4075,13 +4075,13 @@ LogicalResult verifyDotAlgorithmAttr(
   // dot_general_i10
   if (!isValidType(accumulationType))
     return emitError() << "accumulation type must be float";
-  // dot_general_c21
+  // dot_general_c22
   if (lhsComponentCount < 1)
     return emitError() << "lhs component count must be positive";
-  // dot_general_c22
+  // dot_general_c23
   if (rhsComponentCount < 1)
     return emitError() << "rhs component count must be positive";
-  // dot_general_c23
+  // dot_general_c24
   if (numPrimitiveOperations < 1)
     return emitError() << "num primitive operations must be positive";
   return success();

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -456,7 +456,8 @@ LogicalResult verifyDotGeneralOp(std::optional<Location> location, Value lhs,
                                  ArrayRef<int64_t> lhsContractingDimensions,
                                  ArrayRef<int64_t> rhsContractingDimensions,
                                  std::optional<ArrayAttr> precisionConfig,
-                                 Value result);
+                                 bool isDefaultPrecisionConfig,
+                                 bool hasAlgorithmSpecified, Value result);
 
 LogicalResult verifyDynamicBroadcastInDimOp(
     std::optional<Location> location, Value operand, Value outputDimensions,

--- a/stablehlo/dialect/TypeInference.h
+++ b/stablehlo/dialect/TypeInference.h
@@ -459,6 +459,12 @@ LogicalResult verifyDotGeneralOp(std::optional<Location> location, Value lhs,
                                  bool isDefaultPrecisionConfig,
                                  bool hasAlgorithmSpecified, Value result);
 
+LogicalResult verifyDotAlgorithmAttr(
+    ::llvm::function_ref<InFlightDiagnostic()> emitError, Type lhsPrecisionType,
+    Type rhsPrecisionType, Type accumulationType, int64_t lhsComponentCount,
+    int64_t rhsComponentCount, int64_t numPrimitiveOperations,
+    bool allowImpreciseAccumulation);
+
 LogicalResult verifyDynamicBroadcastInDimOp(
     std::optional<Location> location, Value operand, Value outputDimensions,
     ArrayRef<int64_t> broadcastDimensions,

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -28,6 +28,8 @@ limitations under the License.
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/SmallVectorExtras.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Errc.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -63,6 +65,8 @@ limitations under the License.
 #include "stablehlo/reference/Token.h"
 #include "stablehlo/reference/Types.h"
 #include "stablehlo/reference/Value.h"
+
+#define DEBUG_TYPE "stablehlo-interpreter"
 
 namespace mlir {
 namespace stablehlo {
@@ -609,6 +613,10 @@ SmallVector<InterpreterValue> eval(Region &region,
     } else if (isa<DotOp>(operation)) {
       failOnDecomposableOp(operation);
     } else if (auto op = dyn_cast<DotGeneralOp>(operation)) {
+      LLVM_DEBUG({
+        if (op.getAlgorithm().has_value())
+          llvm::dbgs() << "ignoring dot algorithm constraints in interpreter";
+      });
       auto lhs = scope.findTensor(op.getLhs());
       auto rhs = scope.findTensor(op.getRhs());
       auto lhsBatchingDimensions =

--- a/stablehlo/tests/interpret/dot_general.mlir
+++ b/stablehlo/tests/interpret/dot_general.mlir
@@ -17,6 +17,24 @@ func.func @dot_general_op_test_si64() {
 
 // -----
 
+func.func @dot_general_op_test_algorithm() {
+  %lhs = stablehlo.constant dense<[[[1, 2], [3, 4]],
+                                   [[5, 6], [7, 8]]]> : tensor<2x2x2xi64>
+  %rhs = stablehlo.constant dense<[[[1, 0], [0, 1]],
+                                   [[1, 0], [0, 1]]]> : tensor<2x2x2xi64>
+  %result = stablehlo.dot_general %lhs, %rhs,
+    batching_dims = [0] x [0],
+    contracting_dims = [2] x [1],
+    precision = [DEFAULT, DEFAULT],
+    algorithm = <lhs_precision_type = tf32, rhs_precision_type = tf32, accumulation_type = tf32, lhs_component_count = 1, rhs_component_count = 1, num_primitive_operations = 1, allow_imprecise_accumulation = false>
+    : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>
+  check.expect_eq_const %result, dense<[[[1, 2], [3, 4]],
+                                        [[5, 6], [7, 8]]]> : tensor<2x2x2xi64>
+  func.return
+}
+
+// -----
+
 func.func @dot_general_op_test_empty_dims() {
   %lhs = stablehlo.constant dense<[[1, 2], [3, 4]]> : tensor<2x2xi64>
   %rhs = stablehlo.constant dense<[[1, 0], [0, 1]]> : tensor<2x2xi64>

--- a/stablehlo/tests/interpret/dot_general.mlir
+++ b/stablehlo/tests/interpret/dot_general.mlir
@@ -26,8 +26,15 @@ func.func @dot_general_op_test_algorithm() {
     batching_dims = [0] x [0],
     contracting_dims = [2] x [1],
     precision = [DEFAULT, DEFAULT],
-    algorithm = <lhs_precision_type = tf32, rhs_precision_type = tf32, accumulation_type = tf32, lhs_component_count = 1, rhs_component_count = 1, num_primitive_operations = 1, allow_imprecise_accumulation = false>
-    : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>
+    algorithm = <
+      lhs_precision_type = tf32,
+      rhs_precision_type = tf32,
+      accumulation_type = tf32,
+      lhs_component_count = 1,
+      rhs_component_count = 1,
+      num_primitive_operations = 1,
+      allow_imprecise_accumulation = false
+    > : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>
   check.expect_eq_const %result, dense<[[[1, 2], [3, 4]],
                                         [[5, 6], [7, 8]]]> : tensor<2x2x2xi64>
   func.return

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -3055,6 +3055,17 @@ func.func @dot_general(%arg0: tensor<1x?x1x?xf32>, %arg1: tensor<?x1x?x1x?xf32>)
 
 // -----
 
+// CHECK-LABEL: func @dot_general_algorithm
+func.func @dot_general_algorithm(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
+    dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
+    precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>],
+    algorithm = #stablehlo.dot_algorithm<lhs_precision_type = tf32, rhs_precision_type = tf32, accumulation_type = f32, lhs_component_count = 1, rhs_component_count = 1, num_primitive_operations = 1, allow_imprecise_accumulation = false>
+  }> : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>  return %0 : tensor<2x2x2xi64>
+}
+
+// -----
+
 func.func @dot_general_c1(%arg0: tensor<?x?x?xf32>, %arg1: tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
   // expected-error @+1 {{lhs and rhs should have the same number of batching dimensions}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) {

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -3056,11 +3056,41 @@ func.func @dot_general(%arg0: tensor<1x?x1x?xf32>, %arg1: tensor<?x1x?x1x?xf32>)
 // -----
 
 // CHECK-LABEL: func @dot_general_algorithm
-func.func @dot_general_algorithm(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
+func.func @dot_general_algorithm_tf32(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
   %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
     dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
     precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>],
     algorithm = #stablehlo.dot_algorithm<lhs_precision_type = tf32, rhs_precision_type = tf32, accumulation_type = f32, lhs_component_count = 1, rhs_component_count = 1, num_primitive_operations = 1, allow_imprecise_accumulation = false>
+  }> : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>  return %0 : tensor<2x2x2xi64>
+}
+
+// -----
+
+func.func @dot_general_algorithm_i8(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
+  // expected-error @+3 {{lhs precision type must be float}}
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
+    dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
+    algorithm = #stablehlo.dot_algorithm<lhs_precision_type = i8, rhs_precision_type = f32, accumulation_type = f32, lhs_component_count = 1, rhs_component_count = 1, num_primitive_operations = 1, allow_imprecise_accumulation = false>
+  }> : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>  return %0 : tensor<2x2x2xi64>
+}
+
+// -----
+
+func.func @dot_general_algorithm_i9(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
+  // expected-error @+3 {{rhs precision type must be float}}
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
+    dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
+    algorithm = #stablehlo.dot_algorithm<lhs_precision_type = f32, rhs_precision_type = i8, accumulation_type = f32, lhs_component_count = 1, rhs_component_count = 1, num_primitive_operations = 1, allow_imprecise_accumulation = false>
+  }> : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>  return %0 : tensor<2x2x2xi64>
+}
+
+// -----
+
+func.func @dot_general_algorithm_i10(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
+  // expected-error @+3 {{accumulation type must be float}}
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
+    dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
+    algorithm = #stablehlo.dot_algorithm<lhs_precision_type = f32, rhs_precision_type = f32, accumulation_type = i8, lhs_component_count = 1, rhs_component_count = 1, num_primitive_operations = 1, allow_imprecise_accumulation = false>
   }> : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>  return %0 : tensor<2x2x2xi64>
 }
 
@@ -3288,6 +3318,47 @@ func.func @dot_general_c11(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5xf32>) -
     precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
   } : (tensor<2x3x4xf32>, tensor<2x3x5xf32>) -> tensor<2x4x5xf32>
   func.return %0 : tensor<2x4x5xf32>
+}
+
+// -----
+
+func.func @dot_general_algorithm_c21(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
+  // expected-error@+3 {{lhs component count must be positive}}
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
+    dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
+    algorithm = #stablehlo.dot_algorithm<lhs_precision_type = tf32, rhs_precision_type = tf32, accumulation_type = f32, lhs_component_count = -1, rhs_component_count = 1, num_primitive_operations = 1, allow_imprecise_accumulation = false>
+  }> : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>  return %0 : tensor<2x2x2xi64>
+}
+
+// -----
+
+func.func @dot_general_algorithm_c22(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
+  // expected-error@+3 {{rhs component count must be positive}}
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
+    dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
+    algorithm = #stablehlo.dot_algorithm<lhs_precision_type = tf32, rhs_precision_type = tf32, accumulation_type = f32, lhs_component_count = 1, rhs_component_count = 0, num_primitive_operations = 1, allow_imprecise_accumulation = false>
+  }> : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>  return %0 : tensor<2x2x2xi64>
+}
+
+// -----
+
+func.func @dot_general_algorithm_c23(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
+  // expected-error@+3 {{num primitive operations must be positive}}
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
+    dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
+    algorithm = #stablehlo.dot_algorithm<lhs_precision_type = tf32, rhs_precision_type = tf32, accumulation_type = f32, lhs_component_count = 1, rhs_component_count = 1, num_primitive_operations = 0, allow_imprecise_accumulation = false>
+  }> : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>  return %0 : tensor<2x2x2xi64>
+}
+
+// -----
+
+func.func @dot_general_algorithm_c24(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
+  // expected-error @+1 {{must specify DEFAULT precision config when algorithm is set}}
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
+    dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
+    precision_config = [#stablehlo<precision HIGHEST>, #stablehlo<precision HIGHEST>],
+    algorithm = #stablehlo.dot_algorithm<lhs_precision_type = tf32, rhs_precision_type = tf32, accumulation_type = f32, lhs_component_count = 1, rhs_component_count = 1, num_primitive_operations = 1, allow_imprecise_accumulation = false>
+  }> : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>  return %0 : tensor<2x2x2xi64>
 }
 
 // -----

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -3066,7 +3066,7 @@ func.func @dot_general_algorithm_tf32(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x
 
 // -----
 
-func.func @dot_general_algorithm_i8(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
+func.func @dot_general_i8(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
   // expected-error @+3 {{lhs precision type must be float}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
     dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
@@ -3076,7 +3076,7 @@ func.func @dot_general_algorithm_i8(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x
 
 // -----
 
-func.func @dot_general_algorithm_i9(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
+func.func @dot_general_i9(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
   // expected-error @+3 {{rhs precision type must be float}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
     dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
@@ -3086,7 +3086,7 @@ func.func @dot_general_algorithm_i9(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x
 
 // -----
 
-func.func @dot_general_algorithm_i10(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
+func.func @dot_general_i10(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
   // expected-error @+3 {{accumulation type must be float}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
     dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
@@ -3322,7 +3322,7 @@ func.func @dot_general_c11(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5xf32>) -
 
 // -----
 
-func.func @dot_general_algorithm_c21(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
+func.func @dot_general_c21(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
   // expected-error @+1 {{must specify DEFAULT precision config when algorithm is set}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
     dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
@@ -3333,7 +3333,7 @@ func.func @dot_general_algorithm_c21(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2
 
 // -----
 
-func.func @dot_general_algorithm_c22(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
+func.func @dot_general_c22(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
   // expected-error@+3 {{lhs component count must be positive}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
     dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
@@ -3343,7 +3343,7 @@ func.func @dot_general_algorithm_c22(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2
 
 // -----
 
-func.func @dot_general_algorithm_c23(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
+func.func @dot_general_c23(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
   // expected-error@+3 {{rhs component count must be positive}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
     dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
@@ -3353,7 +3353,7 @@ func.func @dot_general_algorithm_c23(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2
 
 // -----
 
-func.func @dot_general_algorithm_c24(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
+func.func @dot_general_c24(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
   // expected-error@+3 {{num primitive operations must be positive}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
     dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -3323,6 +3323,17 @@ func.func @dot_general_c11(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x5xf32>) -
 // -----
 
 func.func @dot_general_algorithm_c21(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
+  // expected-error @+1 {{must specify DEFAULT precision config when algorithm is set}}
+  %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
+    dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
+    precision_config = [#stablehlo<precision HIGHEST>, #stablehlo<precision HIGHEST>],
+    algorithm = #stablehlo.dot_algorithm<lhs_precision_type = tf32, rhs_precision_type = tf32, accumulation_type = f32, lhs_component_count = 1, rhs_component_count = 1, num_primitive_operations = 1, allow_imprecise_accumulation = false>
+  }> : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>  return %0 : tensor<2x2x2xi64>
+}
+
+// -----
+
+func.func @dot_general_algorithm_c22(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
   // expected-error@+3 {{lhs component count must be positive}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
     dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
@@ -3332,7 +3343,7 @@ func.func @dot_general_algorithm_c21(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2
 
 // -----
 
-func.func @dot_general_algorithm_c22(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
+func.func @dot_general_algorithm_c23(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
   // expected-error@+3 {{rhs component count must be positive}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
     dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
@@ -3342,22 +3353,11 @@ func.func @dot_general_algorithm_c22(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2
 
 // -----
 
-func.func @dot_general_algorithm_c23(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
+func.func @dot_general_algorithm_c24(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
   // expected-error@+3 {{num primitive operations must be positive}}
   %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
     dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
     algorithm = #stablehlo.dot_algorithm<lhs_precision_type = tf32, rhs_precision_type = tf32, accumulation_type = f32, lhs_component_count = 1, rhs_component_count = 1, num_primitive_operations = 0, allow_imprecise_accumulation = false>
-  }> : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>  return %0 : tensor<2x2x2xi64>
-}
-
-// -----
-
-func.func @dot_general_algorithm_c24(%arg0: tensor<2x2x2xi64>, %arg1: tensor<2x2x2xi64>) -> tensor<2x2x2xi64> {
-  // expected-error @+1 {{must specify DEFAULT precision config when algorithm is set}}
-  %0 = "stablehlo.dot_general"(%arg0, %arg1) <{
-    dot_dimension_numbers = #stablehlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
-    precision_config = [#stablehlo<precision HIGHEST>, #stablehlo<precision HIGHEST>],
-    algorithm = #stablehlo.dot_algorithm<lhs_precision_type = tf32, rhs_precision_type = tf32, accumulation_type = f32, lhs_component_count = 1, rhs_component_count = 1, num_primitive_operations = 1, allow_imprecise_accumulation = false>
   }> : (tensor<2x2x2xi64>, tensor<2x2x2xi64>) -> tensor<2x2x2xi64>  return %0 : tensor<2x2x2xi64>
 }
 

--- a/stablehlo/transforms/StablehloLegalizeDeprecatedOpsPatterns.td
+++ b/stablehlo/transforms/StablehloLegalizeDeprecatedOpsPatterns.td
@@ -30,7 +30,6 @@ def GetDefaultDotDimensionNumbers : NativeCodeCall<
 def GetDefaultBroadcastDimensions : NativeCodeCall<
   "getBroadcastDimensionsFromBroadcastSizes(cast<RankedTensorType>($0.getType()), cast<DenseI64ArrayAttr>($1))">;
 
-
 // Here, the element type can be any integer or float type. But, note that only
 // 32 bit integers are supported for the value.
 class GetScalarOfType<int value> : NativeCodeCall<
@@ -48,7 +47,7 @@ def CreateTokenToAfterAll : Pat<
 
 def DotToDotGeneral : Pat<
   (StableHLO_DotOp $lhs, $rhs, $precision_config),
-  (StableHLO_DotGeneralOp $lhs, $rhs, (GetDefaultDotDimensionNumbers $lhs), $precision_config)>;
+  (StableHLO_DotGeneralOp $lhs, $rhs, (GetDefaultDotDimensionNumbers $lhs), $precision_config, (NativeCodeCall<"Attribute{}">))>;
 
 def UnaryEinsumToEinsum : Pat<
   (StableHLO_UnaryEinsumOp $operand, $equation),


### PR DESCRIPTION
Implementation of https://github.com/openxla/stablehlo/pull/2422.

Done:
- Attribute impl
- Spec updates
- Test cases

To-do:
- Create an XLA doc on supported algorithm pairs to link to from spec.
- Compatibility impl, will do this in a child CL to keep review simplified. 

To consider:
- Should we verify algorithms more strictly, so that only algs supported on _some_ hardware are allowed in StableHLO. Expanding support will be trivial, no RFC required, but StableHLO should try to statically enforce as much as possible, why allow nonsense pairs.
- Should dot_general on integers support floating point precision types?

Other cleanup:
- PrecisionConfig is no longer implicitly optional, but all uses are wrapped in `OptionalAttr` now.