### PR TITLE
Fix issue when targeting a patch version for serialization

### DIFF
--- a/stablehlo/tests/vhlo/vhlo_to_version_downgrade_patch.mlir
+++ b/stablehlo/tests/vhlo/vhlo_to_version_downgrade_patch.mlir
@@ -12,4 +12,4 @@ func.func public @all_to_all(%arg0: tensor<8x8x1xui16>) -> tensor<1x8x8xui16> {
   // CHECK: vhlo.all_to_all_v1
   %0 = "stablehlo.all_to_all"(%arg0) <{concat_dimension = 2 : i64, replica_groups = dense<[[0, 1, 2, 3, 4, 5, 6, 7]]> : tensor<1x8xi64>, split_count = 8 : i64, split_dimension = 0 : i64}> : (tensor<8x8x1xui16>) -> tensor<1x8x8xui16>
   return %0 : tensor<1x8x8xui16>
-}diff --ruN a/stablehlo/stablehlo/transforms/VhloToVersion.cpp b/stablehlo/stablehlo/transforms/VhloToVersion.cpp
+}

--- a/stablehlo/tests/vhlo/vhlo_to_version_downgrade_patch.mlir
+++ b/stablehlo/tests/vhlo/vhlo_to_version_downgrade_patch.mlir
@@ -1,0 +1,15 @@
+// RUN: stablehlo-opt --stablehlo-legalize-to-vhlo --vhlo-to-version='target=1.4.1' %s | FileCheck %s
+
+// AllToAll was in the initial StableHLO opset, but changed in v1.5.0 to have
+// tuple arguments. Ensure that serializing for 1.4.1 is valid and targets the
+// v1.4.0 opset.
+//
+// This will catch issues in op `isLegal` checks:
+//   op.minVersion() <= target <= op.maxVersion()
+
+// CHECK-LABEL: vhlo.func_v1 @all_to_all
+func.func public @all_to_all(%arg0: tensor<8x8x1xui16>) -> tensor<1x8x8xui16> {
+  // CHECK: vhlo.all_to_all_v1
+  %0 = "stablehlo.all_to_all"(%arg0) <{concat_dimension = 2 : i64, replica_groups = dense<[[0, 1, 2, 3, 4, 5, 6, 7]]> : tensor<1x8xi64>, split_count = 8 : i64, split_dimension = 0 : i64}> : (tensor<8x8x1xui16>) -> tensor<1x8x8xui16>
+  return %0 : tensor<1x8x8xui16>
+}diff --ruN a/stablehlo/stablehlo/transforms/VhloToVersion.cpp b/stablehlo/stablehlo/transforms/VhloToVersion.cpp

--- a/stablehlo/transforms/VhloToVersion.cpp
+++ b/stablehlo/transforms/VhloToVersion.cpp
@@ -92,6 +92,13 @@ FailureOr<Version> validateTargetVersion(llvm::StringRef versionRef,
                                    << " is greater than current version "
                                    << Version::getCurrentVersion();
 
+  // Opset changes warrant a minor version bump, so this conversion assumes
+  // patch v0 since it is written against the opset at version `X.Y.0`.
+  if (targetVersion.getPatch() != 0) {
+    targetVersion =
+        vhlo::Version(targetVersion.getMajor(), targetVersion.getMinor(), 0);
+  }
+
   return targetVersion;
 }
 


### PR DESCRIPTION
We want to allow targeting patch version because we allow `-target=current` so it makes sense that current can resolve to a patch version.

That said we write our compat passes against patch v0 since all opset changes require a minor version bump and therefore have patch v0.

This PR implements "version flooring" inside the vhlo-to-version pass.