### PR TITLE
DotGeneralOp interpreter updates

### DIFF
--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -816,6 +816,21 @@ Element convert(Type type, std::complex<double> value) {
                                              APFloat(value.imag())));
 }
 
+Element convertUsingZeroValue(Type type) {
+  if (isSupportedBooleanType(type))
+    return convert(type, false);
+  if (isSupportedSignedIntegerType(type))
+    return convert(type, static_cast<int64_t>(0));
+  if (isSupportedUnsignedIntegerType(type))
+    return convert(type, static_cast<uint64_t>(0));
+  if (isSupportedFloatType(type))
+    return convert(type, static_cast<APFloat>(0.0));
+  if (isSupportedComplexType(type))
+    return convert(type, std::complex<APFloat>(APFloat(0.0), APFloat(0.0)));
+  report_fatal_error(invalidArgument("Unsupported element type: %s",
+                                     debugString(type).c_str()));
+}
+
 Element exponential(const Element &el) {
   return mapWithUpcastToDouble(
       el, [](double e) { return std::exp(e); },

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -816,7 +816,7 @@ Element convert(Type type, std::complex<double> value) {
                                              APFloat(value.imag())));
 }
 
-Element convertUsingZeroValue(Type type) {
+Element getZeroValueOfType(Type type) {
   if (isSupportedBooleanType(type)) return convert(type, false);
   if (isSupportedSignedIntegerType(type))
     return convert(type, static_cast<int64_t>(0));

--- a/stablehlo/reference/Element.cpp
+++ b/stablehlo/reference/Element.cpp
@@ -817,8 +817,7 @@ Element convert(Type type, std::complex<double> value) {
 }
 
 Element convertUsingZeroValue(Type type) {
-  if (isSupportedBooleanType(type))
-    return convert(type, false);
+  if (isSupportedBooleanType(type)) return convert(type, false);
   if (isSupportedSignedIntegerType(type))
     return convert(type, static_cast<int64_t>(0));
   if (isSupportedUnsignedIntegerType(type))

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -224,6 +224,9 @@ Element convert(Type type, std::complex<APFloat> value);
 /// then the behavior is also TBD (#180).
 Element convert(Type type, std::complex<double> value);
 
+/// Returns converted Element object of type `type` from zero `value`
+Element convertUsingZeroValue(Type type);
+
 /// Returns cosine of Element object.
 Element cosine(const Element &e);
 

--- a/stablehlo/reference/Element.h
+++ b/stablehlo/reference/Element.h
@@ -224,8 +224,8 @@ Element convert(Type type, std::complex<APFloat> value);
 /// then the behavior is also TBD (#180).
 Element convert(Type type, std::complex<double> value);
 
-/// Returns converted Element object of type `type` from zero `value`
-Element convertUsingZeroValue(Type type);
+/// Returns Element object of type `type` from zero `value`
+Element getZeroValueOfType(Type type);
 
 /// Returns cosine of Element object.
 Element cosine(const Element &e);

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -1718,7 +1718,7 @@ Tensor dotGeneralOp(const Tensor &lhs, const Tensor &rhs,
 
     // Now that the lhsIndex/rhsIndex and the iteration space are set up,
     // we can compute the dot product of the (virtual) slices of lhs and rhs.
-    auto resultElement = convertUsingZeroValue(resultType.getElementType());
+    auto resultElement = getZeroValueOfType(resultType.getElementType());
     while (true) {
       resultElement =
           resultElement +

--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -1718,9 +1718,12 @@ Tensor dotGeneralOp(const Tensor &lhs, const Tensor &rhs,
 
     // Now that the lhsIndex/rhsIndex and the iteration space are set up,
     // we can compute the dot product of the (virtual) slices of lhs and rhs.
-    auto resultElement = convert(resultType.getElementType(), 0.0);
+    auto resultElement = convertUsingZeroValue(resultType.getElementType());
     while (true) {
-      resultElement = resultElement + lhs.get(lhsIndex) * rhs.get(rhsIndex);
+      resultElement =
+          resultElement +
+          convert(resultType.getElementType(), lhs.get(lhsIndex)) *
+              convert(resultType.getElementType(), rhs.get(rhsIndex));
       if (failed(incrementIndices())) break;
     }
     result.set(resultIndex, resultElement);


### PR DESCRIPTION
1. earlier code assumed result element type is float : added `convertUsingZeroValue` to handle supported types.

2. `result` element type and `lhs` and `rhs` element types can be different. Convert the `lhs``rhs` to `result` element type  before computation to avoid errors like `LLVM ERROR: Element types don't match: i32 vs i8`

Tests: 
- existing stablehlo tests 
- Validated against new `dot_general` tests being added at https://github.com/openxla/stablehlo/pull/2500