### PR TITLE
Fix an outdated pass-creation function declaration

### DIFF
--- a/stablehlo/transforms/Passes.h
+++ b/stablehlo/transforms/Passes.h
@@ -33,7 +33,6 @@ limitations under the License.
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/TypeID.h"
 #include "mlir/Transforms/DialectConversion.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "stablehlo/dialect/StablehloOps.h"
 #include "stablehlo/dialect/Version.h"
 
@@ -41,10 +40,6 @@ namespace mlir {
 namespace stablehlo {
 
 #define GEN_PASS_DECL
-
-std::unique_ptr<::mlir::Pass> createStablehloAggressiveSimplificationPass(
-    GreedyRewriteConfig config);
-
 #define GEN_PASS_REGISTRATION
 #include "stablehlo/transforms/Passes.h.inc"
 

--- a/stablehlo/transforms/optimization/Passes.h
+++ b/stablehlo/transforms/optimization/Passes.h
@@ -16,6 +16,7 @@ limitations under the License.
 #ifndef STABLEHLO_TRANSFORMS_OPTIMIZATION_PASSES_H
 #define STABLEHLO_TRANSFORMS_OPTIMIZATION_PASSES_H
 
+#include <memory>
 #include <utility>
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -33,6 +34,10 @@ namespace stablehlo {
 #define GEN_PASS_DECL
 #define GEN_PASS_REGISTRATION
 #include "stablehlo/transforms/optimization/Passes.h.inc"
+
+std::unique_ptr<::mlir::Pass> createStablehloAggressiveSimplificationPass(
+    StablehloAggressiveSimplificationPassOptions options,
+    GreedyRewriteConfig rewriteConfig);
 
 std::pair<StablehloAggressiveFolderPassOptions,
           StablehloAggressiveSimplificationPassOptions>


### PR DESCRIPTION
The declaration for a pass-creation function was located in the wrong header file, resulting in a linker error if someone tried to use it. This change moves the declaration to the correct header and updates its function signature per PR #2775.