### PR TITLE
Expose materialize functions in Chlo to Stablehlo lowering

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1137,6 +1137,7 @@ cc_library(
         "stablehlo/transforms/PassUtils.h",
         "stablehlo/transforms/Passes.h",
         "stablehlo/transforms/StablehloRefineShapes.h",
+        "stablehlo/transforms/ChloDecompositionUtils.h",
     ],
     strip_include_prefix = ".",
     deps = [

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1133,11 +1133,11 @@ cc_library(
         "stablehlo/transforms/VhloToVersion.cpp",
     ],
     hdrs = [
+        "stablehlo/transforms/ChloDecompositionUtils.h",
         "stablehlo/transforms/MapStablehloToVhlo.h",
         "stablehlo/transforms/PassUtils.h",
         "stablehlo/transforms/Passes.h",
         "stablehlo/transforms/StablehloRefineShapes.h",
-        "stablehlo/transforms/ChloDecompositionUtils.h",
     ],
     strip_include_prefix = ".",
     deps = [

--- a/stablehlo/transforms/ChloDecompositionUtils.h
+++ b/stablehlo/transforms/ChloDecompositionUtils.h
@@ -1,0 +1,42 @@
+/* Copyright 2024 The StableHLO Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef THIRD_PARTY_STABLEHLO_STABLEHLO_TRANSFORMS_CHLO_DECOMP_UTILS_H_
+#define THIRD_PARTY_STABLEHLO_STABLEHLO_TRANSFORMS_CHLO_DECOMP_UTILS_H_
+
+#include "mlir/IR/Value.h"
+#include "mlir/IR/ValueRange.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+namespace stablehlo {
+
+// Utility functions used in the Chlo to stablehlo legalization.
+
+Value getConstantLikeMaxFiniteValue(OpBuilder &b, Location loc, Value val);
+
+Value getConstantLikeInfValue(OpBuilder &b, Location loc, Value val,
+                              bool negative);
+
+Value getConstantLikeSmallestNormalizedValue(OpBuilder &b, Location loc,
+                                             Value val);
+
+Value materializeLgamma(ConversionPatternRewriter &rewriter, Location loc,
+                        ValueRange args);
+
+Value materializeDigamma(ConversionPatternRewriter &rewriter, Location loc,
+                         ValueRange args);
+
+}  // namespace stablehlo
+}  // namespace mlir
+
+#endif  // THIRD_PARTY_STABLEHLO_STABLEHLO_TRANSFORMS_CHLO_DECOMP_UTILS_H_

--- a/stablehlo/transforms/ChloDecompositionUtils.h
+++ b/stablehlo/transforms/ChloDecompositionUtils.h
@@ -10,8 +10,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef THIRD_PARTY_STABLEHLO_STABLEHLO_TRANSFORMS_CHLO_DECOMP_UTILS_H_
-#define THIRD_PARTY_STABLEHLO_STABLEHLO_TRANSFORMS_CHLO_DECOMP_UTILS_H_
+#ifndef STABLEHLO_TRANSFORMS_CHLO_DECOMP_UTILS_H_
+#define STABLEHLO_TRANSFORMS_CHLO_DECOMP_UTILS_H_
 
 #include "mlir/IR/Value.h"
 #include "mlir/IR/ValueRange.h"
@@ -46,4 +46,4 @@ Value materializePolygamma(ConversionPatternRewriter &rewriter, Location loc,
 }  // namespace stablehlo
 }  // namespace mlir
 
-#endif  // THIRD_PARTY_STABLEHLO_STABLEHLO_TRANSFORMS_CHLO_DECOMP_UTILS_H_
+#endif  // STABLEHLO_TRANSFORMS_CHLO_DECOMP_UTILS_H_

--- a/stablehlo/transforms/ChloDecompositionUtils.h
+++ b/stablehlo/transforms/ChloDecompositionUtils.h
@@ -22,17 +22,13 @@ namespace stablehlo {
 
 // Utility functions used in the Chlo to stablehlo legalization.
 
-Value materializeLgamma(OpBuilder &rewriter, Location loc,
-                        ValueRange args);
+Value materializeLgamma(OpBuilder &rewriter, Location loc, ValueRange args);
 
-Value materializeDigamma(OpBuilder &rewriter, Location loc,
-                         ValueRange args);
+Value materializeDigamma(OpBuilder &rewriter, Location loc, ValueRange args);
 
-Value materializeZeta(OpBuilder &rewriter, Location loc,
-                      ValueRange args);
+Value materializeZeta(OpBuilder &rewriter, Location loc, ValueRange args);
 
-Value materializePolygamma(OpBuilder &rewriter, Location loc,
-                           ValueRange args);
+Value materializePolygamma(OpBuilder &rewriter, Location loc, ValueRange args);
 
 }  // namespace stablehlo
 }  // namespace mlir

--- a/stablehlo/transforms/ChloDecompositionUtils.h
+++ b/stablehlo/transforms/ChloDecompositionUtils.h
@@ -22,19 +22,26 @@ namespace stablehlo {
 
 // Utility functions used in the Chlo to stablehlo legalization.
 
-Value getConstantLikeMaxFiniteValue(OpBuilder &b, Location loc, Value val);
-
-Value getConstantLikeInfValue(OpBuilder &b, Location loc, Value val,
-                              bool negative);
-
-Value getConstantLikeSmallestNormalizedValue(OpBuilder &b, Location loc,
-                                             Value val);
-
 Value materializeLgamma(ConversionPatternRewriter &rewriter, Location loc,
                         ValueRange args);
 
+Value materializeCoshApproximation(ConversionPatternRewriter &rewriter,
+                                   Location loc, ValueRange operands);
+
+Value materializeSinhApproximationForLargeX(ConversionPatternRewriter &rewriter,
+                                            Location loc, ValueRange operands);
+
+Value materializeSinhApproximation(ConversionPatternRewriter &rewriter,
+                                   Location loc, ValueRange operands);
+
 Value materializeDigamma(ConversionPatternRewriter &rewriter, Location loc,
                          ValueRange args);
+
+Value materializeZeta(ConversionPatternRewriter &rewriter, Location loc,
+                      ValueRange args);
+
+Value materializePolygamma(ConversionPatternRewriter &rewriter, Location loc,
+                           ValueRange args);
 
 }  // namespace stablehlo
 }  // namespace mlir

--- a/stablehlo/transforms/ChloDecompositionUtils.h
+++ b/stablehlo/transforms/ChloDecompositionUtils.h
@@ -22,25 +22,16 @@ namespace stablehlo {
 
 // Utility functions used in the Chlo to stablehlo legalization.
 
-Value materializeLgamma(ConversionPatternRewriter &rewriter, Location loc,
+Value materializeLgamma(OpBuilder &rewriter, Location loc,
                         ValueRange args);
 
-Value materializeCoshApproximation(ConversionPatternRewriter &rewriter,
-                                   Location loc, ValueRange operands);
-
-Value materializeSinhApproximationForLargeX(ConversionPatternRewriter &rewriter,
-                                            Location loc, ValueRange operands);
-
-Value materializeSinhApproximation(ConversionPatternRewriter &rewriter,
-                                   Location loc, ValueRange operands);
-
-Value materializeDigamma(ConversionPatternRewriter &rewriter, Location loc,
+Value materializeDigamma(OpBuilder &rewriter, Location loc,
                          ValueRange args);
 
-Value materializeZeta(ConversionPatternRewriter &rewriter, Location loc,
+Value materializeZeta(OpBuilder &rewriter, Location loc,
                       ValueRange args);
 
-Value materializePolygamma(ConversionPatternRewriter &rewriter, Location loc,
+Value materializePolygamma(OpBuilder &rewriter, Location loc,
                            ValueRange args);
 
 }  // namespace stablehlo

--- a/stablehlo/transforms/ChloLegalizeToStablehlo.cpp
+++ b/stablehlo/transforms/ChloLegalizeToStablehlo.cpp
@@ -1250,7 +1250,7 @@ constexpr std::array<double, 8> kLanczosCoefficients = {
     12.507343278686904814458936853,     -0.13857109526572011689554707,
     9.984369578019570859563e-6,         1.50563273514931155834e-7};
 
-} // namespace
+}  // namespace
 
 // Compute the Lgamma function using Lanczos' approximation from "A Precision
 // Approximation of the Gamma Function". SIAM Journal on Numerical Analysis
@@ -1437,7 +1437,7 @@ struct ConvertCoshOp final : OpConversionPattern<mlir::chlo::CoshOp> {
   }
 };
 
-} // namespace
+}  // namespace
 
 // Compute the Digamma function using Lanczos' approximation from "A Precision
 // Approximation of the Gamma Function". SIAM Journal on Numerical Analysis


### PR DESCRIPTION
We want to perform constant propogation through `chlo.lgamma` in Enzyme-JaX

[Kevin](https://github.com/EnzymeAD/Enzyme-JAX/pull/182#discussion_r1876814931) mentioned he was open to exposing some materialize functions (which are currently static, and not callable from [our pass](https://github.com/EnzymeAD/Enzyme-JAX/blob/main/src/enzyme_ad/jax/Passes/EnzymeHLOOpt.cpp) atm)



@wsmoses @GleasonK 