### PR TITLE
Changes to allow StableHLO to be added as a Bzlmod dep

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,6 +18,8 @@
 #
 # For more details, please check https://github.com/bazelbuild/bazel/issues/18958
 ###############################################################################
+module(name = "stablehlo")
+
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "rules_python", version = "0.30.0")
 

--- a/stablehlo/tests/BUILD.bazel
+++ b/stablehlo/tests/BUILD.bazel
@@ -168,7 +168,7 @@ RUNFILES_DIR = LITE_CFG_PY.parents[2].absolute().as_posix()''',
             "//:stablehlo-translate",
             "@llvm-project//llvm:FileCheck",
             "@llvm-project//llvm:not",
-        ] + glob(["%s.bc" % src]),
+        ] + glob(["%s.bc" % src], allow_empty=True),
         tags = ["stablehlo_tests"],
         deps = ["@rules_python//python/runfiles"],
     )


### PR DESCRIPTION
To add StableHLO as a dependency in the WORKSPACE (due to it depending on LLVM, which doesn't support Bzlmod yet) but in a Bazel project that uses Bzlmod then a patch is required to get it to work.

The WORKSPACE would have something like this in it:
```
git_repository(
    name = "stablehlo",
    commit = "48a1e14edc8219577fcad53de1924876f855f431",
    patch_args = ["-p1"],
    patches = [
        "//patches:stablehlo/00-bazel-dep.patch",
    ],
    remote = "https://github.com/openxla/stablehlo.git",
)
```

This PR is the contents of that patch file.