### PR TITLE
Delete empty testdata files

### DIFF
--- a/stablehlo/testdata/dynamic/cummax_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/cummax_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/image_resize_linear_0_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/image_resize_linear_0_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/image_resize_linear_to_fixed_dim_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/image_resize_linear_to_fixed_dim_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/jnp_pad_mode_edge_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/jnp_pad_mode_edge_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/random_categorical_0_dim_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/random_categorical_0_dim_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/random_categorical_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/random_categorical_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/random_gamma_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/random_gamma_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/random_uniform_even_1_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/random_uniform_even_1_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/random_uniform_even_2_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/random_uniform_even_2_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_cumlogsumexp_axis_by_fun_float32_8_9_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_cumlogsumexp_axis_by_fun_float32_8_9_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_cumlogsumexp_dtype_by_fun_float32_8_9_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_cumlogsumexp_dtype_by_fun_float32_8_9_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_cumlogsumexp_reverse_float32_8_9_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_cumlogsumexp_reverse_float32_8_9_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_cummax_axis_by_fun_float32_8_9_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_cummax_axis_by_fun_float32_8_9_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_cummax_dtype_by_fun_float32_8_9_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_cummax_dtype_by_fun_float32_8_9_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_cummax_reverse_float32_8_9_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_cummax_reverse_float32_8_9_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_cummin_axis_by_fun_float32_8_9_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_cummin_axis_by_fun_float32_8_9_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_cummin_dtype_by_fun_float32_8_9_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_cummin_dtype_by_fun_float32_8_9_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_cummin_reverse_float32_8_9_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_cummin_reverse_float32_8_9_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_cumprod_axis_by_fun_float32_8_9_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_cumprod_axis_by_fun_float32_8_9_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_cumprod_dtype_by_fun_float32_8_9_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_cumprod_dtype_by_fun_float32_8_9_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_cumprod_reverse_float32_8_9_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_cumprod_reverse_float32_8_9_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_cumsum_axis_by_fun_float32_8_9_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_cumsum_axis_by_fun_float32_8_9_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_cumsum_dtype_by_fun_float32_8_9_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_cumsum_dtype_by_fun_float32_8_9_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_cumsum_reverse_float32_8_9_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_cumsum_reverse_float32_8_9_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_gather_from_take_name_2_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_gather_from_take_name_2_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_gather_from_take_name_3_axis_2_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_gather_from_take_name_3_axis_2_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_gather_from_take_name_4_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_gather_from_take_name_4_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_gather_from_take_name_5_oob_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_gather_from_take_name_5_oob_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_gather_from_take_name_8_neg_oob_axis_2_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_gather_from_take_name_8_neg_oob_axis_2_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_gather_from_take_name_8_neg_oob_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_gather_from_take_name_8_neg_oob_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_random_categorical_bfloat16_5_4_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_random_categorical_bfloat16_5_4_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_random_categorical_bfloat16_8_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_random_categorical_bfloat16_8_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_random_randint_int8_32_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_random_randint_int8_32_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_random_randint_int8_5_4_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_random_randint_int8_5_4_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_random_split_i_1_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_random_split_i_1_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_random_split_i_2_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_random_split_i_2_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_random_uniform_bfloat16_32_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_random_uniform_bfloat16_32_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-

--- a/stablehlo/testdata/dynamic/vmap_random_uniform_bfloat16_5_4_dynamic.mlir
+++ b/stablehlo/testdata/dynamic/vmap_random_uniform_bfloat16_5_4_dynamic.mlir
@@ -1,7 +1,0 @@
-// RUN: stablehlo-translate --serialize --target=current %s | stablehlo-translate --deserialize | stablehlo-opt > %t.0
-// RUN: stablehlo-opt %s > %t.1
-// RUN: diff %t.0 %t.1
-
-module {
-}
-


### PR DESCRIPTION
I'm not sure why these were generated as empty files, but they're not useful so lets delete them. I'll look into how these were generated separately.

Notified of these as @jtristan applies the https://github.com/leanprover/SHerLOC project to testdata files.

Fixes https://github.com/openxla/stablehlo/issues/2537, confirmed that there are 38 lines in that issue and 38 files removed in this PR.