### PR TITLE
Expose populateStablehloToLinalgConversionPatterns function

### DIFF
--- a/stablehlo/conversions/linalg/transforms/Rewriters.h
+++ b/stablehlo/conversions/linalg/transforms/Rewriters.h
@@ -22,28 +22,15 @@ limitations under the License.
 namespace mlir::stablehlo {
 
 //===----------------------------------------------------------------------===//
-// General StableHLO/CHLO lowering patterns.
+// General StableHLO lowering patterns.
 //===----------------------------------------------------------------------===//
 
 /// Populates the patterns that convert from StableHLO to Linalg on tensors.
 void populateStablehloToLinalgConversionPatterns(MLIRContext *context,
                                                  TypeConverter &typeConverter,
                                                  RewritePatternSet *patterns,
-                                                 bool enablePrimitiveOps);
-
-/// Collection of rewrite patterns for lowering of CHLO ops to StableHLO and
-/// Shape ops.
-void populateLegalizeChloPatterns(MLIRContext *context,
-                                  RewritePatternSet *patterns);
-
-/// Collection of rewrite patterns for lowering of StableHLO ops to SCF control
-/// flow ops.
-void populateLegalizeControlFlowPatterns(MLIRContext *context,
-                                         RewritePatternSet *patterns);
-
-/// Collection of rewrite patterns for lowering of StableHLO dim operations.
-void populateLegalizeShapeComputationPatterns(MLIRContext *context,
-                                              RewritePatternSet *patterns);
+                                                 bool enablePrimitiveOps,
+                                                 bool enableSparseOps);
 
 //===----------------------------------------------------------------------===//
 // Fine-grained patterns used by the implementation.


### PR DESCRIPTION
This function declaration has existed since the code was forked from IREE in https://github.com/openxla/stablehlo/pull/1817, but the implementation was kept private (static function within an anonymous namespace).

I'm now trying to switch IREE from having its own implementation to using the upstream implementation from this project in https://github.com/iree-org/iree/pull/19792, and I would like to access these patterns directly, instead of through the `StablehloLegalizeToLinalgPass`. With the patterns I can run conversion including my own sets of additional patterns, while a pass runs in isolation.

I'm also deleting the `populateLegalizeChloPatterns`, `populateLegalizeControlFlowPatterns`, and `populateLegalizeShapeComputationPatterns` declarations, which were not migrated from IREE and are also dangling without implementations.