### PR TITLE
Add ide.md to TOC

### DIFF
--- a/docs/_toc.yaml
+++ b/docs/_toc.yaml
@@ -53,6 +53,8 @@ toc:
     path: /stablehlo/type_inference
   - title: The VHLO dialect
     path: /stablehlo/vhlo
+  - title: IDE setup tips
+    path: /stablehlo/ide
   - title: StableHLO Passes
     path: /stablehlo/generated/stablehlo_passes
   - title: StableHLO Interpreter Passes


### PR DESCRIPTION
The page exists at: https://openxla.org/stablehlo/ide

But it isn't mentioned in `_toc.yaml` so it is missing the side bar on the page, and it doesn't show up in the typical nav bar.