### PR TITLE
Bump WEEK_12 compat to v1.3.0

### DIFF
--- a/stablehlo/dialect/Version.cpp
+++ b/stablehlo/dialect/Version.cpp
@@ -85,7 +85,7 @@ Version Version::fromCompatibilityRequirement(
     case CompatibilityRequirement::WEEK_4:
       return Version(1, 7, 0);  // v1.7.0 - Sept 05, 2024
     case CompatibilityRequirement::WEEK_12:
-      return Version(1, 1, 0);  // v1.1.0 - May 30, 2024
+      return Version(1, 3, 0);  // v1.3.0 - Jul 16, 2024
     case CompatibilityRequirement::MAX:
       return Version::getMinimumVersion();
   }


### PR DESCRIPTION
Bump 12W compat to v1.3.0 released on July 16, 2024

Tags: https://github.com/openxla/stablehlo/tags

12W is used in `xla::GetDefaultStablehloVersion()` which is used by `PjRtCApiCompiler::Compile()` xla/pjrt/pjrt_c_api_client.cc:2317