### PR TITLE
Update PyTorch export tutorial

### DIFF
--- a/docs/tutorials/pytorch-export.ipynb
+++ b/docs/tutorials/pytorch-export.ipynb
@@ -139,7 +139,7 @@
         "\n",
         "_Dynamic batch dimensions can be specified as a part of the initial `torch.export` step._\n",
         "\n",
-        "_`torch_xla` doesn't yet support exporting models with dynamic shapes to StableHLO, so we recommend using the experimental library [`torch_xla2`](https://github.com/pytorch/xla/tree/master/experimental/torch_xla2) for this. It has a similar API for exporting, converts PyTorch models to JAX prior to exporting to StableHLO, and has high opset coverage along with great dynamic shape support._"
+        "_`torch_xla`'s support for exporting dynamic models is limited, for these cases we recommend using [`torch_xla2`](https://github.com/pytorch/xla/tree/master/experimental/torch_xla2) for this. This lowering path leverages JAX for lowering to StableHLO, and has high opset coverage with much broader support for exported programs with dynamic shapes._"
       ]
     },
     {

--- a/docs/tutorials/pytorch-export.ipynb
+++ b/docs/tutorials/pytorch-export.ipynb
@@ -11,13 +11,15 @@
         "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)][pytorch-tutorial-colab]\n",
         "[![Open in Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)][pytorch-tutorial-kaggle]\n",
         "\n",
-        "_Intro to the [`torch_xla.stablehlo`](https://github.com/pytorch/xla/blob/main/docs/stablehlo.md) module._\n",
+        "PyTorch is a popular library for building deep learning models.\n",
+        "In this tutorial, you will learn to export a PyTorch model to StableHLO, and then directly to TensorFlow SavedModel.\n",
         "\n",
         "## Tutorial Setup\n",
         "\n",
         "### Install required dependencies\n",
         "\n",
-        "We'll be using `torch` and `torchvision` to get a `resnet18` model, and `torch_xla` to export to StableHLO.\n",
+        "We use `torch` and `torchvision` to get a [ResNet18 model](https://pytorch.org/vision/stable/models/resnet.html) model, and `torch_xla` to export it to StableHLO.\n",
+        "We also need to install `tensorflow` to work with SavedModel, and recommend using `tensorflow-cpu` or `tf-nightly` for this tutorial.\n",
         "\n",
         "[pytorch-tutorial-colab]: https://colab.research.google.com/github/openxla/stablehlo/blob/main/docs/tutorials/pytorch-export.ipynb\n",
         "[pytorch-tutorial-kaggle]: https://kaggle.com/kernels/welcome?src=https://github.com/openxla/stablehlo/blob/main/docs/tutorials/pytorch-export.ipynb"
@@ -31,7 +33,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install torch_xla==2.3.0 torch==2.3.0 torchvision==0.18.0"
+        "!pip install torch_xla==2.5.0 torch==2.5.0 torchvision==0.20.0 tensorflow-cpu"
       ]
     },
     {
@@ -43,17 +45,18 @@
         "## Export PyTorch model to StableHLO\n",
         "\n",
         "The general set of steps for exporting a PyTorch model to StableHLO is:\n",
-        "1. Export using PyTorch's `torch.export` API.\n",
-        "2. Convert exported FX Graph to StableHLO using `torch_xla.stablehlo` APIs.\n",
+        "1. Use [PyTorch's `torch.export` API](https://pytorch.org/docs/2.5/export.html#torch-export) to generate an exported FX graph (i.e., `ExportedProgram`)\n",
+        "2. Use [PyTorch/XLA's `torch_xla.stablehlo` API](https://pytorch.org/xla/master/features/stablehlo.html) to convert the `ExportedProgram` to StableHLO\n",
         "\n",
         "### Export model to FX graph using `torch.export`\n",
         "\n",
-        "This step uses entirely vanilla PyTorch APIs to export a `resnet18` model from `torchvision`. Sample inputs are required for graph tracing, we use a `tensor<4x3x224x224xf32>` in this case."
+        "This step uses vanilla PyTorch APIs to export a `resnet18` model from `torchvision`.\n",
+        "Sample inputs are required for graph tracing, we use a `tensor<4x3x224x224xf32>` in this case."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": 1,
       "metadata": {
         "id": "GhIpxnx5fuxy"
       },
@@ -74,14 +77,16 @@
         "id": "zuMAr3WO1PBk"
       },
       "source": [
-        "### Export FX Graph to StableHLO using TorchXLA\n",
+        "### Export FX graph to StableHLO using `torch_xla.stablehlo`\n",
         "\n",
-        "Once we have an exported FX graph, we can convert to StableHLO using the `torch_xla.stablehlo` module. In this case we'll use `exported_program_to_stablehlo`."
+        "Once we have an exported FX graph, we can convert it to StableHLO using `exported_program_to_stablehlo` in the `torch_xla.stablehlo` module.\n",
+        "\n",
+        "We can then look at the exported StableHLO program with `get_stablehlo_text`."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": 2,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -91,21 +96,28 @@
       },
       "outputs": [
         {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "WARNING:root:Defaulting to PJRT_DEVICE=CPU\n"
+          ]
+        },
+        {
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "module @IrToHlo.508 attributes {mhlo.cross_program_prefetches = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {\n",
+            "module @IrToHlo.484 attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {\n",
             "  func.func @main(%arg0: tensor<1000xf32>, %arg1: tensor<1000x512xf32>, %arg2: tensor<512xf32>, %arg3: tensor<512xf32>, %arg4: tensor<512xf32>, %arg5: tensor<512xf32>, %arg6: tensor<512x256x1x1xf32>, %arg7: tensor<256xf32>, %arg8: tensor<256xf32>, %arg9: tensor<256xf32>, %arg10: tensor<256xf32>, %arg11: tensor<256x128x1x1xf32>, %arg12: tensor<128xf32>, %arg13: tensor<128xf32>, %arg14: tensor<128xf32>, %arg15: tensor<128xf32>, %arg16: tensor<128x64x1x1xf32>, %arg17: tensor<64xf32>, %arg18: tensor<64xf32>, %arg19: tensor<64xf32>, %arg20: tensor<64xf32>, %arg21: tensor<64x3x7x7xf32>, %arg22: tensor<4x3x224x224xf32>, %arg23: tensor<64xf32>, %arg24: tensor<64xf32>, %arg25: tensor<64xf32>, %arg26: tensor<64xf32>, %arg27: tensor<64x64x3x3xf32>, %arg28: tensor<64xf32>, %arg29: tensor<64xf32>, %arg30: tensor<64xf32>, %arg31: tensor<64xf32>, %arg32: tensor<64x64x3x3xf32>, %arg33: tensor<64xf32>, %arg34: tensor<64xf32>, %arg35: tensor<64xf32>, %arg36: tensor<64xf32>, %arg37: tensor<64x64x3x3xf32>, %arg38: tensor<64xf32>, %arg39: tensor<64xf32>, %arg40: tensor<64xf32>, %arg41: tensor<64xf32>, %arg42: tensor<64x64x3x3xf32>, %arg43: tensor<128xf32>, %arg44: tensor<128xf32>, %arg45: tensor<128xf32>, %arg46: tensor<128xf32>, %arg47: tensor<128x128x3x3xf32>, %arg48: tensor<128xf32>, %arg49: tensor<128xf32>, %arg50: tensor<128xf32>, %arg51: tensor<128xf32>, %arg52: tensor<128x64x3x3xf32>, %arg53: tensor<128xf32>, %arg54: tensor<128xf32>, %arg55: tensor<128xf32>, %arg56: tensor<128xf32>, %arg57: tensor<128x128x3x3xf32>, %arg58: tensor<128xf32>, %arg59: tensor<128xf32>, %arg60: tensor<128xf32>, %arg61: tensor<128xf32>, %arg62: tensor<128x128x3x3xf32>, %arg63: tensor<256xf32>, %arg64: tensor<256xf32>, %arg65: tensor<256xf32>, %arg66: tensor<256xf32>, %arg67: tensor<256x256x3x3xf32>, %arg68: tensor<256xf32>, %arg69: tensor<256xf32>, %arg70: tensor<256xf32>, %arg71: tensor<256xf32>, %arg72: tensor<256x128x3x3xf32>, %arg73: tensor<256xf32>, %arg74: tensor<256xf32>, %arg75: tensor<256xf32>, %arg76: tensor<256xf32>, %arg77: tensor<256x256x3x3xf32>, %arg78: tensor<256xf32>, %arg79: tensor<256xf32>, %arg80: tensor<256xf32>, %arg81: tensor<256xf32>, %arg82: tensor<256x256x3x3xf32>, %arg83: tensor<512xf32>, %arg84: tensor<512xf32>, %arg85: tensor<512xf32>, %arg86: tensor<512xf32>, %arg87: tensor<512x512x3x3xf32>, %arg88: tensor<512xf32>, %arg89: tensor<512xf32>, %arg90: tensor<512xf32>, %arg91: tensor<512xf32>, %arg92: tensor<512x256x3x3xf32>, %arg93: tensor<512xf32>, %arg94: tensor<512xf32>, %arg95: tensor<512xf32>, %arg96: tensor<512xf32>, %arg97: tensor<512x512x3x3xf32>, %arg98: tensor<512xf32>, %arg99: tensor<512xf32>, %arg100: tensor<512xf32>, %arg101: tensor<512xf32>, %arg102: tensor<512x512x3x3xf32>) -> tensor<4x1000xf32> {\n",
-            "    %0 = stablehlo.constant dense<0.0204081628> : tensor<4x512xf32>\n",
-            "    %1 = stablehlo.constant dense<0.000000e+00> : tensor<4x512x7x7xf32>\n",
-            "    %2 = stablehlo.constant dense<0.000000e+00> : tensor<4x256x14x14xf32>\n",
-            "    %3 = stablehlo.constant dense<0.000000e+00> : tensor<4x128x28x28xf32>\n",
-            "    %4 = stablehlo.constant dense<0.000000e+00> : tensor<4x64x56x56xf32>\n",
-            "    %5 = stablehlo.constant dense<0.000000e+00> : tensor<4x64x112x112xf32>\n",
-            "    %6 = stablehlo.constant dense<0xFF800000> : tensor<f32>\n",
-            "    %7 = stablehlo.constant dense<0.000000e+00> : tensor<f32>\n",
-            "    %8 = stablehlo.convolution(%arg22, %arg21) dim_numbers = [b, f, 0, 1]x[o, i, 0, 1]->[b, f, 0, 1], window = {stride = [2, 2], pad = [[3, 3], [3, 3]], lhs_dilate = [1, 1], rhs_dilate = [1, 1], reverse = [0, 0]} {batch_group_count = 1 : i64, feature_group_count = 1 : i64, precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} : (tensor<4x3x224x224xf32>, tensor<64x3x7x7xf32>) -> tensor<4x64x112x112xf32>\n",
-            "    %output, %batch_mean, %batch_var = \"stablehlo.batch_norm_training\"(%8, %arg20, %arg19) {epsilon = 9.99999974E-6 : f3 \n",
+            "    %cst = stablehlo.constant dense<0.0204081628> : tensor<4x512xf32>\n",
+            "    %cst_0 = stablehlo.constant dense<0.000000e+00> : tensor<4x512x7x7xf32>\n",
+            "    %cst_1 = stablehlo.constant dense<0.000000e+00> : tensor<4x256x14x14xf32>\n",
+            "    %cst_2 = stablehlo.constant dense<0.000000e+00> : tensor<4x128x28x28xf32>\n",
+            "    %cst_3 = stablehlo.constant dense<0.000000e+00> : tensor<4x64x56x56xf32>\n",
+            "    %cst_4 = stablehlo.constant dense<0.000000e+00> : tensor<4x64x112x112xf32>\n",
+            "    %cst_5 = stablehlo.constant dense<0xFF800000> : tensor<f32>\n",
+            "    %cst_6 = stablehlo.constant dense<0.000000e+00> : tensor<f32>\n",
+            "    %0 = stablehlo.convolution(%arg22, %arg21) dim_numbers = [b, f, 0, 1]x[o, i, 0, 1]->[b, f, 0, 1], window = {stride = [2, 2], pad = [[3, 3], [3, 3]], lhs_dilate = [1, 1], rhs_dilate = [1, 1], reverse = [false, false]} {batch_group_count = 1 : i64, feature_group_count = 1 : i64, precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]} : (tensor<4x3x224x224xf32>, tensor<64x3x7x7xf32>) -> tensor<4x64x112x112xf32>\n",
+            "    %output, %batch_mean, %batch_var = \"stablehlo.ba \n",
             "...\n"
           ]
         }
@@ -125,22 +137,31 @@
       "source": [
         "### Export with dynamic batch dimension\n",
         "\n",
-        "_This is a new feature and will be included in pip installation after the 2.4 release, or if using `torch_xla` nightly. Once PyTorch/XLA 2.4 is released, this will be converted into a running example. Using the nightly `torch` and `torch_xla` will likely lead to notebook failures in the meantime._\n",
         "\n",
-        "Dynamic batch dimensions can be specified as a part of the initial `torch.export` step. The FX Graph's symint information is used to export to dynamic StableHLO.\n",
+        "Dynamic batch dimensions can be specified as a part of the initial `torch.export` step. The FX graph's SymInt information is used to export to dynamic StableHLO.\n",
         "\n",
-        "In this example, we specify that dim 0 of the sample input is dynamic, which propagates shape using a `tensor<?x3x224x224xf32>`.\n",
+        "In this example, we specify that dimension 0 of the sample input is dynamic, which propagates shape using a `tensor<?x3x224x224xf32>`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# TODO: FIX\n",
+        "# Kernel crashes with \"INVALID_ARGUMENT: Non-broadcast dimensions must not be dynamic\"\n",
         "\n",
-        "```python\n",
-        "from torch.export import Dim\n",
+        "# from torch.export import Dim\n",
         "\n",
-        "# Create a dynamic batch size, for the first dimension of the input\n",
-        "batch = Dim(\"batch\", max=15)\n",
-        "dynamic_shapes = ({0: batch},)\n",
-        "dynamic_export = export(resnet18, sample_input, dynamic_shapes=dynamic_shapes)\n",
-        "dynamic_stablehlo = exported_program_to_stablehlo(dynamic_export)\n",
-        "print(dynamic_stablehlo.get_stablehlo_text('forward')[0:5000],\"\\n...\")\n",
-        "```"
+        "# # Create a dynamic batch size, for the first dimension of the input\n",
+        "# batch = Dim(\"batch\", min=4, max=6)\n",
+        "# dynamic_shapes = ({0: batch},)\n",
+        "\n",
+        "# # Export to FX Graph and then to StableHLO\n",
+        "# dynamic_export = export(resnet18, sample_input, dynamic_shapes=dynamic_shapes)\n",
+        "# dynamic_stablehlo = exported_program_to_stablehlo(dynamic_export)\n",
+        "# print(dynamic_stablehlo.get_stablehlo_text('forward')[0:5000],\"\\n...\")"
       ]
     },
     {
@@ -149,14 +170,15 @@
         "id": "ySTEYXzG1fU6"
       },
       "source": [
-        "### Saving and reloading StableHLO\n",
+        "### Save and reload StableHLO\n",
         "\n",
-        "The `StableHLOGraphModule` has methods to `save` and `load` StableHLO artifacts. This stores StableHLO portable bytecode artifacts which have full backward compatiblity guarantees."
+        "`StableHLOGraphModule` has methods to `save` and `load` StableHLO artifacts.\n",
+        "This stores StableHLO portable bytecode artifacts which have complete forward and backward compatibility guarantees."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": 3,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -170,12 +192,7 @@
           "output_type": "stream",
           "text": [
             "constants  data  functions\n",
-            "forward.bytecode  forward.meta\tforward.mlir\n",
-            "tensor([[-0.7431, -2.5955, -0.0718,  ..., -1.4230,  1.5928, -0.7693],\n",
-            "        [ 0.6199, -1.5941, -0.9018,  ...,  0.2452,  0.6159,  2.4765],\n",
-            "        [-3.0291,  2.2174, -2.2809,  ..., -0.9081,  1.8253,  2.2141],\n",
-            "        [ 0.9318, -0.0566,  0.8561,  ..., -0.1650,  0.7882, -0.2697]],\n",
-            "       device='xla:0')\n"
+            "forward.bytecode  forward.meta\tforward.mlir\n"
           ]
         }
       ],
@@ -185,11 +202,37 @@
         "# Save to tmp\n",
         "stablehlo_program.save('/tmp/stablehlo_dir')\n",
         "!ls /tmp/stablehlo_dir\n",
-        "!ls /tmp/stablehlo_dir/functions\n",
-        "\n",
+        "!ls /tmp/stablehlo_dir/functions"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "tensor([[-2.3258, -0.9606, -0.9439,  ...,  0.3519,  0.6261,  2.3971],\n",
+            "        [ 1.6479, -0.0268,  1.0511,  ..., -1.2512,  2.2042,  1.8865],\n",
+            "        [ 0.1756, -0.3658, -0.0651,  ...,  0.0661,  2.1358,  0.5009],\n",
+            "        [-1.6709, -0.7363, -2.0963,  ..., -1.3716,  0.3321, -0.9199]],\n",
+            "       device='xla:0')\n"
+          ]
+        }
+      ],
+      "source": [
         "# Reload and execute - Stable serialization, forward / backward compatible.\n",
         "reloaded = StableHLOGraphModule.load('/tmp/stablehlo_dir')\n",
         "print(reloaded(sample_input[0]))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "_Note: You can also use wrappers to export and save. Learn more in the [PyTorch/XLA documentation on exporting to StableHLO](https://pytorch.org/xla/master/features/stablehlo.html#other-common-wrappers)._"
       ]
     },
     {
@@ -198,52 +241,22 @@
         "id": "NsJyDxxnjd4B"
       },
       "source": [
-        "## Export to SavedModel\n",
+        "## Export to TensorFlow SavedModel\n",
         "\n",
-        "It is common to want to export a StableHLO model to SavedModel for interop with existing compilation pipelines, existing TF tooling, or serving via [TF Serving](https://github.com/tensorflow/serving).\n",
+        "It is common to want to export a StableHLO model to TensorFlow SavedModel for interoperability with existing compilation pipelines, existing TensorFlow tooling, or serving via [TensorFlow Serving](https://github.com/tensorflow/serving).\n",
         "\n",
-        "PyTorch/XLA makes it easy to pack StableHLO into a SavedModel, which can be loaded back and executed."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gsUYjXg75mHM"
-      },
-      "source": [
-        "### Install latest TF\n",
+        "PyTorch/XLA's `torch_xla.tf_saved_model_integration` module makes it easy to pack StableHLO into a SavedModel, which can be loaded back and executed.\n",
         "\n",
-        "SavedModel definition lives in TF, so we need to install the dependency. We recommend using `tensorflow-cpu` or `tf-nightly`."
+        "### Export to SavedModel with `torch_xla.tf_saved_model_integration`\n",
+        "\n",
+        "We use the `save_torch_module_as_tf_saved_model` function for this conversion, which uses the `torch.export` and `torch_xla.stablehlo.exported_program_to_stablehlo` functions under the hood.\n",
+        "\n",
+        "The input to the API is a PyTorch model, and we use the same `resnet18` from the previous examples."
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "collapsed": true,
-        "id": "d-y5rLcQjqbk"
-      },
-      "outputs": [],
-      "source": [
-        "!pip install -U tensorflow-cpu"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pty18Wc-5sGb"
-      },
-      "source": [
-        "### Export to SavedModel using `torch_xla.tf_saved_model_integration`\n",
-        "\n",
-        "PyTorch/XLA provides a simple API for exporting StableHLO in a SavedModel `save_torch_module_as_tf_saved_model`. This uses the `torch.export` and `torch_xla.stablehlo.exported_program_to_stablehlo` functions under the hood.\n",
-        "\n",
-        "The input to the API is a PyTorch model, we'll use the same `resnet18` from the previous examples."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": 6,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -282,12 +295,12 @@
         "\n",
         "Now we can load that SavedModel and compile using our `sample_input` from a previous example.\n",
         "\n",
-        "_Note: the restored model does *not* require PyTorch or PyTorch/XLA to run, just XLA._"
+        "_Note: The restored model does *not* require PyTorch or PyTorch/XLA to run, just XLA._"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": 7,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -297,18 +310,28 @@
       },
       "outputs": [
         {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
+            "I0000 00:00:1730760467.760638    8492 service.cc:148] XLA service 0x7ede002016e0 initialized for platform Host (this does not guarantee that XLA will be used). Devices:\n",
+            "I0000 00:00:1730760467.760777    8492 service.cc:156]   StreamExecutor device (0): Host, Default Version\n",
+            "I0000 00:00:1730760468.613723    8492 device_compiler.h:188] Compiled cluster using XLA!  This line is logged at most once for the lifetime of the process.\n"
+          ]
+        },
+        {
           "name": "stdout",
           "output_type": "stream",
           "text": [
             "[<tf.Tensor: shape=(4, 1000), dtype=float32, numpy=\n",
-            "array([[-0.74313045, -2.595488  , -0.0718156 , ..., -1.4230162 ,\n",
-            "         1.5928375 , -0.7693139 ],\n",
-            "       [ 0.61994374, -1.594082  , -0.901797  , ...,  0.2451565 ,\n",
-            "         0.6159245 ,  2.4764667 ],\n",
-            "       [-3.029084  ,  2.2174084 , -2.2808676 , ..., -0.90810233,\n",
-            "         1.8252805 ,  2.214109  ],\n",
-            "       [ 0.93176216, -0.0566061 ,  0.8560745 , ..., -0.16496754,\n",
-            "         0.7881946 , -0.26973075]], dtype=float32)>]\n"
+            "array([[-2.3257551 , -0.96061766, -0.9439326 , ...,  0.35189423,\n",
+            "         0.62605226,  2.3971176 ],\n",
+            "       [ 1.6479174 , -0.02676968,  1.0511047 , ..., -1.2511721 ,\n",
+            "         2.2041895 ,  1.8865337 ],\n",
+            "       [ 0.17559683, -0.365776  , -0.06507193, ...,  0.06606296,\n",
+            "         2.135755  ,  0.500913  ],\n",
+            "       [-1.6709077 , -0.7362997 , -2.0962732 , ..., -1.3716122 ,\n",
+            "         0.33205754, -0.91991633]], dtype=float32)>]\n"
           ]
         }
       ],
@@ -325,15 +348,24 @@
         "id": "fSk7HFVk8CqR"
       },
       "source": [
-        "# Common Troubleshooting\n",
+        "## Troubleshooting\n",
         "\n",
-        "Most issues in PyTorch to StableHLO require a GH ticket as a next step. Teams are generally quick to help resolve issues.\n",
+        "### Version mismatch\n",
         "\n",
-        "- Issues in `torch.export`: These need to be resolved in upstream PyTorch.\n",
-        "- Issues in `torch_xla.stablehlo`: Open a ticket on pytorch/xla repo.\n",
+        "Ensure that you have the same version of PyTorch/XLA and PyTorch. Version mismatch can result in import errors, as well as some runtime issues.\n",
         "\n",
-        "The most common issue is that dependencies are out of sync. PyTorch/XLA and PyTorch must be on the same version. Version mismatch can result in import errors, as well as some runtime issues. After that, it is possible that a program fails to export due to a bug in the PyTorch/XLA bridge, for which a ticket with repro is helpful."
+        "### Export bugs\n",
+        "\n",
+        "If your program fails to export due to a bug in the PyTorch/XLA bridge, open an issue on GitHub with a reproducible example:\n",
+        "\n",
+        "- Issues in `torch.export`: Report these in the upstream [pytorch/pytorch](https://github.com/pytorch/pytorch) repository\n",
+        "- Issues in `torch_xla.stablehlo`: Open a ticket on [pytorch/xla](https://github.com/pytorch/xla) repository"
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": []
     }
   ],
   "metadata": {
@@ -345,7 +377,16 @@
       "name": "python3"
     },
     "language_info": {
-      "name": "python"
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.10"
     }
   },
   "nbformat": 4,

--- a/docs/tutorials/pytorch-export.ipynb
+++ b/docs/tutorials/pytorch-export.ipynb
@@ -135,33 +135,11 @@
         "id": "2Ujt2OjtpERw"
       },
       "source": [
-        "### Export with dynamic batch dimension\n",
+        "_Tip:_\n",
         "\n",
+        "_Dynamic batch dimensions can be specified as a part of the initial `torch.export` step._\n",
         "\n",
-        "Dynamic batch dimensions can be specified as a part of the initial `torch.export` step. The FX graph's SymInt information is used to export to dynamic StableHLO.\n",
-        "\n",
-        "In this example, we specify that dimension 0 of the sample input is dynamic, which propagates shape using a `tensor<?x3x224x224xf32>`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# TODO: FIX\n",
-        "# Kernel crashes with \"INVALID_ARGUMENT: Non-broadcast dimensions must not be dynamic\"\n",
-        "\n",
-        "# from torch.export import Dim\n",
-        "\n",
-        "# # Create a dynamic batch size, for the first dimension of the input\n",
-        "# batch = Dim(\"batch\", min=4, max=6)\n",
-        "# dynamic_shapes = ({0: batch},)\n",
-        "\n",
-        "# # Export to FX Graph and then to StableHLO\n",
-        "# dynamic_export = export(resnet18, sample_input, dynamic_shapes=dynamic_shapes)\n",
-        "# dynamic_stablehlo = exported_program_to_stablehlo(dynamic_export)\n",
-        "# print(dynamic_stablehlo.get_stablehlo_text('forward')[0:5000],\"\\n...\")"
+        "_`torch_xla` doesn't yet support exporting models with dynamic shapes to StableHLO, so we recommend using the experimental library [`torch_xla2`](https://github.com/pytorch/xla/tree/master/experimental/torch_xla2) for this. It has a similar API for exporting, converts PyTorch models to JAX prior to exporting to StableHLO, and has high opset coverage along with great dynamic shape support._"
       ]
     },
     {
@@ -232,7 +210,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "_Note: You can also use wrappers to export and save. Learn more in the [PyTorch/XLA documentation on exporting to StableHLO](https://pytorch.org/xla/master/features/stablehlo.html#other-common-wrappers)._"
+        "_Note: You can also use convenience wrappers like `save_torch_model_as_stablehlo` to export and save. Learn more in the [PyTorch/XLA documentation on exporting to StableHLO](https://pytorch.org/xla/master/features/stablehlo.html#other-common-wrappers)._"
       ]
     },
     {


### PR DESCRIPTION
This PR updates the "Exporting StableHLO from PyTorch" tutorial. Specifically:

- Update dependencies, combine the tensorflow dependency in the first section to avoid warnings (about using tensorflow-cpu) on Kaggle
- Minor updates to narration and links, along with an introduction statement
- Removed dynamic batch size code, addedd notes instead

(Supersedes #2616, same updates but we get a rich diff here)