### PR TITLE
Fix duplicate symbols for downstream CAPIObjects users

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -943,7 +943,6 @@ cc_library(
     ],
 )
 
-
 # Header-only target, used when using the C API from a separate shared library.
 cc_library(
     name = "stablehlo_dialect_capi_headers",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -943,6 +943,36 @@ cc_library(
     ],
 )
 
+
+# Header-only target, used when using the C API from a separate shared library.
+cc_library(
+    name = "stablehlo_dialect_capi_headers",
+    hdrs = STABLEHLO_DIALECT_CAPI_HEADERS,
+    strip_include_prefix = ".",
+    deps = [
+        "@llvm-project//mlir:CAPIIRHeaders",
+    ],
+)
+
+# Alwayslink target, used when exporting the C API from a shared library.
+cc_library(
+    name = "stablehlo_dialect_capi_objects",
+    srcs = STABLEHLO_DIALECT_CAPI_SOURCES,
+    hdrs = STABLEHLO_DIALECT_CAPI_HEADERS,
+    strip_include_prefix = ".",
+    deps = [
+        ":stablehlo_ops",
+        ":stablehlo_portable_api",
+        ":stablehlo_serialization",
+        ":version",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:CAPIIRObjects",
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Support",
+    ],
+    alwayslink = True,
+)
+
 STABLEHLO_UNIFIED_CAPI_SOURCES = [
     "stablehlo/integrations/c/StablehloPasses.cpp",
     "stablehlo/integrations/c/StablehloUnifiedApi.cpp",
@@ -1010,7 +1040,7 @@ cc_library(
         ":linalg_passes",
         ":reference_api",
         ":reference_configuration",
-        ":stablehlo_dialect_capi",
+        ":stablehlo_dialect_capi_objects",
         ":stablehlo_ops",
         ":stablehlo_passes",
         ":stablehlo_portable_api",


### PR DESCRIPTION
Should fix failure in https://github.com/openxla/xla/pull/22438

I need just a bit more time to validate this entirely on Linux