### PR TITLE
Disallow empty globs in bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -70,3 +70,6 @@ test --nobuild_runfile_links
 # https://bazel.build/reference/command-line-reference#flag--legacy_external_runfiles
 build --nolegacy_external_runfiles
 test --nolegacy_external_runfiles
+
+# Disallow empty globs unless explicitly declared using `allow_empty=True`
+common --incompatible_disallow_empty_glob

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "9e42fa15fdae2a59a51ea764fd71c5e9f785b0fcb894b4e6007c56956b0082af",
+  "moduleFileHash": "7d7242dc1d15217a8af40c80c5f91829a0f3fb0a5216b1c07a374b7cb24dfdfd",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -17,10 +17,10 @@
   },
   "moduleDepGraph": {
     "<root>": {
-      "name": "",
+      "name": "stablehlo",
       "version": "",
       "key": "<root>",
-      "repoName": "",
+      "repoName": "stablehlo",
       "executionPlatformsToRegister": [],
       "toolchainsToRegister": [],
       "extensionUsages": [
@@ -30,7 +30,7 @@
           "usingModule": "<root>",
           "location": {
             "file": "@@//:MODULE.bazel",
-            "line": 24,
+            "line": 26,
             "column": 23
           },
           "imports": {},
@@ -45,7 +45,7 @@
               "devDependency": false,
               "location": {
                 "file": "@@//:MODULE.bazel",
-                "line": 30,
+                "line": 32,
                 "column": 17
               }
             }

--- a/stablehlo/tests/BUILD.bazel
+++ b/stablehlo/tests/BUILD.bazel
@@ -157,6 +157,7 @@ RUNFILES_DIR = LITE_CFG_PY.parents[2].absolute().as_posix()''',
             "//:stablehlo-translate",
             "@llvm-project//llvm:FileCheck",
             "@llvm-project//llvm:not",
+        # Allow empty since not all `.mlir` tests have `.mlir.bc` test files.
         ] + glob(["%s.bc" % src], allow_empty=True),
         tags = ["stablehlo_tests"],
         deps = ["@rules_python//python/runfiles"],

--- a/stablehlo/tests/BUILD.bazel
+++ b/stablehlo/tests/BUILD.bazel
@@ -157,8 +157,11 @@ RUNFILES_DIR = LITE_CFG_PY.parents[2].absolute().as_posix()''',
             "//:stablehlo-translate",
             "@llvm-project//llvm:FileCheck",
             "@llvm-project//llvm:not",
-        # Allow empty since not all `.mlir` tests have `.mlir.bc` test files.
-        ] + glob(["%s.bc" % src], allow_empty=True),
+            # Allow empty since not all `.mlir` tests have `.mlir.bc` test files.
+        ] + glob(
+            ["%s.bc" % src],
+            allow_empty = True,
+        ),
         tags = ["stablehlo_tests"],
         deps = ["@rules_python//python/runfiles"],
     )


### PR DESCRIPTION
Issue was discovered and fixed in https://github.com/openxla/stablehlo/pull/2743, but lets enforce this to avoid breaking downstream users going forward.

This bazel flag will be flipped to default in bazel8 so might as well get ahead of things too.