### PR TITLE
ExpectCloseOp  : Keep only one `optional-group` in custom assembly

### DIFF
--- a/stablehlo/tests/CheckOps.td
+++ b/stablehlo/tests/CheckOps.td
@@ -150,13 +150,13 @@ def CHECK_ExpectCloseOp :
   let arguments = (ins
       TensorOf<[AnyFloat, AnyComplex]>:$actual,
       TensorOf<[AnyFloat, AnyComplex]>:$expected,
-      DefaultValuedOptionalAttr<UI64Attr, "1">:$max_ulp_difference,
+      DefaultValuedAttr<UI64Attr, "1">:$max_ulp_difference,
       DefaultValuedOptionalAttr<UI64Attr, "0">:$min_ulp_difference
   );
 
   let assemblyFormat = [{
       $actual `,` $expected
-      (`,` `max_ulp_difference` `=` $max_ulp_difference^)?
+      `,` `max_ulp_difference` `=` $max_ulp_difference
       (`,` `min_ulp_difference` `=` $min_ulp_difference^)?
       `:` attr-dict type($actual) `,` type($expected)
     }];


### PR DESCRIPTION
After recent LLVM integrate, optional attributes that have a default value, will not be printed anymore. 
This exposed `ExpectCloseOp` custom assembly parser limitation. It can't handle a scenario of - if `max_ulp_difference` is not printed.

```
if (::mlir::succeeded(parser.parseOptionalComma())) { 
  if (parser.parseKeyword("max_ulp_difference"))
    return ::mlir::failure();
  if (parser.parseEqual()) return ::mlir::failure();
...
}

```

existing parser expects `max_ulp_difference` to be present after `,` which is not the case anymore for test
`check.expect_close %3, %4, max_ulp_difference = 1, min_ulp_difference = 1 : tensor<9xf64>, tensor<9xf64>`
To address this, we will need nested `optional-group`s which results in an error `attribute 'min_ulp_difference' is already bound`

fix- keep only one `optional-group` in custom assembly.

Reviewed, none other stablehlo op has multiple `optional-group`s  in custom assembly.

