### PR TITLE
Fix location versioning

### DIFF
--- a/stablehlo/tests/transforms/stablehlo_compatibility_expander_locations.mlir
+++ b/stablehlo/tests/transforms/stablehlo_compatibility_expander_locations.mlir
@@ -1,5 +1,5 @@
 // RUN: stablehlo-opt %s -stablehlo-compatibility-expander=target=1.8.0 --mlir-print-debuginfo | FileCheck %s
-// RUN: stablehlo-opt %s -stablehlo-compatibility-expander=target=1.8.0 --mlir-print-debuginfo | stablehlo-translate --serialize --target=1.8.0
+// RUN: stablehlo-opt %s -stablehlo-compatibility-expander=target=1.8.0 --mlir-print-debuginfo | stablehlo-translate --serialize --target=1.8.0 | stablehlo-translate -deserialize -mlir-print-debuginfo | FileCheck %s
 
 // Test that FileLineColRange locations are converted to FileLineColLoc
 // locations, including in nested location contexts, block args, module op, etc.

--- a/stablehlo/tests/transforms/stablehlo_compatibility_expander_locations.mlir
+++ b/stablehlo/tests/transforms/stablehlo_compatibility_expander_locations.mlir
@@ -1,4 +1,5 @@
 // RUN: stablehlo-opt %s -stablehlo-compatibility-expander=target=1.8.0 --mlir-print-debuginfo | FileCheck %s
+// RUN: stablehlo-opt %s -stablehlo-compatibility-expander=target=1.8.0 --mlir-print-debuginfo | stablehlo-translate --serialize --target=1.8.0
 
 // Test that FileLineColRange locations are converted to FileLineColLoc
 // locations, including in nested location contexts, block args, module op, etc.

--- a/stablehlo/transforms/StablehloCompatibilityExpander.cpp
+++ b/stablehlo/transforms/StablehloCompatibilityExpander.cpp
@@ -375,8 +375,10 @@ void populateStablehloCompatibilityExpanderPatterns(
     patterns->add<TanOp_ComplexElementType_CompatiblityExpander,
                   TanOp_CompatiblityExpander>(context);
 
-  // MLIR Upstream FileLineColRange introduced just before v1.8.4.
-  if (targetVersion < vhlo::Version(1, 8, 4))
+  // MLIR Upstream FileLineColRange introduced ~v1.8.4
+  // Conservatively use 1.9.0 since StableHLO passes require major versions for
+  // incompats.
+  if (targetVersion < vhlo::Version(1, 9, 0))
     patterns->add<FileLineColRangeToLoc>(context);
 }
 

--- a/stablehlo/transforms/VhloToVersion.cpp
+++ b/stablehlo/transforms/VhloToVersion.cpp
@@ -189,15 +189,18 @@ LogicalResult isLegalType(Type type, const Version& targetVersion) {
 
 bool isLegalLocation(Location loc, const Version& targetVersion) {
   // FileLineColRange locations are a forward incompatibility in upstream MLIR
-  // just before v1.8.4 was tagged. Support for downgrading these locations
-  // exists in StablehloCompatibilityExpanderPass.
+  // just before v1.8.4 was tagged. Conservatively use 1.9.0 since StableHLO
+  // passes require major versions for incompats.
+  //
+  // Support for downgrading these locations exists in
+  // StablehloCompatibilityExpanderPass.
   bool isLegal = true;
   loc->walk([&](Location childLoc) -> WalkResult {
     if (auto fileLineColLoc = dyn_cast<FileLineColRange>(childLoc)) {
-      static const Version kFileLineColLocMinVersion = Version(1, 8, 4);
-      if (!isStrictFileLineColLoc(loc) &&
+      static const Version kFileLineColLocMinVersion = Version(1, 9, 0);
+      if (!isStrictFileLineColLoc(childLoc) &&
           targetVersion < kFileLineColLocMinVersion) {
-        LLVM_DEBUG(llvm::dbgs() << "failed to legalize location " << loc
+        LLVM_DEBUG(llvm::dbgs() << "failed to legalize location " << childLoc
                                 << " to version " << targetVersion << '\n');
         isLegal = false;
         return WalkResult::interrupt();


### PR DESCRIPTION
Two bugs:
- Serialization floors version to `X.Y.0` so we can't use `1.8.4` as a version. Makes sense, incompats should be confined to major version bumps
- Fix bug in the logic for valid location checking, was checking the parent location not the active location. Update test file to also test serialization behavior.