### PR TITLE
Add source link to awesome.md.

### DIFF
--- a/docs/awesome.md
+++ b/docs/awesome.md
@@ -18,7 +18,9 @@ backends. Built by industry leaders in AI modeling, software, and hardware.
 **How is the community using OpenXLA?** This page consolidates links to
 repositories and projects using OpenXLA to provide inspiration and code pointers!
 
-**Have a project that uses OpenXLA?** Send us a pull request and add it to this page!
+**Have a project that uses OpenXLA?** Send us a
+[pull request](https://github.com/openxla/stablehlo/blob/main/docs/awesome.md)
+and add it to this page!
 
 ## Frameworks
 


### PR DESCRIPTION
I couldn't find an easy link back to this source file from https://openxla.org/stablehlo/awesome.

I _think_ this style of URL should be fine, but I might be missing some website detail (for example, the hosted website has support for translations).

A site-wide solution may be available for some source files. For example:
* The mkdocs-material site generator has "edit this page" and "view source of this page" actions: https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/#code-actions.
* Some tensorflow examples include "View source on GitHub" buttons for notebooks: https://www.tensorflow.org/guide/keras/functional_api