### PR TITLE
Bazel build only build affected targets on pull_request

### DIFF
--- a/.github/workflows/buildAndTestBazel.yml
+++ b/.github/workflows/buildAndTestBazel.yml
@@ -39,8 +39,11 @@ jobs:
     runs-on: ${{ github.repository == 'openxla/stablehlo' && 'ubuntu-22.04-64core' ||  'ubuntu-22.04'  }}
 
     steps:
+    # Checkout StableHLO with all commits in the chain
     - name: Checkout StableHLO
       uses: actions/checkout@v4
+      with:
+        fetch-depth: $(( ${{ github.event_name == 'pull_request' && github.event.pull_request.commits || 0 }} + 1 ))
 
     - name: Validate LLVM Commit
       run: |
@@ -63,7 +66,18 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-stablehlo_bazelbuild-
 
-    - name: Build StableHLO
+    - name: Build and Test StableHLO (Diff Only)
+      if: ${{ github.event_name == 'pull_request' }}
+      shell: bash
+      run: |
+        START_HASH=${{ github.event.pull_request.base.sha }}
+        END_HASH=${{ github.event.pull_request.head.sha }}
+        BAZEL_DIFF=/tmp/bazel-diff.jar
+        curl -Lo "$BAZEL_DIFF" https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff_deploy.jar
+        ./build_tools/github_actions/ci_build_bazel.sh "$BAZEL_DIFF" "$START_HASH" "$END_HASH"
+
+    - name: Build and Test StableHLO (All)
+      if: ${{ github.event_name != 'pull_request' }}
       shell: bash
       run: |
         ./build_tools/github_actions/ci_build_bazel.sh

--- a/build_tools/github_actions/ci_build_bazel.sh
+++ b/build_tools/github_actions/ci_build_bazel.sh
@@ -16,11 +16,76 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [[ $# -ne 0 ]] ; then
-  echo "Usage: $0"
+if [[ $# -ne 0 && $# -ne 3 ]] ; then
+  echo "Usage: $0 [<bazel-diff.jar> <start_commit> <end_commit>]"
+  echo "   Builds and tests all bazel targets."
+  echo "   If start_commit and end_commit are specified, uses bazel-diff to"
+  echo "   determine the set of targets to build based on code changes."
+  echo
+  echo "Example: Build all affected targets between current branch and main"
+  echo "  $ curl -Lo bazel-diff.jar https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff_deploy.jar"
+  echo "  $ ci_build_bazel.sh bazel-diff.jar $(git merge-base main HEAD) $(git rev-parse HEAD)"
   exit 1
 fi
 
-# Build and Test StableHLO
-bazel build --lockfile_mode=error //... --config=asan --config=ubsan
-bazel test //... --config=asan --config=ubsan
+bazel-test-all() {
+  # Build and Test StableHLO
+  bazel build --lockfile_mode=error //... --config=asan --config=ubsan
+  bazel test //... --config=asan --config=ubsan
+}
+
+bazel-test-diff() {
+  set -e
+  WORKSPACE_PATH=$(git rev-parse --show-toplevel)
+  BAZEL_DIFF_JAR="$1"
+  PREVIOUS_REV="$2" # Starting Revision SHA
+  FINAL_REV="$3" # Final Revision SHA
+  BAZEL_PATH="$(which bazel)"
+
+  STARTING_HASHES_JSON="/tmp/starting_hashes.json"
+  FINAL_HASHES_JSON="/tmp/final_hashes.json"
+  IMPACTED_TARGETS_PATH="/tmp/impacted_targets.txt"
+
+  bazel-diff() {
+    java -jar "$BAZEL_DIFF_JAR" "$@"
+  }
+
+  git -C "$WORKSPACE_PATH" checkout "$PREVIOUS_REV" --quiet
+
+  echo "Generating Hashes for Revision '$PREVIOUS_REV'"
+  bazel-diff generate-hashes -w "$WORKSPACE_PATH" -b "$BAZEL_PATH" $STARTING_HASHES_JSON
+
+  git -C "$WORKSPACE_PATH" checkout "$FINAL_REV" --quiet
+
+  echo "Generating Hashes for Revision '$FINAL_REV'"
+  bazel-diff generate-hashes -w "$WORKSPACE_PATH" -b "$BAZEL_PATH" $FINAL_HASHES_JSON
+
+  echo "Determining Impacted Targets"
+  bazel-diff get-impacted-targets -sh $STARTING_HASHES_JSON -fh $FINAL_HASHES_JSON -o $IMPACTED_TARGETS_PATH
+  echo ""
+
+  impacted_targets=()
+  IFS=$'\n' read -d '' -r -a impacted_targets < $IMPACTED_TARGETS_PATH || true
+  formatted_impacted_targets=$(IFS=$'\n'; echo "${impacted_targets[*]}")
+  if [[ -z "$formatted_impacted_targets" ]]; then
+    echo "No impacted targets from change."
+    exit 0
+  fi
+
+  echo "Impacted Targets between $PREVIOUS_REV and $FINAL_REV:"
+  echo "$formatted_impacted_targets"
+  echo ""
+
+  # Build and Test impacted targets
+  bazel build --target_pattern_file=/tmp/impacted_targets.txt
+  bazel test --target_pattern_file=/tmp/impacted_targets.txt
+}
+
+# Run bazel build and test
+if [[ $# -eq 0 ]] ; then
+  bazel-test-all
+else
+  bazel-test-diff "$@"
+fi
+
+

--- a/build_tools/github_actions/ci_build_bazel.sh
+++ b/build_tools/github_actions/ci_build_bazel.sh
@@ -23,8 +23,8 @@ if [[ $# -ne 0 && $# -ne 3 ]] ; then
   echo "   determine the set of targets to build based on code changes."
   echo
   echo "Example: Build all affected targets between current branch and main"
-  echo "  $ curl -Lo bazel-diff.jar https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff_deploy.jar"
-  echo "  $ ci_build_bazel.sh bazel-diff.jar main $(git rev-parse --abbrev-ref HEAD)"
+  echo "  $ curl -Lo /tmp/bazel-diff.jar https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff_deploy.jar"
+  echo "  $ ci_build_bazel.sh /tmp/bazel-diff.jar main $(git rev-parse --abbrev-ref HEAD)"
   exit 1
 fi
 
@@ -72,7 +72,7 @@ bazel-test-diff() {
     exit 0
   fi
 
-  NUM_IMPACTED=$(echo $formatted_impacted_targets | wc -l)
+  NUM_IMPACTED=$(echo "$formatted_impacted_targets" | wc -l)
   echo "[$NUM_IMPACTED] Impacted Targets between $PREVIOUS_REV and $FINAL_REV:"
   echo "$formatted_impacted_targets"
   echo ""

--- a/build_tools/github_actions/ci_build_bazel.sh
+++ b/build_tools/github_actions/ci_build_bazel.sh
@@ -88,5 +88,3 @@ if [[ $# -eq 0 ]] ; then
 else
   bazel-test-diff "$@"
 fi
-
-

--- a/build_tools/github_actions/ci_build_bazel.sh
+++ b/build_tools/github_actions/ci_build_bazel.sh
@@ -24,7 +24,7 @@ if [[ $# -ne 0 && $# -ne 3 ]] ; then
   echo
   echo "Example: Build all affected targets between current branch and main"
   echo "  $ curl -Lo bazel-diff.jar https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff_deploy.jar"
-  echo "  $ ci_build_bazel.sh bazel-diff.jar $(git merge-base main HEAD) $(git rev-parse HEAD)"
+  echo "  $ ci_build_bazel.sh bazel-diff.jar main $(git rev-parse --abbrev-ref HEAD)"
   exit 1
 fi
 
@@ -72,7 +72,8 @@ bazel-test-diff() {
     exit 0
   fi
 
-  echo "Impacted Targets between $PREVIOUS_REV and $FINAL_REV:"
+  NUM_IMPACTED=$(echo $formatted_impacted_targets | wc -l)
+  echo "[$NUM_IMPACTED] Impacted Targets between $PREVIOUS_REV and $FINAL_REV:"
   echo "$formatted_impacted_targets"
   echo ""
 


### PR DESCRIPTION
- It's painful that doc-only changes compile the entire codebase and run all tests.
- We can't use `paths-ignore` from github actions because it marks jobs as pending and we have branch protections enabled which require all status checks to be green.
- This seems like a generally good change to build what you change, after merge to main we will still build and test all.

Calculates diff in GH actions using https://github.com/Tinder/bazel-diff

## Example 1, this PR, GH actions files only, no impacted build files:

```sh
$ curl -Lo /tmp/bazel-diff.jar https://github.com/Tinder/bazel-diff/releases/latest/download/bazel-diff_deploy.jar
$ ./build_tools/github_actions/ci_build_bazel.sh /tmp/bazel-diff.jar $(git merge-base main HEAD) $(git rev-parse HEAD)
Generating Hashes for Revision 'd2708ad6cca730d4c17317388a7acbf8eac2c9f6'
Loading: 0 packages loaded

Generating Hashes for Revision '1565f5bac3ed5df5e0bdd38843fb84efde28e1d1'
Loading: 0 packages loaded

Determining Impacted Targets

No impacted targets from change.
```

## Example 2, modify `StablehloOps.cpp`, fairly core file, should test ~all:

```sh
$ ./build_tools/github_actions/ci_build_bazel.sh /tmp/bazel-diff.jar $(git merge-base main HEAD) $(git rev-parse HEAD)
Generating Hashes for Revision 'd2708ad6cca730d4c17317388a7acbf8eac2c9f6'
Loading: 0 packages loaded

Generating Hashes for Revision '310993d82d94b0cf7a5389e659e35ac32cd32089'
Loading: 0 packages loaded

Determining Impacted Targets

[3188] Impacted Targets between d2708ad6cca730d4c17317388a7acbf8eac2c9f6 and 310993d82d94b0cf7a5389e659e35ac32cd32089:
//:interpreter_ops
//:interpreter_passes
//:linalg_passes
//:reference_api
[...]
//stablehlo/testdata:abs_int32_20_20.mlir.test
//stablehlo/testdata:abs_int64_20_20.mlir.test
[...]
//stablehlo/tests:check_ops
//stablehlo/tests:chlo/chlo_legalize_to_stablehlo.mlir.test
//stablehlo/tests:chlo/chlo_legalize_to_stablehlo_broadcast.mlir.test
//stablehlo/tests:infer_chlo.mlir.test
//stablehlo/tests:infer_stablehlo.mlir.test
//stablehlo/tests:interpret/abs.mlir.test
[...]
```
