### PR TITLE
Fix some warnings

### DIFF
--- a/stablehlo/dialect/Version.cpp
+++ b/stablehlo/dialect/Version.cpp
@@ -86,6 +86,7 @@ Version Version::fromCompatibilityRequirement(
     case CompatibilityRequirement::MAX:
       return Version::getMinimumVersion();
   }
+  llvm_unreachable("Unhandled case");
 }
 
 mlir::Diagnostic& operator<<(mlir::Diagnostic& diag, const Version& version) {

--- a/stablehlo/transforms/StablehloAggressiveFolder.cpp
+++ b/stablehlo/transforms/StablehloAggressiveFolder.cpp
@@ -291,7 +291,7 @@ struct EvalCompareOpPattern : public OpRewritePattern<CompareOp> {
                                 PatternRewriter& rewriter) const override {
     auto resultType = op.getType();
     return evalElementwise(rewriter, op, [&](APSInt lhs, APSInt rhs) {
-      bool result;
+      bool result = false;
       switch (op.getComparisonDirection()) {
         case ComparisonDirection::EQ:
           result = lhs == rhs;


### PR DESCRIPTION
This PR fixes the following warnings:
```
stablehlo/stablehlo/dialect/Version.cpp:89:1: 
  warning: control reaches end of non-void function [-Wreturn-type]
```

```
stablehlo/stablehlo/transforms/StablehloAggressiveFolder.cpp:315:59: 
  warning: 'result' may be used uninitialized in this function [-Wmaybe-uninitialized]
  315 |       return getAPSInt(resultType.getElementType(), result);
```