### PR TITLE
Always include LLVM CMake modules.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,20 +109,17 @@ if(STABLEHLO_STANDALONE_BUILD)
   set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
   list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
   list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
-
-  include(TableGen)
-  include(AddLLVM)
-  include(AddMLIR)
   include(HandleLLVMOptions)
 endif()
 
 if(STABLEHLO_BUILD_EMBEDDED)
   message(STATUS "Building StableHLO embedded in another project")
-  include(TableGen)
-  include(AddLLVM)
-  include(AddMLIR)
   include(HandleLLVMOptions)
 endif()
+
+include(TableGen)
+include(AddLLVM)
+include(AddMLIR)
 
 # Add the CMake modules specific to StableHLO
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")


### PR DESCRIPTION
These LLVM CMake modules used to be unconditionally included, but #2430 changed that to only conditionally including them in the standalone and embedded builds, leaving out the external-project build.

That broke integration in https://github.com/iree-org/iree where Stablehlo is an external project. [Error log here](https://gist.github.com/bjacob/17f86fb5f07007e06b94f3a9347747a1). These are linking errors when building with Clang or GCC, with unresolved symbols for `typeinfo` for various types, referenced from Stablehlo symbols. `typeinfo` is a RTTI feature, and all LLVM-derived projects normally disable RTTI, which is why these symbols are not defined, and why that is normally not a problem. What changed with #2430 was that suddenly, the disabling of RTTI was itself disabled in our external build of Stablehlo. [Here is the code](https://github.com/llvm/llvm-project/blob/09ba83be0ac178851e3c9c9c8fefddbdd4d8353f/llvm/cmake/modules/AddLLVM.cmake#L63-L64) that is responsible for disabling RTTI. It was not kicking in anymore, because `LLVM_COMPILER_IS_GCC_COMPATIBLE` was not defined. It is normally defined by this `include` [just above](https://github.com/llvm/llvm-project/blob/09ba83be0ac178851e3c9c9c8fefddbdd4d8353f/llvm/cmake/modules/AddLLVM.cmake#L5) in that file.

But as of #2430, the `include(AddLLVM)` itself was no longer done in the Stablehlo project, instead the Stablehlo external build was relying on `include(AddLLVM)` to have been done in the parent project, which it was. The problem was that while the parent-project `include(AddLLVM)` did define all the functions provided by that module, the CMake variable definitions such as `LLVM_COMPILER_IS_GCC_COMPATIBLE` were made on the parent project and were not visible to the child project.

Summary of the above: in their current shape, LLVM CMake modules such as `AddLLVM` (and `AddMLIR`, which Stablehlo uses, and which itself relies on `AddLLVM`) must be included by any child project that uses them, even if the parent project already included them.
