### PR TITLE
Fix stablehlo_capi_objects to depend on :CAPIIRObjects, not :CAPIIR.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -941,7 +941,7 @@ cc_library(
         ":stablehlo_serialization",
         ":version",
         "@llvm-project//llvm:Support",
-        "@llvm-project//mlir:CAPIIR",
+        "@llvm-project//mlir:CAPIIRObjects",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Support",
     ],


### PR DESCRIPTION
Depending on :CAPIIR from a capi_objects target causes duplicate symbol problems in JAX on Windows.