### PR TITLE
Set `/bigobj` option on MSVC to fix object limit error.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,10 @@ endif()
 if(MSVC)
   # Required to use M_PI. Must be set before any `#include <cmath>`.
   add_compile_definitions("_USE_MATH_DEFINES")
+
+  # Tablegen outputs from LLVM/MLIR can easily exceed the default 64k section
+  # count limit, so increase to 2^32.
+  add_compile_options("/bigobj")
 endif()
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This fixes downstream build errors tracked at https://github.com/iree-org/iree/issues/18785.

Sample error message when building on Windows with MSVC:
```
FAILED: llvm-external-projects/stablehlo/stablehlo/dialect/CMakeFiles/obj.VhloOps.dir/VhloOps.cpp.obj
C:\ProgramData\Chocolatey\bin\ccache C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1441~1.341\bin\Hostx64\x64\cl.exe  /nologo /TP -DGTEST_HAS_RTTI=0 -D_HAS_EXCEPTIONS=0 -D_USE_MATH_DEFINES -ID:\a\iree\iree\third_party\llvm-project\llvm\include -ID:\a\iree\iree\build-windows\llvm-project\include -ID:\a\iree\iree\third_party\llvm-project\mlir\include -ID:\a\iree\iree\third_party\stablehlo -ID:\a\iree\iree\build-windows\llvm-external-projects\stablehlo -ID:\a\iree\iree\third_party\llvm-project\lld\include -ID:\a\iree\iree\build-windows\llvm-project\tools\lld\include -external:I\..\mlir\include -external:ID:\a\iree\iree\build-windows\llvm-project\tools\mlir\include -external:W0 /DWIN32 /D_WINDOWS /EHsc /Z7 /O2 /Ob1  -std:c++17 -MD  /EHs-c- /GR- /showIncludes /Follvm-external-projects\stablehlo\stablehlo\dialect\CMakeFiles\obj.VhloOps.dir\VhloOps.cpp.obj /Fdllvm-external-projects\stablehlo\stablehlo\dialect\CMakeFiles\obj.VhloOps.dir\ /FS -c D:\a\iree\iree\third_party\stablehlo\stablehlo\dialect\VhloOps.cpp
cl : Command line warning D9025 : overriding '/EHs' with '/EHs-'
cl : Command line warning D9025 : overriding '/EHc' with '/EHc-'
D:\a\iree\iree\third_party\stablehlo\stablehlo\dialect\VhloOps.cpp : fatal error C1128: number of sections exceeded object file format limit: compile with /bigobj
```

I think our downstream Windows builds worked with https://github.com/openxla/stablehlo/pull/2573 but they do not work with https://github.com/openxla/stablehlo/pull/2575, without this change. Hooray for compiler options whack-a-mole.