### PR TITLE
[stablehlo][tosa] adjust to int_div rename to intdiv

### DIFF
--- a/stablehlo/conversions/tosa/tests/binary.mlir
+++ b/stablehlo/conversions/tosa/tests/binary.mlir
@@ -45,7 +45,7 @@ func.func @concatenate(%arg0 : tensor<3x3xf32>, %arg1 : tensor<3x3xf32>) -> tens
 
 // CHECK-LABEL: @divide
 func.func @divide(%arg0 : tensor<10xi32>, %arg1 : tensor<10xi32>) -> tensor<10xi32> {
-  // CHECK: tosa.int_div
+  // CHECK: tosa.intdiv
   %0 = "stablehlo.divide"(%arg0, %arg1) : (tensor<10xi32>, tensor<10xi32>) -> tensor<10xi32>
   return %0 : tensor<10xi32>
 }

--- a/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.pdll
+++ b/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.pdll
@@ -156,7 +156,7 @@ Pattern =>
 Pattern =>
   replace op<stablehlo.divide>(input0 : Value<_: Tosa_Int32Tensor>,
                           input1 : Value<_: Tosa_Int32Tensor>)
-     with op<tosa.int_div>(input0, input1);
+     with op<tosa.intdiv>(input0, input1);
 Pattern =>
   replace op<stablehlo.maximum>(input0 : Value<_: Tosa_Tensor>,
                            input1 : Value<_: Tosa_Tensor>)


### PR DESCRIPTION
This patch updates code and lit tests for the renaming of Tosa operator int_div to intdiv

renaming of Tosa int_div to intdiv was merged in this llvm PR: https://github.com/llvm/llvm-project/pull/135080

