### PR TITLE
Add more MHLO folders to StableHLO

### DIFF
--- a/stablehlo/tests/transforms/stablehlo_aggressive_folder.mlir
+++ b/stablehlo/tests/transforms/stablehlo_aggressive_folder.mlir
@@ -269,6 +269,17 @@ func.func @eval_convert_f64_precision_loss() -> (tensor<1xf32>, tensor<f32>) {
 
 // -----
 
+// CHECK-LABEL: func @fold_sqrt
+func.func @fold_sqrt() -> (tensor<f32>) {
+  // CHECK: [[RESULT0:%.*]] = stablehlo.constant dense<2.0{{.*}}> : tensor<f32>
+  // CHECK: return [[RESULT0]]
+  %0 = stablehlo.constant dense<4.0> : tensor<f32>
+  %1 = stablehlo.sqrt %0 : tensor<f32>
+  func.return %1 : tensor<f32>
+}
+
+// -----
+
 // CHECK-LABEL: func @eval_transpose
 func.func @eval_transpose() -> (tensor<2x3x2xi32>, tensor<2x4x3xi32>, tensor<4x3x2xi32>) {
   // CHECK: [[RESULT0:%.*]] = stablehlo.constant dense<

--- a/stablehlo/tests/transforms/stablehlo_aggressive_simplification.mlir
+++ b/stablehlo/tests/transforms/stablehlo_aggressive_simplification.mlir
@@ -899,6 +899,23 @@ func.func @multiply_by_one(%arg0: tensor<i32>) -> tensor<i32> {
   return %0 : tensor<i32>
 }
 
+// CHECK-LABEL: @multiply_by_zero_float
+func.func @multiply_by_zero_float(%arg0: tensor<f32>) -> tensor<f32> {
+  %cst = stablehlo.constant dense<0.0> : tensor<f32>
+  // CHECK: stablehlo.constant dense<0.0{{.*}}> : tensor<f32>
+  %0 = stablehlo.multiply %cst, %arg0 : tensor<f32>
+  return %0 : tensor<f32>
+}
+
+// CHECK-LABEL: @multiply_by_one_float
+func.func @multiply_by_one_float(%arg0: tensor<f32>) -> tensor<f32> {
+  %cst = stablehlo.constant dense<1.0> : tensor<f32>
+  %0 = stablehlo.multiply %cst, %arg0 : tensor<f32>
+  // CHECK-NOT: stablehlo.constant
+  // CHECK: return %arg0 : tensor<f32>
+  return %0 : tensor<f32>
+}
+
 // -----
 
 /////////

--- a/stablehlo/transforms/optimization/StablehloAggressiveFolder.cpp
+++ b/stablehlo/transforms/optimization/StablehloAggressiveFolder.cpp
@@ -817,7 +817,7 @@ struct FoldSqrtOpPattern : public OpRewritePattern<mlir::stablehlo::SqrtOp> {
       return APFloat(std::sqrt(a.convertToDouble()));
 
     if (a.getSizeInBits(a.getSemantics()) == 32)
-      return APFloat(std::sqrtf(a.convertToFloat()));
+      return APFloat(sqrtf(a.convertToFloat()));
     return {};
   }
 };

--- a/stablehlo/transforms/optimization/StablehloAggressiveSimplificationPatterns.td
+++ b/stablehlo/transforms/optimization/StablehloAggressiveSimplificationPatterns.td
@@ -68,6 +68,10 @@ def EmptyI64Array : AttrConstraint<
     CPred<"cast<DenseI64ArrayAttr>($_self).empty()">,
     "is empty i64 array">;
 
+def AnyOne : AttrConstraint<
+    CPred<"::mlir::matchPattern($_self, m_AnyAttrOf(m_One(), m_OneFloat()))">,
+    "is integer one">;
+
 def IntOne : AttrConstraint<
     CPred<"::mlir::matchPattern($_self, m_One())">,
     "is integer one">;
@@ -303,11 +307,11 @@ def : CanonicalizeConstantToRhs<StableHLO_MulOp>;
 
 // Pattern: multiply(X, 0i) -> 0i
 // Multiplication by 0. This fold is not trivial for floats in presence of NaNs
-def : Pat<(StableHLO_MulOp $lhs, (StableHLO_ConstantOp:$zero IntZero:$value)),
+def : Pat<(StableHLO_MulOp $lhs, (StableHLO_ConstantOp:$zero AnyZero:$value)),
           (replaceWithValue $zero)>;
 
 // Pattern: multiply(X, 1i) -> X
-def : Pat<(StableHLO_MulOp $lhs, (StableHLO_ConstantOp IntOne:$value)),
+def : Pat<(StableHLO_MulOp $lhs, (StableHLO_ConstantOp AnyOne:$value)),
           (replaceWithValue $lhs)>;
 
 ////////

--- a/stablehlo/transforms/optimization/StablehloTargetIndependentOptimization.cpp
+++ b/stablehlo/transforms/optimization/StablehloTargetIndependentOptimization.cpp
@@ -45,7 +45,7 @@ struct StablehloTargetIndependentOptimizationPass
 
   LogicalResult initialize(MLIRContext* context) override {
     RewritePatternSet patterns_(context);
-    bool foldFloat = false;
+    bool foldFloat = true;
     populateStablehloCanonicalizationPatterns(context, &patterns_);
     populateStablehloAggressiveFolderPatterns(&patterns_, context, foldFloat,
                                               /*benefit=*/2);


### PR DESCRIPTION
Some of these may seem unsafe (simplifying float `X*1.0` or `X*0.0` may not account for NaNs properly), but both MHLO and XLA simplifications do this optim so probably generally safe.