### PR TITLE
Bump WEEK_12 to v1.4.2, WEEK_4 to 1.7.3

### DIFF
--- a/stablehlo/dialect/Version.cpp
+++ b/stablehlo/dialect/Version.cpp
@@ -83,9 +83,9 @@ Version Version::fromCompatibilityRequirement(
     case CompatibilityRequirement::NONE:
       return Version::getCurrentVersion();
     case CompatibilityRequirement::WEEK_4:
-      return Version(1, 7, 1);  // v1.7.1 - Sept 09, 2024
+      return Version(1, 7, 3);  // v1.7.3 - Sept 23, 2024
     case CompatibilityRequirement::WEEK_12:
-      return Version(1, 4, 1);  // v1.4.1 - Jul 22, 2024
+      return Version(1, 4, 2);  // v1.4.2 - Jul 25, 2024
     case CompatibilityRequirement::MAX:
       return Version::getMinimumVersion();
   }


### PR DESCRIPTION
WEEK_4: v1.7.3 2024-09-23 28 days ago
WEEK_12: v1.4.2 2024-07-25 88 days ago

[get_compatibility_versions.py](https://gist.github.com/apivovarov/e5f949983feff1fc378d93f3008a9900)

BTW, WEEK_12 will be v1.5.0 in 3 days on Oct 24