### PR TITLE
Fix SortOp interpreter

### DIFF
--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -2435,8 +2435,7 @@ SmallVector<Tensor> sortOp(ArrayRef<Tensor> inputs, Axis dimension,
 
     // After the tensor of handles has been sorted, we apply the results of
     // this sort by reshuffling input elements into result elements.
-    auto &resultsTogether = inputsTogether;
-    for (auto [inputHandle, resultHandle] : llvm::enumerate(resultsTogether)) {
+    for (auto [resultHandle, inputHandle] : llvm::enumerate(inputsTogether)) {
       for (auto [input, result] : llvm::zip(inputs, results)) {
         auto inputIndex = *resultIt;
         auto resultIndex = *resultIt;

--- a/stablehlo/tests/interpret/sort.mlir
+++ b/stablehlo/tests/interpret/sort.mlir
@@ -15,3 +15,16 @@ func.func @sort_stable() {
   check.expect_eq_const %result1, dense<[[1, 2, 1], [3, 2, 3]]> : tensor<2x3xi64>
   func.return
 }
+
+// -----
+
+func.func public @sort() {
+  %input = stablehlo.constant dense<[[0, 1, 1, -3, -3, -2, 0], [4, -1, 3, 0, 4, 0, -3], [1, 0, 0, 0, 0, 2, 3], [-3, -4, -4, -2, 0, 3, 3], [0, 5, 2, -2, 0, -2, 0]]> : tensor<5x7xi64>
+  %result = "stablehlo.sort"(%input) <{dimension = 0 : i64}> ({
+  ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
+    %1 = stablehlo.compare  LT, %arg0, %arg1,  SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    stablehlo.return %1 : tensor<i1>
+  }) : (tensor<5x7xi64>) -> tensor<5x7xi64>
+  check.expect_eq_const %result, dense<[[ -3, -4, -4, -3, -3, -2, -3 ], [ 0, -1, 0, -2, 0, -2, 0 ], [ 0, 0, 1, -2, 0, 0, 0 ], [ 1, 1, 2, 0, 0, 2, 3 ], [ 4, 5, 3, 0, 4, 3, 3 ]]> :  tensor<5x7xi64>
+  func.return
+}

--- a/stablehlo/tests/interpret/sort.mlir
+++ b/stablehlo/tests/interpret/sort.mlir
@@ -18,7 +18,7 @@ func.func @sort_stable() {
 
 // -----
 
-func.func public @sort() {
+func.func public @sort_issue_2440() {
   %input = stablehlo.constant dense<[[0, 1, 1, -3, -3, -2, 0], [4, -1, 3, 0, 4, 0, -3], [1, 0, 0, 0, 0, 2, 3], [-3, -4, -4, -2, 0, 3, 3], [0, 5, 2, -2, 0, -2, 0]]> : tensor<5x7xi64>
   %result = "stablehlo.sort"(%input) <{dimension = 0 : i64}> ({
   ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):


### PR DESCRIPTION
fixes https://github.com/openxla/stablehlo/issues/2440. The source and destination indices were not in correct order. 