### PR TITLE
Use `LINK_COMPONENTS` to link `LLVMSupport`

### DIFF
--- a/stablehlo/integrations/c/CMakeLists.txt
+++ b/stablehlo/integrations/c/CMakeLists.txt
@@ -28,6 +28,8 @@ add_mlir_public_c_api_library(ChloCAPI
 
   LINK_LIBS PUBLIC
   ChloOps
+
+  LINK_COMPONENTS PUBLIC
   LLVMSupport
 )
 
@@ -40,7 +42,6 @@ add_mlir_public_c_api_library(StablehloCAPI
   StablehloTypes.cpp
 
   LINK_LIBS PUBLIC
-  LLVMSupport
   MLIRCAPIIR
   MLIRIR
   MLIRSupport
@@ -51,6 +52,9 @@ add_mlir_public_c_api_library(StablehloCAPI
   StablehloReferenceConfiguration
   StablehloSerialization
   Version
+
+  LINK_COMPONENTS PUBLIC
+  LLVMSupport
 )
 
 add_mlir_public_c_api_library(VhloCAPI

--- a/stablehlo/reference/CMakeLists.txt
+++ b/stablehlo/reference/CMakeLists.txt
@@ -169,10 +169,12 @@ add_mlir_library(StablehloReferenceProcessGrid
   ProcessGrid.cpp
 
   LINK_LIBS PUBLIC
-  LLVMSupport
   MLIRIR
   MLIRSupport
   StablehloReferenceTensor
+
+  LINK_COMPONENTS PUBLIC
+  LLVMSupport
 )
 
 add_mlir_library(StablehloReferenceScope


### PR DESCRIPTION
In #2494, `LLVMSupport` was added as a linked dependency to a few targets such as `ChloCAPI`, using the `add_mlir_public_c_api_library` function, passing `LLVMSupport` along with other dependencies under `LINK_LIBS`.

Trying to integrate these changes in https://github.com/iree-org/iree , I get these CMake errors:

```
CMake Error at build/lib/cmake/mlir/AddMLIR.cmake:265 (message):
  ChloCAPI specifies LINK_LIBS LLVMSupport, but LINK_LIBS cannot be used for
  LLVM libraries.  Please use LINK_COMPONENTS instead.
Call Stack (most recent call first):
  build/lib/cmake/mlir/AddMLIR.cmake:375 (_check_llvm_components_usage)
  build/lib/cmake/mlir/AddMLIR.cmake:637 (add_mlir_library)
  third_party/stablehlo/stablehlo/integrations/c/CMakeLists.txt:24 (add_mlir_public_c_api_library)
```

This PR is simply following the suggesting in that error message, and that seems to work.