### PR TITLE
[cmake] Remove dependence on LLVM 'Core' component in the CMake build

### DIFF
--- a/stablehlo/conversions/linalg/transforms/CMakeLists.txt
+++ b/stablehlo/conversions/linalg/transforms/CMakeLists.txt
@@ -30,9 +30,6 @@ add_mlir_library(StablehloLinalgTransforms
   StablehloOpsIncGen
   StablehloLinalgTransformsPassIncGen
 
-  LINK_COMPONENTS
-  Core
-
   LINK_LIBS PUBLIC
   ChloOps
   StablehloBase

--- a/stablehlo/conversions/tosa/transforms/CMakeLists.txt
+++ b/stablehlo/conversions/tosa/transforms/CMakeLists.txt
@@ -33,9 +33,6 @@ add_mlir_library(StablehloTOSATransforms
   StablehloTOSAPDLLPatternsIncGen
   StablehloOpsIncGen
 
-  LINK_COMPONENTS
-  Core
-
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRPass


### PR DESCRIPTION
This change removes two spurious 'LINK_COMPONENTS Core' declarations in
the CMake build. Depending on the 'Core' component indicates that the
libraries depend on the code under 'llvm-project/llvm/lib/IR' (e.g. 'LLVMCore'
library), which is not true for the StablehloLinalgTransforms and
StablehloTOSATransforms libraries.
