### PR TITLE
Bump 4w and 12w version numbers

### DIFF
--- a/stablehlo/dialect/Version.cpp
+++ b/stablehlo/dialect/Version.cpp
@@ -80,13 +80,13 @@ Version Version::fromCompatibilityRequirement(
     case CompatibilityRequirement::NONE:
       return Version::getCurrentVersion();
     case CompatibilityRequirement::WEEK_4:
-      return Version(1, 3, 0);  // v1.3.0 - Jul 15, 2024
+      return Version(1, 5, 0);  // v1.3.0 - Aug 1, 2024
     case CompatibilityRequirement::WEEK_12:
-      return Version(1, 0, 0);  // v1.0.0 - May 14, 2024
+      return Version(1, 1, 0);  // v1.1.0 - May 30, 2024
     case CompatibilityRequirement::MAX:
       return Version::getMinimumVersion();
   }
-  llvm_unreachable("Unhandled case");
+  llvm::report_fatal_error("Unhandled compatibility requirement");
 }
 
 mlir::Diagnostic& operator<<(mlir::Diagnostic& diag, const Version& version) {


### PR DESCRIPTION
For 4w compat, enables use of TanOp. For 12w, enables use of gather/scatter batch dims.