### PR TITLE
Bump WEEK_12 to v1.5.0, WEEK_4 to 1.7.5

### DIFF
--- a/stablehlo/dialect/Version.cpp
+++ b/stablehlo/dialect/Version.cpp
@@ -83,9 +83,9 @@ Version Version::fromCompatibilityRequirement(
     case CompatibilityRequirement::NONE:
       return Version::getCurrentVersion();
     case CompatibilityRequirement::WEEK_4:
-      return Version(1, 7, 3);  // v1.7.3 - Sept 23, 2024
+      return Version(1, 7, 5);  // Sep 26, 2024
     case CompatibilityRequirement::WEEK_12:
-      return Version(1, 4, 2);  // v1.4.2 - Jul 25, 2024
+      return Version(1, 5, 0);  // Aug 1, 2024
     case CompatibilityRequirement::MAX:
       return Version::getMinimumVersion();
   }


### PR DESCRIPTION
WEEK_4: v1.7.5 2024-09-26 28 days ago
WEEK_12: v1.5.0 2024-08-01 84 days ago

[get_compatibility_versions.py](https://gist.github.com/apivovarov/e5f949983feff1fc378d93f3008a9900)
