### PR TITLE
Bump WEEK_12=>v1.4.1, WEEK_4=>1.7.1

### DIFF
--- a/stablehlo/dialect/Version.cpp
+++ b/stablehlo/dialect/Version.cpp
@@ -83,9 +83,9 @@ Version Version::fromCompatibilityRequirement(
     case CompatibilityRequirement::NONE:
       return Version::getCurrentVersion();
     case CompatibilityRequirement::WEEK_4:
-      return Version(1, 7, 0);  // v1.7.0 - Sept 05, 2024
+      return Version(1, 7, 1);  // v1.7.1 - Sept 09, 2024
     case CompatibilityRequirement::WEEK_12:
-      return Version(1, 3, 0);  // v1.3.0 - Jul 16, 2024
+      return Version(1, 4, 1);  // v1.4.1 - Jul 22, 2024
     case CompatibilityRequirement::MAX:
       return Version::getMinimumVersion();
   }


### PR DESCRIPTION
Bump version in `Version::fromCompatibilityRequirement`
- WEEK_12 => v1.4.1 (84 days ago)
- WEEK_4 => 1.7.1 (35 days ago)