### PR TITLE
Don't require inlining for shape refinement

### DIFF
--- a/stablehlo/transforms/Passes.td
+++ b/stablehlo/transforms/Passes.td
@@ -356,6 +356,25 @@ def StablehloRefineShapesPass : Pass<"stablehlo-refine-shapes", "ModuleOp"> {
 
     %1 = stablehlo.add %arg0, %arg0 : tensor<16xf32>
     ```
+
+  Modules valid for shape refinement must have the following properties:
+
+    * All the dynamic shapes depend only on the input shapes (no shape
+      dependency on the input array contents). We refer to the operations that
+      depend transitively only on the input shapes (e.g., as given by
+      `stablehlo.get_dimension_size`) or global constants like the resolved
+      values of symbolic integers (i.e. tensor<Axf32> : A = 5), as `dimension`
+      operations. All dimension values can be resolved to constants through
+      inter-procedural constant folding.
+    * Intermediate functions may take a number of token arguments (of type
+      !stablehlo.token) at the start of the argument list, followed by some
+      global constant arguments which are constant integer scalars, such as the
+      resolved values of symbolic integers (i.e. tensor<Axf32> : A = 5).
+    * Some intermediate functions may return computations on global constants,
+      i.e. `floordiv` on symint values. These functions are indicated by only
+      returning constant values after refinement. These functions are inlined.
+    * All calls to a single function resolve to the same argument shapes, and no
+      recursive / co-recursive function calls are made.
   }];
 }
 
@@ -375,4 +394,5 @@ def VhloToVersionPass : Pass<"vhlo-to-version"> {
     Option<"targetVersionOption", "target", "std::string", "",
            "The target version. Must be a version of the form #.#.# .">,
   ];
+  let dependentDialects = ["mlir::vhlo::VhloDialect"];
 }

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -292,7 +292,7 @@ class RefinementKey {
       MLIRContext& context) const {
     SmallVector<Type> types(getLeadingTokenOperands() +
                             getFunctionalArgumentTypes().size());
-    for (size_t i = 0; i < leadingTokenOperands; ++i)
+    for (size_t i = 0; i < static_cast<size_t>(leadingTokenOperands); ++i)
       types[i] = stablehlo::TokenType::get(&context);
     for (auto [i, refinedType] : llvm::enumerate(getFunctionalArgumentTypes()))
       types[i + leadingTokenOperands] = refinedType;

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -444,9 +444,9 @@ class RefineShapeState {
   LogicalResult emitDifferentRefinementContextError(func::FuncOp func,
                                                     RefinementKey key,
                                                     RefinementKey prevKey) {
-    return func.emitOpError()
-           << "refined with invompatible refinement keys:" << "\n  curr="
-           << key.toString() << "\n  prev=" << prevKey.toString();
+    return func.emitOpError() << "refined with invompatible refinement keys:"
+                              << "\n  curr=" << key.toString()
+                              << "\n  prev=" << prevKey.toString();
   }
 };
 

--- a/stablehlo/transforms/StablehloRefineShapes.h
+++ b/stablehlo/transforms/StablehloRefineShapes.h
@@ -35,6 +35,11 @@ namespace stablehlo {
 // be obtained from the module.
 func::FuncOp getStablehloRefineShapesTarget(ModuleOp module);
 
+// Refine the arguments of the given function using the given types.
+// Wraps all operands in a custom call to keep the IR valid during refinement.
+// %0 = stablehlo.custom_call @stablehlo.shape_refinement_operand_wrapper(%arg0)
+LogicalResult refineArguments(func::FuncOp func, TypeRange refinedTypes);
+
 // Refines the values using the given types.
 // Tricky implementation details:
 //   1) Need to support partial shape refinements, e.g. if just a single


### PR DESCRIPTION
Currently we require MLIR function inlining before refining shapes. Refining shapes in order and following call operations (enforcing no recursive calls) should allow for `refine(dynamic_export, static_args) == static_export` to be true