### PR TITLE
CMake: Do not specify `LLVMSupport` in `LINK_LIBS`.

### DIFF
--- a/stablehlo/integrations/c/CMakeLists.txt
+++ b/stablehlo/integrations/c/CMakeLists.txt
@@ -41,7 +41,7 @@ add_mlir_public_c_api_library(StablehloCAPI
   LINK_LIBS PUBLIC
   MLIRCAPIIR
   MLIRIR
-  MLIRSupport
+  MLIRSupport  # LLVMSupport is automatically added in AddLLVM.cmake.
   StablehloOps
   StablehloPasses
   StablehloPortableApi

--- a/stablehlo/integrations/c/CMakeLists.txt
+++ b/stablehlo/integrations/c/CMakeLists.txt
@@ -28,7 +28,6 @@ add_mlir_public_c_api_library(ChloCAPI
 
   LINK_LIBS PUBLIC
   ChloOps
-  LLVMSupport
 )
 
 add_mlir_public_c_api_library(StablehloCAPI
@@ -40,7 +39,6 @@ add_mlir_public_c_api_library(StablehloCAPI
   StablehloTypes.cpp
 
   LINK_LIBS PUBLIC
-  LLVMSupport
   MLIRCAPIIR
   MLIRIR
   MLIRSupport

--- a/stablehlo/reference/CMakeLists.txt
+++ b/stablehlo/reference/CMakeLists.txt
@@ -169,7 +169,6 @@ add_mlir_library(StablehloReferenceProcessGrid
   ProcessGrid.cpp
 
   LINK_LIBS PUBLIC
-  LLVMSupport
   MLIRIR
   MLIRSupport
   StablehloReferenceTensor

--- a/stablehlo/reference/CMakeLists.txt
+++ b/stablehlo/reference/CMakeLists.txt
@@ -20,7 +20,7 @@ add_mlir_library(StablehloReferenceApi
   MLIRIR
   MLIRParser
   MLIRPass
-  MLIRSupport
+  MLIRSupport  # LLVMSupport is automatically added in AddLLVM.cmake.
   InterpreterOps
   StablehloPasses
   StablehloReferenceConfiguration
@@ -40,7 +40,7 @@ add_mlir_library(StablehloReferenceAxes
 
   LINK_LIBS PUBLIC
   MLIRIR
-  MLIRSupport
+  MLIRSupport  # LLVMSupport is automatically added in AddLLVM.cmake.
 )
 
 add_mlir_library(StablehloReferenceConfiguration
@@ -48,7 +48,7 @@ add_mlir_library(StablehloReferenceConfiguration
   Configuration.cpp
 
   LINK_LIBS PUBLIC
-  MLIRSupport
+  MLIRSupport  # LLVMSupport is automatically added in AddLLVM.cmake.
   StablehloReferenceErrors
   StablehloReferenceProcess
   StablehloReferenceScope
@@ -60,7 +60,7 @@ add_mlir_library(StablehloReferenceElement
 
   LINK_LIBS PUBLIC
   MLIRIR
-  MLIRSupport
+  MLIRSupport  # LLVMSupport is automatically added in AddLLVM.cmake.
   StablehloReferenceTypes
 )
 
@@ -70,7 +70,7 @@ add_mlir_library(StablehloReferenceErrors
 
   LINK_LIBS PUBLIC
   MLIRIR
-  MLIRSupport
+  MLIRSupport  # LLVMSupport is automatically added in AddLLVM.cmake.
 )
 
 add_mlir_library(StablehloReferenceIndex
@@ -79,7 +79,7 @@ add_mlir_library(StablehloReferenceIndex
 
   LINK_LIBS PUBLIC
   MLIRIR
-  MLIRSupport
+  MLIRSupport  # LLVMSupport is automatically added in AddLLVM.cmake.
 )
 
 set(LLVM_TARGET_DEFINITIONS InterpreterOps.td)
@@ -102,7 +102,7 @@ add_mlir_dialect_library(InterpreterOps
   StablehloReferenceOps
   StablehloReferenceProcessGrid
   MLIRIR
-  MLIRSupport
+  MLIRSupport  # LLVMSupport is automatically added in AddLLVM.cmake.
 )
 
 set(LLVM_TARGET_DEFINITIONS InterpreterPasses.td)
@@ -120,7 +120,7 @@ add_mlir_library(InterpreterPasses
   InterpreterOps
   MLIRIR
   MLIRPass
-  MLIRSupport
+  MLIRSupport  # LLVMSupport is automatically added in AddLLVM.cmake.
   MLIRTransforms
   MLIRTransformUtils
 )
@@ -170,7 +170,7 @@ add_mlir_library(StablehloReferenceProcessGrid
 
   LINK_LIBS PUBLIC
   MLIRIR
-  MLIRSupport
+  MLIRSupport  # LLVMSupport is automatically added in AddLLVM.cmake.
   StablehloReferenceTensor
 )
 
@@ -182,7 +182,7 @@ add_mlir_library(StablehloReferenceScope
   StablehloReferenceValue
   StablehloReferenceTensor
   StablehloReferenceToken
-  MLIRSupport
+  MLIRSupport  # LLVMSupport is automatically added in AddLLVM.cmake.
 )
 
 add_mlir_library(StablehloReferenceTensor
@@ -204,7 +204,7 @@ add_mlir_library(StablehloReferenceToken
 
   LINK_LIBS PUBLIC
   MLIRIR
-  MLIRSupport
+  MLIRSupport  # LLVMSupport is automatically added in AddLLVM.cmake.
   StablehloOps
 )
 
@@ -214,7 +214,7 @@ add_mlir_library(StablehloReferenceTypes
 
   LINK_LIBS PUBLIC
   MLIRIR
-  MLIRSupport
+  MLIRSupport  # LLVMSupport is automatically added in AddLLVM.cmake.
 )
 
 add_mlir_library(StablehloReferenceValue
@@ -223,7 +223,7 @@ add_mlir_library(StablehloReferenceValue
 
   LINK_LIBS PUBLIC
   MLIRIR
-  MLIRSupport
+  MLIRSupport  # LLVMSupport is automatically added in AddLLVM.cmake.
   StablehloReferenceTensor
   StablehloReferenceToken
 )


### PR DESCRIPTION
This is a new take on https://github.com/openxla/stablehlo/pull/2573.

There, I was trying to fix CMake errors in the external build, with the error message saying that `LINK_COMPONENTS` should be used instead of `LINK_LIBS` for  LLVM libraries.  That change fixed my external build, but broke the standalone build on CI.

Reading the `AddMLIR.cmake` code generating the error, I came across this line:
https://github.com/llvm/llvm-project/blob/ee4dd147baff8f971f3ec5aad5a216ca9837a732/mlir/cmake/modules/AddMLIR.cmake#L287-L288

```cmake
  # MLIR libraries uniformly depend on LLVMSupport.  Just specify it once here.
  list(APPEND ARG_LINK_COMPONENTS Support)
```

This looks like hardcoding always depending on `LLVMSupport`  (though I wasn't quite sure about the nuance between `Support` and `LLVMSupport`). If that's correct, then we never needed specifying `LLVMSupport` in the first place. So I tried just omitting it, and that seems to work. WDYT?