### PR TITLE
[tosa] Make legalization pass operate top-down

### DIFF
--- a/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.cpp
+++ b/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.cpp
@@ -508,7 +508,9 @@ LogicalResult StablehloLegalizeToTosaPass::initialize(MLIRContext* ctx) {
 }
 
 void StablehloLegalizeToTosaPass::runOnOperation() {
-  (void)applyPatternsAndFoldGreedily(getOperation(), patterns);
+  GreedyRewriteConfig config;
+  config.useTopDownTraversal = true;
+  (void)applyPatternsAndFoldGreedily(getOperation(), patterns, config);  
 }
 
 }  // namespace


### PR DESCRIPTION
Some of these patterns, e.g., the reduce conversion one, assumes that the reduce op is converted before the body. But this wasn't required/enforced.