### PR TITLE
Pass to wrap StableHLO ops in composite

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1246,6 +1246,7 @@ cc_library(
         "stablehlo/transforms/StablehloLegalizeToVhlo.cpp",
         "stablehlo/transforms/StablehloRefineArguments.cpp",
         "stablehlo/transforms/StablehloRefineShapes.cpp",
+        "stablehlo/transforms/StablehloWrapInComposite.cpp",
         "stablehlo/transforms/VhloLegalizeToStablehlo.cpp",
         "stablehlo/transforms/VhloToVersion.cpp",
     ],

--- a/docs/generated/stablehlo_passes.md
+++ b/docs/generated/stablehlo_passes.md
@@ -380,15 +380,16 @@ Notes:
     operation, and `N` is a unique integer identifier generated to prevent
     naming conflicts within the module.
 
-This pass can be used in three distinct ways:
+This pass can be used in two distinct ways:
 
 **Mode 1: Command-line Usage**
 
-This mode is the simplest, using the `stablehlo-opt` utility with the
-`op-names` (a comma-separated list of operation names) and `version` (an
-integer version number) options. It wraps **all instances** of specified
-operations. The attributes of the newly created `stablehlo.composite`
-operation will be the same as the attributes of the original operation.
+This mode is intended for debugging or testing, as it offers minimal control
+over the attributes of the generated `stablehlo.composite` operations.
+It wraps **all instances** of operations specified using the `op-names`
+(a comma-separated list of operation names) options. The attributes of the
+newly created `stablehlo.composite` operation will be the same as the
+attributes of the original operation.
 
 **Usage Example:**
 
@@ -396,28 +397,7 @@ operation will be the same as the attributes of the original operation.
 stablehlo-opt input.mlir --stablehlo-wrap-in-composite=op-names='stablehlo.add,stablehlo.mul' -o output.mlir
 ```
 
-**Mode 2: Programmatic Single-Op Wrapping**
-
-This mode provides programmatic control to wrap
-**a specific operation instance** and returns a pointer to the newly
-created `stablehlo.composite` operation.
-
-**Example (C++):**
-
-```cpp
-// To wrap a specific stablehlo.add instance
-
-mlir::stablehlo::AddOp addOp = ...; // The op instanced to be wrapped.
-mlir::ModuleOp module = addOp->getParentOfType<mlir::ModuleOp>();
-mlir::OpBuilder builder(addOp);
-mlir::NamedAttrList attrs = ...; // Attributes to be set on the composite op.
-int32_t version = 0; // Composite version.
-
-mlir::stablehlo::CompositeOp compositeOp = mlir::stablehlo::wrapOperationInComposite(builder, addOp, attrs, version, module);
-addOp.replaceAllUsesWith(compositeOp);
-```
-
-**Mode 3: Programmatic Module-Wide Wrapping with customized Attribute Handling**
+**Mode 2: Programmatic Module-Wide Wrapping with customized Attribute Handling**
 
 This mode extends programmatic wrapping to the entire module, offering
 fine-grained control over which operations are wrapped and their attributes.
@@ -447,8 +427,6 @@ handled. Its semantics are as follows:
 **Example (C++):**
 
 ```cpp
-
-// ... inside a pass or function ...
 
 stablehlo::CompositeAttributeProviderMap compositeAttributeProviderMap;
 

--- a/docs/generated/stablehlo_passes.md
+++ b/docs/generated/stablehlo_passes.md
@@ -338,6 +338,143 @@ Modules valid for shape refinement must have the following properties:
   * All calls to a single function resolve to the same argument shapes, and no
     recursive / co-recursive function calls are made.
 
+### `-stablehlo-wrap-in-composite`
+
+_Wraps a non-composite  StableHLO op in a composite op._
+
+Wraps StableHLO operations in `stablehlo.composite` operations.
+
+For instance, consider a simple StableHLO program:
+
+```mlir
+  func.func @main(%arg0 : tensor<2xf32>, %arg1 : tensor<2xf32>) -> tensor<2xf32> {
+    %0 = stablehlo.add %arg0, %arg1 : tensor<2xf32>
+    return %0 : tensor<2xf32>
+  }
+```
+
+Applying this pass to wrap `stablehlo.add` operations will result in the
+following program:
+
+```mlir
+  func.func @main(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> tensor<2xf32> {
+    %0 = stablehlo.composite "stablehlo.add" %arg0, %arg1 {decomposition = @stablehlo.add.impl} : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
+    return %0 : tensor<2xf32>
+  }
+  func.func private @stablehlo.add.impl(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> tensor<2xf32> {
+    %0 = stablehlo.add %arg0, %arg1 : tensor<2xf32>
+    return %0 : tensor<2xf32>
+  }
+```
+
+Notes:
+
+  - The `name` attribute of the generated `stablehlo.composite` operation
+    will always be the same as the name of the original operation that was
+    wrapped (e.g., if you wrap a `stablehlo.add` operation, the composite
+    will also be named `"stablehlo.add"`).
+  - The private function that encapsulates the original operation
+    (referenced by the `decomposition` attribute of the
+    `stablehlo.composite` operation) will be named using the pattern
+    `<op_name>.impl[.N]`, where `<op_name>` is the name of the original
+    operation, and `N` is a unique integer identifier generated to prevent
+    naming conflicts within the module.
+
+This pass can be used in three distinct ways:
+
+**Mode 1: Command-line Usage**
+
+This mode is the simplest, using the `stablehlo-opt` utility with the
+`op-names` (a comma-separated list of operation names) and `version` (an
+integer version number) options. It wraps **all instances** of specified
+operations. The attributes of the newly created `stablehlo.composite`
+operation will be the same as the attributes of the original operation.
+
+**Usage Example:**
+
+```bash
+stablehlo-opt input.mlir --stablehlo-wrap-in-composite=op-names='stablehlo.add,stablehlo.mul' -o output.mlir
+```
+
+**Mode 2: Programmatic Single-Op Wrapping**
+
+This mode provides programmatic control to wrap
+**a specific operation instance** and returns a pointer to the newly
+created `stablehlo.composite` operation.
+
+**Example (C++):**
+
+```cpp
+  // To wrap a specific stablehlo.add instance
+
+  mlir::stablehlo::AddOp addOp = ...; // The op instanced to be wrapped.
+  mlir::ModuleOp module = addOp->getParentOfType<mlir::ModuleOp>();
+  mlir::OpBuilder builder(addOp);
+  mlir::NamedAttrList attrs = ...; // Attributes to be set on the composite op.
+  int32_t version = 0; // Composite version.
+
+  mlir::stablehlo::CompositeOp compositeOp = mlir::stablehlo::wrapOperationInComposite(builder, addOp, attrs, version, module);
+  addOp.replaceAllUsesWith(compositeOp);
+```
+
+**Mode 3: Programmatic Module-Wide Wrapping with Attribute Predicates**
+
+This mode extends programmatic wrapping to the entire module, offering
+fine-grained control over which operations are wrapped and their attributes.
+This is achieved by using the `createStablehloWrapInCompositePass` API,
+which takes an `AttributePredicateMap` as an argument.
+
+The `AttributePredicateMap` is a map that dictates which operations should
+be considered for wrapping and how their attributes should be handled. Its
+semantics are as follows:
+
+- **Keys (mlir::TypeID):** `TypeID` of an MLIR operation. If an operation's
+    `TypeID` matches a key in the map, it becomes a candidate for wrapping.
+- **Values (Lambda Functions):** Lambda function of type
+    `std::function<std::optional<NamedAttrList>(Operation*)>`. This function
+    is applied to each candidate operation.
+    - **Input:** An `mlir::Operation*`, which is an instance of the
+      operation type corresponding to the `TypeID` key.
+    - **Return Value:** An `std::optional<NamedAttrList>`.
+      - If the lambda returns a `NamedAttrList` (wrapped in
+        `std::optional`), the operation is wrapped in a
+        `stablehlo::composite` operation, and the returned attributes are
+        used to set the composite's attributes.
+      - If the lambda returns `std::nullopt`, the operation is **not**
+        wrapped. This allows for selective wrapping based on custom
+        criteria.
+
+**Example (C++):**
+
+```cpp
+
+// ... inside a pass or function ...
+
+stablehlo::AttributePredicateMap attributePredicateMap;
+
+attributePredicateMap[mlir::TypeID::get<mlir::stablehlo::AddOp>()] =
+  [](mlir::Operation* op) -> std::optional<mlir::NamedAttrList> {
+  // Custom logic to determine if and how to wrap the operation.
+  // Example: Only wrap if it's on a specific type.
+  if (op->getOperand(0).getType().isa<mlir::Float32Type>()) {
+    return mlir::NamedAttrList(op->getAttrs());
+  }
+  return std::nullopt; // Do not wrap.
+};
+
+pm.addPass(createStablehloWrapInCompositePass(attributePredicateMap, compositeVersion));
+if (mlir::failed(pm.run(module))) {
+  return;
+}
+```
+
+#### Options
+
+```
+-op-names : The names of the ops to wrap.
+-version  : The version number of the composite op.
+```
+
 ### `-vhlo-legalize-to-stablehlo`
 
 _Legalize VHLO to StableHLO._

--- a/stablehlo/tests/transforms/stablehlo_wrap_in_composite.mlir
+++ b/stablehlo/tests/transforms/stablehlo_wrap_in_composite.mlir
@@ -1,4 +1,4 @@
-// RUN: stablehlo-opt --stablehlo-wrap-in-composite=op-names='stablehlo.add,stablehlo.convolution,stablehlo.reduce' --split-input-file --verify-diagnostics %s | FileCheck %s
+// RUN: stablehlo-opt --stablehlo-wrap-in-composite='op-names=stablehlo.add,stablehlo.convolution,stablehlo.reduce version=1' --split-input-file --verify-diagnostics %s | FileCheck %s
 
 // CHECK-LABEL: func.func @wrap_in_composite
 // CHECK-SAME: %[[ARG_0:.*]]: tensor<64x8x8x8xi8>,
@@ -11,8 +11,11 @@
 // CHECK-SAME{LITERAL}: padding = dense<[[0, 1], [0, 1]]> : tensor<2x2xi64>,
 // CHECK-SAME{LITERAL}: rhs_dilation = array<i64: 2, 2>,
 // CHECK-SAME{LITERAL}: window_strides = array<i64: 1, 1>},
-// CHECK-SAME: decomposition = @stablehlo.convolution.impl} : (tensor<64x8x8x8xi8>, tensor<4x4x8x32xi8>) -> tensor<64x3x3x32xi32>
-// CHECK: %[[ADD:.*]] = stablehlo.composite "stablehlo.add" %[[CONV]], %[[ARG_2]] {decomposition = @stablehlo.add.impl} : (tensor<64x3x3x32xi32>, tensor<64x3x3x32xi32>) -> tensor<64x3x3x32xi32>
+// CHECK-SAME: decomposition = @stablehlo.convolution.impl,
+// CHECK-SAME: version = 1 : i32} : (tensor<64x8x8x8xi8>, tensor<4x4x8x32xi8>) -> tensor<64x3x3x32xi32>
+// CHECK: %[[ADD:.*]] = stablehlo.composite "stablehlo.add" %[[CONV]], %[[ARG_2]] {
+// CHECK-SAME: decomposition = @stablehlo.add.impl,
+// CHECK-SAME: version = 1 : i32} : (tensor<64x3x3x32xi32>, tensor<64x3x3x32xi32>) -> tensor<64x3x3x32xi32>
 // CHECK-NEXT: return %[[ADD]]
 
 // CHECK-LABEL: func.func private @stablehlo.add.impl
@@ -55,8 +58,8 @@ func.func @wrap_in_composite(
 // CHECK-NEXT: %[[COMPOSITE_REDUCE:.*]] = stablehlo.composite "stablehlo.reduce" %[[ARG_0]], %[[CONST]] {
 // CHECK-SAME: composite_attributes = {
 // CHECK-SAME: dimensions = array<i64: 1>},
-// CHECK-SAME: decomposition = @stablehlo.reduce.impl}
-// CHECK-SAME: (tensor<4x3xf32>, tensor<f32>) -> tensor<4xf32>
+// CHECK-SAME: decomposition = @stablehlo.reduce.impl,
+// CHECK-SAME: version = 1 : i32} : (tensor<4x3xf32>, tensor<f32>) -> tensor<4xf32>
 // CHECK-NEXT: return %[[COMPOSITE_REDUCE]]
 
 // CHECK-LABEL: func.func private @stablehlo.reduce.impl

--- a/stablehlo/tests/transforms/stablehlo_wrap_in_composite.mlir
+++ b/stablehlo/tests/transforms/stablehlo_wrap_in_composite.mlir
@@ -1,0 +1,85 @@
+// RUN: stablehlo-opt --stablehlo-wrap-in-composite=op-names='stablehlo.add,stablehlo.convolution,stablehlo.reduce' --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL: func.func @wrap_in_composite
+// CHECK-SAME: %[[ARG_0:.*]]: tensor<64x8x8x8xi8>,
+// CHECK-SAME: %[[ARG_1:.*]]: tensor<4x4x8x32xi8>,
+// CHECK-SAME: %[[ARG_2:.*]]: tensor<64x3x3x32xi32>) -> tensor<64x3x3x32xi32> {
+// CHECK: %[[CONV:.*]] = stablehlo.composite "stablehlo.convolution" %[[ARG_0]], %[[ARG_1]] {
+// CHECK-SAME: composite_attributes = {batch_group_count = 1 : i64,
+// CHECK-SAME: dimension_numbers = #stablehlo.conv<[b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f]>,
+// CHECK-SAME: feature_group_count = 1 : i64,
+// CHECK-SAME{LITERAL}: padding = dense<[[0, 1], [0, 1]]> : tensor<2x2xi64>,
+// CHECK-SAME{LITERAL}: rhs_dilation = array<i64: 2, 2>,
+// CHECK-SAME{LITERAL}: window_strides = array<i64: 1, 1>},
+// CHECK-SAME: decomposition = @stablehlo.convolution.impl} : (tensor<64x8x8x8xi8>, tensor<4x4x8x32xi8>) -> tensor<64x3x3x32xi32>
+// CHECK: %[[ADD:.*]] = stablehlo.composite "stablehlo.add" %[[CONV]], %[[ARG_2]] {decomposition = @stablehlo.add.impl} : (tensor<64x3x3x32xi32>, tensor<64x3x3x32xi32>) -> tensor<64x3x3x32xi32>
+// CHECK-NEXT: return %[[ADD]]
+
+// CHECK-LABEL: func.func private @stablehlo.add.impl
+// CHECK-SAME: %[[ARG_0:.*]]: tensor<64x3x3x32xi32>,
+// CHECK-SAME: %[[ARG_1:.*]]: tensor<64x3x3x32xi32>) -> tensor<64x3x3x32xi32> {
+// CHECK: %[[VAL:.*]] = stablehlo.add %[[ARG_0]], %[[ARG_1]] : tensor<64x3x3x32xi32>
+// CHECK-NEXT: return %[[VAL]]
+
+// CHECK-LABEL: func.func private @stablehlo.convolution.impl
+// CHECK-SAME: %[[ARG_0:.*]]: tensor<64x8x8x8xi8>,
+// CHECK-SAME: %[[ARG_1:.*]]: tensor<4x4x8x32xi8>) -> tensor<64x3x3x32xi32> {
+// CHECK: %[[VAL:.*]] = stablehlo.convolution(%[[ARG_0]], %[[ARG_1]])
+// CHECK-SAME{LITERAL}: dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+// CHECK-SAME{LITERAL}: stride = [1, 1],
+// CHECK-SAME{LITERAL}: pad = [[0, 1], [0, 1]],
+// CHECK-SAME{LITERAL}: rhs_dilate = [2, 2]}
+// CHECK-SAME: batch_group_count = 1 : i64
+// CHECK-SAME: feature_group_count = 1 : i64
+// CHECK-SAME: : (tensor<64x8x8x8xi8>, tensor<4x4x8x32xi8>) -> tensor<64x3x3x32xi32>
+// CHECK-NEXT: return %[[VAL]]
+
+func.func @wrap_in_composite(
+    %arg0: tensor<64x8x8x8xi8>,
+    %arg1: tensor<4x4x8x32xi8>,
+    %arg2: tensor<64x3x3x32xi32>) -> tensor<64x3x3x32xi32> {
+  %0 = stablehlo.convolution(%arg0, %arg1)
+         dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+         window = {stride = [1, 1], pad = [[0, 1], [0, 1]], rhs_dilate = [2, 2]}
+         {batch_group_count = 1 : i64, feature_group_count = 1 : i64} :
+       (tensor<64x8x8x8xi8>, tensor<4x4x8x32xi8>) -> tensor<64x3x3x32xi32>
+  %1 = stablehlo.add %0, %arg2 : tensor<64x3x3x32xi32>
+  func.return %1 : tensor<64x3x3x32xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @wrap_in_composite_op_with_region
+// CHECK-SAME: %[[ARG_0:.*]]: tensor<4x3xf32>) -> tensor<4xf32>
+// CHECK: %[[CONST:.*]] = stablehlo.constant
+// CHECK-NEXT: %[[COMPOSITE_REDUCE:.*]] = stablehlo.composite "stablehlo.reduce" %[[ARG_0]], %[[CONST]] {
+// CHECK-SAME: composite_attributes = {
+// CHECK-SAME: dimensions = array<i64: 1>},
+// CHECK-SAME: decomposition = @stablehlo.reduce.impl}
+// CHECK-SAME: (tensor<4x3xf32>, tensor<f32>) -> tensor<4xf32>
+// CHECK-NEXT: return %[[COMPOSITE_REDUCE]]
+
+// CHECK-LABEL: func.func private @stablehlo.reduce.impl
+// CHECK-SAME: %[[ARG_0:.*]]: tensor<4x3xf32>,
+// CHECK-SAME: %[[ARG_1:.*]]: tensor<f32>) -> tensor<4xf32> {
+// CHECK: %[[REDUCE:.*]] = stablehlo.reduce(%[[ARG_0]] init: %[[ARG_1]])
+// CHECK-SAME{LITERAL}: applies stablehlo.add across dimensions = [1]
+// CHECK-SAME: (tensor<4x3xf32>, tensor<f32>) -> tensor<4xf32>
+// CHECK-NEXT: return %[[REDUCE]]
+func.func @wrap_in_composite_op_with_region(%x : tensor<4x3xf32>) -> tensor<4xf32> {
+  %cst = stablehlo.constant dense<2.7> : tensor<f32>
+  %res = stablehlo.reduce(%x init: %cst) applies stablehlo.add across dimensions = [1] : (tensor<4x3xf32>, tensor<f32>) -> tensor<4xf32>
+  func.return %res : tensor<4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @cannot_be_wrapped_ops_does_not_match
+// CHECK-SAME: %[[ARG_0:.*]]: tensor<2xf32>,
+// CHECK-SAME: %[[ARG_1:.*]]: tensor<2xf32>) -> tensor<2xf32> {
+// CHECK: %[[VAL:.*]] = stablehlo.multiply %[[ARG_0]], %[[ARG_1]] : tensor<2xf32>
+// CHECK-NEXT: return %[[VAL]] : tensor<2xf32>
+func.func @cannot_be_wrapped_ops_does_not_match(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> tensor<2xf32> {
+  %0 = stablehlo.multiply %arg0, %arg1 : tensor<2xf32>
+  func.return %0 : tensor<2xf32>
+}

--- a/stablehlo/transforms/CMakeLists.txt
+++ b/stablehlo/transforms/CMakeLists.txt
@@ -57,6 +57,7 @@ add_mlir_dialect_library(StablehloPasses
   StablehloLegalizeToVhlo.cpp
   StablehloRefineArguments.cpp
   StablehloRefineShapes.cpp
+  StablehloWrapInComposite.cpp
   VhloLegalizeToStablehlo.cpp
   VhloToVersion.cpp
   PassUtils.cpp

--- a/stablehlo/transforms/Passes.h
+++ b/stablehlo/transforms/Passes.h
@@ -112,14 +112,15 @@ std::unique_ptr<OperationPass<ModuleOp>> createStablehloRefineArgumentsPass(
     TypeRange refinedTypes);
 
 /// Creates a pass that wraps StableHLO ops in CompositeOp.
-/// The pass takes in a map of op type to attribute predicate. The attribute
-/// predicate is a function that takes in an operation, of the given op type,
-/// and returns a list of attributes to be added to the CompositeOp.
-using AttributePredicate =
+/// The pass takes in a map from op's type id to a function that returns the
+/// attributes to be added to the CompositeOp. The pass also takes in a
+/// version number for the CompositeOp.
+using CompositeAttributeProvider =
     std::function<std::optional<NamedAttrList>(Operation *)>;
-using AttributePredicateMap = llvm::DenseMap<mlir::TypeID, AttributePredicate>;
+using CompositeAttributeProviderMap =
+    llvm::DenseMap<mlir::TypeID, CompositeAttributeProvider>;
 std::unique_ptr<OperationPass<ModuleOp>> createStablehloWrapInCompositePass(
-    const AttributePredicateMap &attributePredicateMap,
+    const CompositeAttributeProviderMap &compositeAttributeProviderMap,
     int32_t compositeVersion);
 
 /// Wraps the given operation in a CompositeOp with the specified NamedAttrs and

--- a/stablehlo/transforms/Passes.h
+++ b/stablehlo/transforms/Passes.h
@@ -125,6 +125,24 @@ std::unique_ptr<OperationPass<ModuleOp>> createStablehloWrapInCompositePass(
 
 /// Wraps the given operation in a CompositeOp with the specified NamedAttrs and
 /// version and returns the CompositeOp.
+///
+/// **A typical usage **
+///
+/// ```cpp
+/// // To wrap a specific stablehlo.add instance
+///
+/// mlir::stablehlo::AddOp addOp = ...; // The op instanced to be wrapped.
+/// mlir::ModuleOp module = addOp->getParentOfType<mlir::ModuleOp>();
+/// mlir::OpBuilder builder(addOp);
+/// mlir::NamedAttrList attrs = ...; // Attributes to be set on the
+///                                  // composite op.
+/// int32_t version = 0; // Composite version.
+///
+/// mlir::stablehlo::CompositeOp compositeOp =
+///   mlir::stablehlo::wrapOperationInComposite(builder, addOp, attrs,
+///                                             version, module);
+/// addOp.replaceAllUsesWith(compositeOp);
+/// ```
 stablehlo::CompositeOp wrapOperationInComposite(OpBuilder &builder,
                                                 Operation *op,
                                                 const NamedAttrList &attrs,

--- a/stablehlo/transforms/Passes.td
+++ b/stablehlo/transforms/Passes.td
@@ -352,8 +352,8 @@ def StablehloRefineShapesPass : Pass<"stablehlo-refine-shapes", "ModuleOp"> {
     The flagship use case for this pass is specializing dynamically-shaped
     programs to static shapes. If a dynamically-shaped StableHLO program has the
     right structure, then updating its argument types from dynamic shapes to
-    static shapes and running this pass will propagate static shapes across
-    the program.
+    static shapes and running this pass will propagate static shapes across the
+    program.
 
     This pass removes `custom_call @shape_refinement_operand_wrapper` by
     replacing uses of the result with the operand directly, and propagates
@@ -418,24 +418,24 @@ def StablehloWrapInCompositePass : Pass<"stablehlo-wrap-in-composite", "ModuleOp
     For instance, consider a simple StableHLO program:
 
     ```mlir
-      func.func @main(%arg0 : tensor<2xf32>, %arg1 : tensor<2xf32>) -> tensor<2xf32> {
-        %0 = stablehlo.add %arg0, %arg1 : tensor<2xf32>
-        return %0 : tensor<2xf32>
-      }
+    func.func @main(%arg0 : tensor<2xf32>, %arg1 : tensor<2xf32>) -> tensor<2xf32> {
+      %0 = stablehlo.add %arg0, %arg1 : tensor<2xf32>
+      return %0 : tensor<2xf32>
+    }
     ```
 
     Applying this pass to wrap `stablehlo.add` operations will result in the
     following program:
 
     ```mlir
-      func.func @main(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> tensor<2xf32> {
-        %0 = stablehlo.composite "stablehlo.add" %arg0, %arg1 {decomposition = @stablehlo.add.impl} : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
-        return %0 : tensor<2xf32>
-      }
-      func.func private @stablehlo.add.impl(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> tensor<2xf32> {
-        %0 = stablehlo.add %arg0, %arg1 : tensor<2xf32>
-        return %0 : tensor<2xf32>
-      }
+    func.func @main(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> tensor<2xf32> {
+      %0 = stablehlo.composite "stablehlo.add" %arg0, %arg1 {decomposition = @stablehlo.add.impl} : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
+      return %0 : tensor<2xf32>
+    }
+    func.func private @stablehlo.add.impl(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> tensor<2xf32> {
+      %0 = stablehlo.add %arg0, %arg1 : tensor<2xf32>
+      return %0 : tensor<2xf32>
+    }
     ```
 
     Notes:
@@ -476,28 +476,28 @@ def StablehloWrapInCompositePass : Pass<"stablehlo-wrap-in-composite", "ModuleOp
     **Example (C++):**
 
     ```cpp
-      // To wrap a specific stablehlo.add instance
+    // To wrap a specific stablehlo.add instance
 
-      mlir::stablehlo::AddOp addOp = ...; // The op instanced to be wrapped.
-      mlir::ModuleOp module = addOp->getParentOfType<mlir::ModuleOp>();
-      mlir::OpBuilder builder(addOp);
-      mlir::NamedAttrList attrs = ...; // Attributes to be set on the composite op.
-      int32_t version = 0; // Composite version.
+    mlir::stablehlo::AddOp addOp = ...; // The op instanced to be wrapped.
+    mlir::ModuleOp module = addOp->getParentOfType<mlir::ModuleOp>();
+    mlir::OpBuilder builder(addOp);
+    mlir::NamedAttrList attrs = ...; // Attributes to be set on the composite op.
+    int32_t version = 0; // Composite version.
 
-      mlir::stablehlo::CompositeOp compositeOp = mlir::stablehlo::wrapOperationInComposite(builder, addOp, attrs, version, module);
-      addOp.replaceAllUsesWith(compositeOp);
+    mlir::stablehlo::CompositeOp compositeOp = mlir::stablehlo::wrapOperationInComposite(builder, addOp, attrs, version, module);
+    addOp.replaceAllUsesWith(compositeOp);
     ```
 
-    **Mode 3: Programmatic Module-Wide Wrapping with Attribute Predicates**
+    **Mode 3: Programmatic Module-Wide Wrapping with customized Attribute Handling**
 
     This mode extends programmatic wrapping to the entire module, offering
     fine-grained control over which operations are wrapped and their attributes.
     This is achieved by using the `createStablehloWrapInCompositePass` API,
-    which takes an `AttributePredicateMap` as an argument.
+    which takes an `CompositeAttributeProviderMap` as an argument.
 
-    The `AttributePredicateMap` is a map that dictates which operations should
-    be considered for wrapping and how their attributes should be handled. Its
-    semantics are as follows:
+    The `CompositeAttributeProviderMap` is a map that dictates which operations
+    should be considered for wrapping and how their attributes should be
+    handled. Its semantics are as follows:
 
     - **Keys (mlir::TypeID):** `TypeID` of an MLIR operation. If an operation's
         `TypeID` matches a key in the map, it becomes a candidate for wrapping.
@@ -521,9 +521,9 @@ def StablehloWrapInCompositePass : Pass<"stablehlo-wrap-in-composite", "ModuleOp
 
     // ... inside a pass or function ...
 
-    stablehlo::AttributePredicateMap attributePredicateMap;
+    stablehlo::CompositeAttributeProviderMap compositeAttributeProviderMap;
 
-    attributePredicateMap[mlir::TypeID::get<mlir::stablehlo::AddOp>()] =
+    compositeAttributeProviderMap[mlir::TypeID::get<mlir::stablehlo::AddOp>()] =
       [](mlir::Operation* op) -> std::optional<mlir::NamedAttrList> {
       // Custom logic to determine if and how to wrap the operation.
       // Example: Only wrap if it's on a specific type.
@@ -533,7 +533,7 @@ def StablehloWrapInCompositePass : Pass<"stablehlo-wrap-in-composite", "ModuleOp
       return std::nullopt; // Do not wrap.
     };
 
-    pm.addPass(createStablehloWrapInCompositePass(attributePredicateMap, compositeVersion));
+    pm.addPass(createStablehloWrapInCompositePass(compositeAttributeProviderMap, compositeVersion));
     if (mlir::failed(pm.run(module))) {
       return;
     }
@@ -542,9 +542,8 @@ def StablehloWrapInCompositePass : Pass<"stablehlo-wrap-in-composite", "ModuleOp
   let options = [
     ListOption<"opNamesOption", "op-names", "std::string",
     "The names of the ops to wrap.">,
-    Option<"versionOption", "version", "int32_t", "0",
+    Option<"versionOption", "version", "int32_t", /*default=*/"0",
            "The version number of the composite op.">,
-
   ];
   let dependentDialects = [
     "mlir::func::FuncDialect",

--- a/stablehlo/transforms/Passes.td
+++ b/stablehlo/transforms/Passes.td
@@ -451,15 +451,16 @@ def StablehloWrapInCompositePass : Pass<"stablehlo-wrap-in-composite", "ModuleOp
         operation, and `N` is a unique integer identifier generated to prevent
         naming conflicts within the module.
 
-    This pass can be used in three distinct ways:
+    This pass can be used in two distinct ways:
 
     **Mode 1: Command-line Usage**
 
-    This mode is the simplest, using the `stablehlo-opt` utility with the
-    `op-names` (a comma-separated list of operation names) and `version` (an
-    integer version number) options. It wraps **all instances** of specified
-    operations. The attributes of the newly created `stablehlo.composite`
-    operation will be the same as the attributes of the original operation.
+    This mode is intended for debugging or testing, as it offers minimal control
+    over the attributes of the generated `stablehlo.composite` operations.
+    It wraps **all instances** of operations specified using the `op-names`
+    (a comma-separated list of operation names) options. The attributes of the
+    newly created `stablehlo.composite` operation will be the same as the
+    attributes of the original operation.
 
     **Usage Example:**
 
@@ -467,28 +468,7 @@ def StablehloWrapInCompositePass : Pass<"stablehlo-wrap-in-composite", "ModuleOp
     stablehlo-opt input.mlir --stablehlo-wrap-in-composite=op-names='stablehlo.add,stablehlo.mul' -o output.mlir
     ```
 
-    **Mode 2: Programmatic Single-Op Wrapping**
-
-    This mode provides programmatic control to wrap
-    **a specific operation instance** and returns a pointer to the newly
-    created `stablehlo.composite` operation.
-
-    **Example (C++):**
-
-    ```cpp
-    // To wrap a specific stablehlo.add instance
-
-    mlir::stablehlo::AddOp addOp = ...; // The op instanced to be wrapped.
-    mlir::ModuleOp module = addOp->getParentOfType<mlir::ModuleOp>();
-    mlir::OpBuilder builder(addOp);
-    mlir::NamedAttrList attrs = ...; // Attributes to be set on the composite op.
-    int32_t version = 0; // Composite version.
-
-    mlir::stablehlo::CompositeOp compositeOp = mlir::stablehlo::wrapOperationInComposite(builder, addOp, attrs, version, module);
-    addOp.replaceAllUsesWith(compositeOp);
-    ```
-
-    **Mode 3: Programmatic Module-Wide Wrapping with customized Attribute Handling**
+    **Mode 2: Programmatic Module-Wide Wrapping with customized Attribute Handling**
 
     This mode extends programmatic wrapping to the entire module, offering
     fine-grained control over which operations are wrapped and their attributes.
@@ -518,8 +498,6 @@ def StablehloWrapInCompositePass : Pass<"stablehlo-wrap-in-composite", "ModuleOp
     **Example (C++):**
 
     ```cpp
-
-    // ... inside a pass or function ...
 
     stablehlo::CompositeAttributeProviderMap compositeAttributeProviderMap;
 

--- a/stablehlo/transforms/Passes.td
+++ b/stablehlo/transforms/Passes.td
@@ -409,3 +409,145 @@ def VhloToVersionPass : Pass<"vhlo-to-version"> {
   ];
   let dependentDialects = ["mlir::vhlo::VhloDialect"];
 }
+
+def StablehloWrapInCompositePass : Pass<"stablehlo-wrap-in-composite", "ModuleOp"> {
+  let summary = "Wraps a non-composite  StableHLO op in a composite op.";
+  let description = [{
+    Wraps StableHLO operations in `stablehlo.composite` operations.
+
+    For instance, consider a simple StableHLO program:
+
+    ```mlir
+      func.func @main(%arg0 : tensor<2xf32>, %arg1 : tensor<2xf32>) -> tensor<2xf32> {
+        %0 = stablehlo.add %arg0, %arg1 : tensor<2xf32>
+        return %0 : tensor<2xf32>
+      }
+    ```
+
+    Applying this pass to wrap `stablehlo.add` operations will result in the
+    following program:
+
+    ```mlir
+      func.func @main(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> tensor<2xf32> {
+        %0 = stablehlo.composite "stablehlo.add" %arg0, %arg1 {decomposition = @stablehlo.add.impl} : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
+        return %0 : tensor<2xf32>
+      }
+      func.func private @stablehlo.add.impl(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> tensor<2xf32> {
+        %0 = stablehlo.add %arg0, %arg1 : tensor<2xf32>
+        return %0 : tensor<2xf32>
+      }
+    ```
+
+    Notes:
+
+      - The `name` attribute of the generated `stablehlo.composite` operation
+        will always be the same as the name of the original operation that was
+        wrapped (e.g., if you wrap a `stablehlo.add` operation, the composite
+        will also be named `"stablehlo.add"`).
+      - The private function that encapsulates the original operation
+        (referenced by the `decomposition` attribute of the
+        `stablehlo.composite` operation) will be named using the pattern
+        `<op_name>.impl[.N]`, where `<op_name>` is the name of the original
+        operation, and `N` is a unique integer identifier generated to prevent
+        naming conflicts within the module.
+
+    This pass can be used in three distinct ways:
+
+    **Mode 1: Command-line Usage**
+
+    This mode is the simplest, using the `stablehlo-opt` utility with the
+    `op-names` (a comma-separated list of operation names) and `version` (an
+    integer version number) options. It wraps **all instances** of specified
+    operations. The attributes of the newly created `stablehlo.composite`
+    operation will be the same as the attributes of the original operation.
+
+    **Usage Example:**
+
+    ```bash
+    stablehlo-opt input.mlir --stablehlo-wrap-in-composite=op-names='stablehlo.add,stablehlo.mul' -o output.mlir
+    ```
+
+    **Mode 2: Programmatic Single-Op Wrapping**
+
+    This mode provides programmatic control to wrap
+    **a specific operation instance** and returns a pointer to the newly
+    created `stablehlo.composite` operation.
+
+    **Example (C++):**
+
+    ```cpp
+      // To wrap a specific stablehlo.add instance
+
+      mlir::stablehlo::AddOp addOp = ...; // The op instanced to be wrapped.
+      mlir::ModuleOp module = addOp->getParentOfType<mlir::ModuleOp>();
+      mlir::OpBuilder builder(addOp);
+      mlir::NamedAttrList attrs = ...; // Attributes to be set on the composite op.
+      int32_t version = 0; // Composite version.
+
+      mlir::stablehlo::CompositeOp compositeOp = mlir::stablehlo::wrapOperationInComposite(builder, addOp, attrs, version, module);
+      addOp.replaceAllUsesWith(compositeOp);
+    ```
+
+    **Mode 3: Programmatic Module-Wide Wrapping with Attribute Predicates**
+
+    This mode extends programmatic wrapping to the entire module, offering
+    fine-grained control over which operations are wrapped and their attributes.
+    This is achieved by using the `createStablehloWrapInCompositePass` API,
+    which takes an `AttributePredicateMap` as an argument.
+
+    The `AttributePredicateMap` is a map that dictates which operations should
+    be considered for wrapping and how their attributes should be handled. Its
+    semantics are as follows:
+
+    - **Keys (mlir::TypeID):** `TypeID` of an MLIR operation. If an operation's
+        `TypeID` matches a key in the map, it becomes a candidate for wrapping.
+    - **Values (Lambda Functions):** Lambda function of type
+        `std::function<std::optional<NamedAttrList>(Operation*)>`. This function
+        is applied to each candidate operation.
+        - **Input:** An `mlir::Operation*`, which is an instance of the
+          operation type corresponding to the `TypeID` key.
+        - **Return Value:** An `std::optional<NamedAttrList>`.
+          - If the lambda returns a `NamedAttrList` (wrapped in
+            `std::optional`), the operation is wrapped in a
+            `stablehlo::composite` operation, and the returned attributes are
+            used to set the composite's attributes.
+          - If the lambda returns `std::nullopt`, the operation is **not**
+            wrapped. This allows for selective wrapping based on custom
+            criteria.
+
+    **Example (C++):**
+
+    ```cpp
+
+    // ... inside a pass or function ...
+
+    stablehlo::AttributePredicateMap attributePredicateMap;
+
+    attributePredicateMap[mlir::TypeID::get<mlir::stablehlo::AddOp>()] =
+      [](mlir::Operation* op) -> std::optional<mlir::NamedAttrList> {
+      // Custom logic to determine if and how to wrap the operation.
+      // Example: Only wrap if it's on a specific type.
+      if (op->getOperand(0).getType().isa<mlir::Float32Type>()) {
+        return mlir::NamedAttrList(op->getAttrs());
+      }
+      return std::nullopt; // Do not wrap.
+    };
+
+    pm.addPass(createStablehloWrapInCompositePass(attributePredicateMap, compositeVersion));
+    if (mlir::failed(pm.run(module))) {
+      return;
+    }
+    ```
+  }];
+  let options = [
+    ListOption<"opNamesOption", "op-names", "std::string",
+    "The names of the ops to wrap.">,
+    Option<"versionOption", "version", "int32_t", "0",
+           "The version number of the composite op.">,
+
+  ];
+  let dependentDialects = [
+    "mlir::func::FuncDialect",
+    "mlir::stablehlo::StablehloDialect",
+  ];
+}

--- a/stablehlo/transforms/StablehloWrapInComposite.cpp
+++ b/stablehlo/transforms/StablehloWrapInComposite.cpp
@@ -1,0 +1,219 @@
+/* Copyright 2024 The StableHLO Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Block.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OperationSupport.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/IR/TypeRange.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Rewrite/FrozenRewritePatternSet.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Support/TypeID.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "stablehlo/dialect/StablehloOps.h"
+#include "stablehlo/transforms/Passes.h"
+
+namespace mlir {
+namespace stablehlo {
+
+#define GEN_PASS_DEF_STABLEHLOWRAPINCOMPOSITEPASS
+#include "stablehlo/transforms/Passes.h.inc"
+
+namespace {
+
+// Builds a new function within the given `module` that encapsulates the
+// functionality of the provided `implOp`. The new function is named uniquely
+// and is set to private visibility.
+func::FuncOp buildFuncOpWrappingOperation(Operation* op, ModuleOp module) {
+  mlir::SymbolTable symbol_table(module);
+  // Create an OpBuilder, insertion point at the end of module's body.
+  mlir::OpBuilder builder(module);
+  builder.setInsertionPointToEnd(&module.getBodyRegion().back());
+
+  // Create the function operation, set private and add to the symbol table.
+  // SymbolTable will resolve all name conflicts.
+  Location loc = op->getLoc();
+  auto funcName = (op->getName().getStringRef() + ".impl").str();
+  mlir::func::FuncOp implFunc = builder.create<mlir::func::FuncOp>(
+      loc, funcName,
+      builder.getFunctionType(op->getOperandTypes(), op->getResultTypes()));
+  implFunc.setPrivate();
+  symbol_table.insert(implFunc);
+
+  Block* block = implFunc.addEntryBlock();
+  builder.setInsertionPointToEnd(block);
+  mlir::Operation* clonedOp = builder.clone(*op);
+  clonedOp->setOperands(block->getArguments());
+  builder.create<mlir::func::ReturnOp>(loc, clonedOp->getResults());
+
+  return implFunc;
+}
+
+// Returns true if the given operation should be wrapped in a CompositeOp.
+bool shouldWrapInComposite(Operation* op,
+                           const AttributePredicateMap& attributePredicateMap) {
+  auto it = attributePredicateMap.find(op->getName().getTypeID());
+  return it != attributePredicateMap.end() && it->second(op) != std::nullopt;
+}
+
+// A ConversionPattern that matches any operation and rewrites it as a
+// stablehlo::CompositeOp. The original operation's functionality is
+// encapsulated within a newly created private function.
+class ConvertGenericOp : public RewritePattern {
+ public:
+  explicit ConvertGenericOp(MLIRContext* context,
+                            AttributePredicateMap attributePredicateMap)
+      : RewritePattern(MatchAnyOpTypeTag(), /*benefit=*/1, context),
+        attributePredicateMap(attributePredicateMap) {}
+
+  LogicalResult matchAndRewrite(Operation* op,
+                                PatternRewriter& rewriter) const override {
+    if (!shouldWrapInComposite(op, attributePredicateMap)) {
+      return failure();
+    }
+
+    auto module = op->getParentOfType<ModuleOp>();
+    if (module == nullptr) {
+      return rewriter.notifyMatchFailure(op, "Failed to find enclosing module");
+    }
+
+    func::FuncOp decomposition = buildFuncOpWrappingOperation(op, module);
+    auto compositeName = op->getName().getStringRef();
+
+    auto attributePredicate =
+        attributePredicateMap.at(op->getName().getTypeID());
+    auto namedAttributes = attributePredicate(op);
+    auto compositeAttributes = rewriter.getDictionaryAttr(*namedAttributes);
+
+    auto compositeOp = rewriter.create<stablehlo::CompositeOp>(
+        op->getLoc(), op->getResultTypes(), op->getOperands(), compositeName,
+        compositeAttributes, decomposition.getSymName());
+    rewriter.replaceOp(op, compositeOp.getResults());
+    return success();
+  }
+
+ private:
+  AttributePredicateMap attributePredicateMap;
+};
+
+class StablehloWrapInCompositePass
+    : public impl::StablehloWrapInCompositePassBase<
+          StablehloWrapInCompositePass> {
+ public:
+  void initializePredicateMap(MLIRContext* context,
+                              ArrayRef<std::string> opNames) {
+    for (const auto& opNameStr : opNames) {
+      StringRef opName = StringRef(opNameStr).trim();
+
+      OperationName registeredOpName = OperationName(opName, context);
+      if (!registeredOpName.isRegistered()) {
+        llvm::errs() << "Warning: Unknown op name in opNamesOption: '" << opName
+                     << "' is not a registered operation.\n";
+        continue;
+      }
+
+      mlir::TypeID opTypeID = registeredOpName.getTypeID();
+
+      // Create a default predicate that returns an empty attribute list.
+      AttributePredicate predicate =
+          [](Operation* op) -> std::optional<NamedAttrList> {
+        return NamedAttrList(op->getAttrs());
+      };
+      attributePredicateMap[opTypeID] = predicate;
+    }
+  }
+
+  StablehloWrapInCompositePass()
+      : StablehloWrapInCompositePassBase<StablehloWrapInCompositePass>(),
+        compositeVersion(versionOption) {}
+  StablehloWrapInCompositePass(const StablehloWrapInCompositePassOptions& opts)
+      : StablehloWrapInCompositePassBase<StablehloWrapInCompositePass>(opts),
+        compositeVersion(versionOption) {}
+  explicit StablehloWrapInCompositePass(
+      const AttributePredicateMap& attributePredicateMap,
+      int32_t compositeVersion)
+      : StablehloWrapInCompositePassBase<StablehloWrapInCompositePass>(),
+        attributePredicateMap(attributePredicateMap),
+        compositeVersion(compositeVersion) {}
+
+  LogicalResult initialize(MLIRContext* context) override {
+    RewritePatternSet patterns_(context);
+    initializePredicateMap(context, opNamesOption);
+    patterns_.add<ConvertGenericOp>(context, attributePredicateMap);
+    patterns = std::move(patterns_);
+    return success();
+  }
+
+  void runOnOperation() override {
+    GreedyRewriteConfig config;
+    config.strictMode = GreedyRewriteStrictness::ExistingOps;
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns),
+                                     config))) {
+      signalPassFailure();
+      return;
+    }
+  }
+
+ private:
+  FrozenRewritePatternSet patterns;
+  AttributePredicateMap attributePredicateMap;
+  int32_t compositeVersion;
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>> createStablehloWrapInCompositePass(
+    const AttributePredicateMap& attributePredicateMap,
+    int32_t compositeVersion) {
+  return std::make_unique<StablehloWrapInCompositePass>(attributePredicateMap,
+                                                        compositeVersion);
+}
+
+stablehlo::CompositeOp wrapOperationInComposite(OpBuilder& builder,
+                                                Operation* op,
+                                                const NamedAttrList& attrs,
+                                                int32_t compositeVersion,
+                                                ModuleOp module) {
+  func::FuncOp decomposition = buildFuncOpWrappingOperation(op, module);
+  auto compositeName = op->getName().getStringRef();
+  auto compositeAttributes = builder.getDictionaryAttr(attrs);
+  auto compositeDecomposition = decomposition.getSymName();
+  auto composite = builder.create<stablehlo::CompositeOp>(
+      op->getLoc(), op->getResultTypes(), op->getOperands(), compositeName,
+      compositeAttributes, compositeDecomposition, compositeVersion);
+  return composite;
+}
+
+}  // namespace stablehlo
+}  // namespace mlir


### PR DESCRIPTION
    Wraps StableHLO operations in `stablehlo.composite` operations.

    For instance, consider a simple StableHLO program:

    ```mlir
      func.func @main(%arg0 : tensor<2xf32>, %arg1 : tensor<2xf32>) -> tensor<2xf32> {
        %0 = stablehlo.add %arg0, %arg1 : tensor<2xf32>
        return %0 : tensor<2xf32>
      }
    ```

    Applying this pass to wrap `stablehlo.add` operations will result in the
    following program:

    ```mlir
      func.func @main(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> tensor<2xf32> {
        %0 = stablehlo.composite "stablehlo.add" %arg0, %arg1 {decomposition = @stablehlo.add.impl} : (tensor<2xf32>, tensor<2xf32>) -> tensor<2xf32>
        return %0 : tensor<2xf32>
      }
      func.func private @stablehlo.add.impl(%arg0: tensor<2xf32>, %arg1: tensor<2xf32>) -> tensor<2xf32> {
        %0 = stablehlo.add %arg0, %arg1 : tensor<2xf32>
        return %0 : tensor<2xf32>
      }
    ```

    Notes:

      - The `name` attribute of the generated `stablehlo.composite` operation
        will always be the same as the name of the original operation that was
        wrapped (e.g., if you wrap a `stablehlo.add` operation, the composite
        will also be named `"stablehlo.add"`).
      - The private function that encapsulates the original operation
        (referenced by the `decomposition` attribute of the
        `stablehlo.composite` operation) will be named using the pattern
        `<op_name>.impl[.N]`, where `<op_name>` is the name of the original
        operation, and `N` is a unique integer identifier generated to prevent
        naming conflicts within the module.

    This pass can be used in three distinct ways:

    **Mode 1: Command-line Usage**

    This mode is the simplest, using the `stablehlo-opt` utility with the
    `op-names` (a comma-separated list of operation names) and `version` (an
    integer version number) options. It wraps **all instances** of specified
    operations. The attributes of the newly created `stablehlo.composite`
    operation will be the same as the attributes of the original operation.

    **Usage Example:**

    ```bash
    stablehlo-opt input.mlir --stablehlo-wrap-in-composite=op-names='stablehlo.add,stablehlo.mul' -o output.mlir
    ```

    **Mode 2: Programmatic Single-Op Wrapping**

    This mode provides programmatic control to wrap
    **a specific operation instance** and returns a pointer to the newly
    created `stablehlo.composite` operation.

    **Example (C++):**

    ```cpp
      // To wrap a specific stablehlo.add instance

      mlir::stablehlo::AddOp addOp = ...; // The op instanced to be wrapped.
      mlir::ModuleOp module = addOp->getParentOfType<mlir::ModuleOp>();
      mlir::OpBuilder builder(addOp);
      mlir::NamedAttrList attrs = ...; // Attributes to be set on the composite op.
      int32_t version = 0; // Composite version.

      mlir::stablehlo::CompositeOp compositeOp = mlir::stablehlo::wrapOperationInComposite(builder, addOp, attrs, version, module);
      addOp.replaceAllUsesWith(compositeOp);
    ```

    **Mode 3: Programmatic Module-Wide Wrapping with Attribute Predicates**

    This mode extends programmatic wrapping to the entire module, offering
    fine-grained control over which operations are wrapped and their attributes.
    This is achieved by using the `createStablehloWrapInCompositePass` API,
    which takes an `AttributePredicateMap` as an argument.

    The `AttributePredicateMap` is a map that dictates which operations should
    be considered for wrapping and how their attributes should be handled. Its
    semantics are as follows:

    - **Keys (mlir::TypeID):** `TypeID` of an MLIR operation. If an operation's
        `TypeID` matches a key in the map, it becomes a candidate for wrapping.
    - **Values (Lambda Functions):** Lambda function of type
        `std::function<std::optional<NamedAttrList>(Operation*)>`. This function
        is applied to each candidate operation.
        - **Input:** An `mlir::Operation*`, which is an instance of the
          operation type corresponding to the `TypeID` key.
        - **Return Value:** An `std::optional<NamedAttrList>`.
          - If the lambda returns a `NamedAttrList` (wrapped in
            `std::optional`), the operation is wrapped in a
            `stablehlo::composite` operation, and the returned attributes are
            used to set the composite's attributes.
          - If the lambda returns `std::nullopt`, the operation is **not**
            wrapped. This allows for selective wrapping based on custom
            criteria.

    **Example (C++):**

    ```cpp

    // ... inside a pass or function ...

    stablehlo::AttributePredicateMap attributePredicateMap;

    attributePredicateMap[mlir::TypeID::get<mlir::stablehlo::AddOp>()] =
      [](mlir::Operation* op) -> std::optional<mlir::NamedAttrList> {
      // Custom logic to determine if and how to wrap the operation.
      // Example: Only wrap if it's on a specific type.
      if (op->getOperand(0).getType().isa<mlir::Float32Type>()) {
        return mlir::NamedAttrList(op->getAttrs());
      }
      return std::nullopt; // Do not wrap.
    };

    pm.addPass(createStablehloWrapInCompositePass(attributePredicateMap, compositeVersion));
    if (mlir::failed(pm.run(module))) {
      return;
    }
    ```