### PR TITLE
Move python bindings to portable apis that use C-API datatypes.

### DIFF
--- a/build_tools/math/generate_ChloDecompositionPatternsMath.py
+++ b/build_tools/math/generate_ChloDecompositionPatternsMath.py
@@ -93,7 +93,8 @@ def main():
     func = getattr(fa.algorithms, fname, None)
     if func is None:
       warnings.warn(
-          f"{fa.algorithms.__name__} does not define {fname}. Skipping.")
+          f"{fa.algorithms.__name__} does not define {fname}. Skipping."
+      )
       continue
     ctx = fa.Context(paths=[fa.algorithms])
     graph = ctx.trace(func, *args).implement_missing(target).simplify()

--- a/stablehlo/conversions/tosa/tests/lit.cfg.py
+++ b/stablehlo/conversions/tosa/tests/lit.cfg.py
@@ -32,9 +32,9 @@ config.environment["FILECHECK_OPTS"] = "-enable-var-scope"
 
 # Make LLVM and StableHLO tools available in RUN directives
 tools = [
-  'stablehlo-opt',
-  'FileCheck',
-  'stablehlo-translate',
+    'stablehlo-opt',
+    'FileCheck',
+    'stablehlo-translate',
 ]
 tool_dirs = [
   config.llvm_tools_dir,

--- a/stablehlo/integrations/python/StablehloApi.cpp
+++ b/stablehlo/integrations/python/StablehloApi.cpp
@@ -190,6 +190,40 @@ void AddPortableApi(py::module &m) {
   });
 
   //
+  // Serialization APIs (deprecated, use _str methods).
+  //
+  m.def(
+      "serialize_portable_artifact",
+      [](std::string_view moduleStrOrBytecode,
+         std::string_view targetVersion) -> py::bytes {
+        StringWriterHelper accumulator;
+        if (mlirLogicalResultIsFailure(stablehloSerializePortableArtifact(
+                toMlirStringRef(moduleStrOrBytecode),
+                toMlirStringRef(targetVersion),
+                accumulator.getMlirStringCallback(),
+                accumulator.getUserData()))) {
+          PyErr_SetString(PyExc_ValueError, "failed to serialize module");
+          return "";
+        }
+        return py::bytes(accumulator.toString());
+      },
+      py::arg("module_str"), py::arg("target_version"));
+
+  m.def(
+      "deserialize_portable_artifact",
+      [](std::string_view artifact) -> py::bytes {
+        StringWriterHelper accumulator;
+        if (mlirLogicalResultIsFailure(stablehloDeserializePortableArtifact(
+                toMlirStringRef(artifact), accumulator.getMlirStringCallback(),
+                accumulator.getUserData()))) {
+          PyErr_SetString(PyExc_ValueError, "failed to deserialize module");
+          return "";
+        }
+        return py::bytes(accumulator.toString());
+      },
+      py::arg("artifact_str"));
+
+  //
   // Serialization APIs.
   //
   m.def(

--- a/stablehlo/integrations/python/tests/stablehlo.py
+++ b/stablehlo/integrations/python/tests/stablehlo.py
@@ -254,9 +254,10 @@ def test_version_requirements():
       stablehlo.StablehloCompatibilityRequirement.WEEK_4,
       stablehlo.StablehloCompatibilityRequirement.WEEK_12,
       stablehlo.StablehloCompatibilityRequirement.MAX,
-    ):
+  ):
     assert is_semver_format(
-        stablehlo.get_version_from_compatibility_requirement(req))
+        stablehlo.get_version_from_compatibility_requirement(req)
+    )
 
 
 ASM_FORMAT = """
@@ -333,7 +334,9 @@ def test_str_serialization_apis():
     assert m is not None
     module_str = str(m)
     bytecode = module_to_bytecode(m)
-    serialized = stablehlo.serialize_portable_artifact_str(bytecode, curr_version)
+    serialized = stablehlo.serialize_portable_artifact_str(
+        bytecode, curr_version
+    )
     deserialized = stablehlo.deserialize_portable_artifact_str(serialized)
     deserialized_module = ir.Module.parse(deserialized)
     assert module_str == str(deserialized_module)


### PR DESCRIPTION
Add `stablehlo.get_version_from_compatibility_requirement` API.