### PR TITLE
Move exported files behind filegroups

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -21,11 +21,9 @@ package(
 
 exports_files([
     "LICENSE",
-    "stablehlo/integrations/python/ChloModule.cpp",
+    # Export to be used by MLIR-free python binding impls
     "stablehlo/integrations/python/StablehloApi.cpp",
     "stablehlo/integrations/python/StablehloApi.h",
-    "stablehlo/integrations/python/StablehloModule.cpp",
-    "stablehlo/integrations/python/VhloModule.cpp",
 ])
 
 filegroup(
@@ -251,6 +249,13 @@ td_library(
         "@llvm-project//mlir:BuiltinDialectTdFiles",
         "@llvm-project//mlir:ControlFlowInterfacesTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",
+    ],
+)
+
+filegroup(
+    name = "chlo_py_api_files",
+    srcs = [
+        "stablehlo/integrations/python/ChloModule.cpp",
     ],
 )
 
@@ -1018,6 +1023,15 @@ gentbl_filegroup(
     deps = [
         ":stablehlo_ops_td_files",
         "@llvm-project//mlir:OpBaseTdFiles",
+    ],
+)
+
+filegroup(
+    name = "stablehlo_py_api_files",
+    srcs = [
+        "stablehlo/integrations/python/PortableApi.cpp",
+        "stablehlo/integrations/python/PortableApi.h",
+        "stablehlo/integrations/python/StablehloModule.cpp",
     ],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1029,8 +1029,8 @@ gentbl_filegroup(
 filegroup(
     name = "stablehlo_py_api_files",
     srcs = [
-        "stablehlo/integrations/python/PortableApi.cpp",
-        "stablehlo/integrations/python/PortableApi.h",
+        "stablehlo/integrations/python/StablehloApi.cpp",
+        "stablehlo/integrations/python/StablehloApi.h",
         "stablehlo/integrations/python/StablehloModule.cpp",
     ],
 )

--- a/stablehlo/integrations/c/StablehloApi.h
+++ b/stablehlo/integrations/c/StablehloApi.h
@@ -62,10 +62,9 @@ MLIR_CAPI_EXPORTED void stablehloGetMinimumVersion(MlirStringCallback callback,
 
 // For two given version strings, return the smaller version.
 // Returns failure if either version is not a valid version string.
-MlirLogicalResult stablehloGetSmallerVersion(MlirStringRef version1,
-                                             MlirStringRef version2,
-                                             MlirStringCallback callback,
-                                             void* userData);
+MLIR_CAPI_EXPORTED MlirLogicalResult
+stablehloGetSmallerVersion(MlirStringRef version1, MlirStringRef version2,
+                           MlirStringCallback callback, void* userData);
 
 // Write a StableHLO program expressed as a string (either prettyprinted MLIR
 // module or MLIR bytecode) to a portable artifact.
@@ -116,7 +115,9 @@ MLIR_CAPI_EXPORTED MlirModule stablehloDeserializePortableArtifact(
 // Entrypoint for calling the StableHLO reference interpreter.
 // Returns an array attribute of dense element attributes for results.
 // Sets error code to non-zero on failure.
-MlirAttribute stablehloEvalModule(MlirModule module, int nArgs,
-                                  MlirAttribute const* args, int* errorCode);
+MLIR_CAPI_EXPORTED MlirAttribute stablehloEvalModule(MlirModule module,
+                                                     int nArgs,
+                                                     MlirAttribute const* args,
+                                                     int* errorCode);
 
 #endif  // STABLEHLO_INTEGRATIONS_C_STABLEHLOAPI_H_


### PR DESCRIPTION
It is problematic to include StableHLO source files from non-StableHLO projects. It makes renaming files and dependencies much more difficult.

Hiding file names behind a target that lives in StableHLO should help with the file renames case. There isn't a good way to keep a dependency list in StableHLO, but the only dependency of python bindings should be CAPI so that shouldn't be too problematic.