### PR TITLE
Add a pattern for folding `stablehlo.while` no-ops

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1239,6 +1239,7 @@ cc_library(
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Rewrite",
+        "@llvm-project//mlir:SideEffectInterfaces",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",

--- a/stablehlo/tests/transforms/stablehlo_aggressive_folder.mlir
+++ b/stablehlo/tests/transforms/stablehlo_aggressive_folder.mlir
@@ -341,3 +341,23 @@ func.func @eval_transpose_splat() -> (tensor<10x3x1xi32>) {
   %1 = stablehlo.transpose %0, dims = [2, 0, 1] : (tensor<3x1x10xi32>) -> tensor<10x3x1xi32>
   func.return %1 : tensor<10x3x1xi32>
 }
+
+// -----
+
+////////
+// WhileOp
+
+// CHECK-LABEL: dce_while_false_condition
+func.func @dce_while_false_condition() -> tensor<i64> {
+  %0 = stablehlo.constant dense<0> : tensor<i64>
+  // CHECK-NOT: stablehlo.while
+  %1 = stablehlo.while(%iterArg = %0) : tensor<i64>
+    cond {
+    %2 = stablehlo.compare LT, %0, %0, SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    stablehlo.return %2 : tensor<i1>
+  } do {
+    %2 = stablehlo.custom_call @something(%iterArg) {has_side_effect = false} : (tensor<i64>) -> tensor<i64>
+    stablehlo.return %2 : tensor<i64>
+  }
+  return %1 : tensor<i64>
+}

--- a/stablehlo/tests/transforms/stablehlo_target_independent_optimization.mlir
+++ b/stablehlo/tests/transforms/stablehlo_target_independent_optimization.mlir
@@ -10,3 +10,52 @@ func.func @add_cst_on_rhs(%arg0: tensor<f32>) -> tensor<f32> {
   %1 = stablehlo.add %0, %arg0 : tensor<f32>
   return %1 : tensor<f32>
 }
+
+// -----
+
+// Check that the WhileOp optimizations from AggressiveFolder and
+// AggressiveSimplification don't interfere with one another. Specifically, we
+// need to make sure that FoldWhileOpPattern doesn't DCE code with side effects.
+
+// CHECK-LABEL: while_op_with_outfeed_no_dce
+func.func @while_op_with_outfeed_no_dce(%arg0: tensor<i64>) -> tensor<i64> {
+  // CHECK: stablehlo.while
+  %0 = stablehlo.while(%iterArg = %arg0) : tensor<i64>
+    cond {
+    %1 = stablehlo.compare LT, %iterArg, %iterArg, SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    stablehlo.return %1 : tensor<i1>
+  } do {
+    %1 = stablehlo.create_token : !stablehlo.token
+    %2 = "stablehlo.outfeed"(%iterArg, %1) <{outfeed_config = ""}> : (tensor<i64>, !stablehlo.token) -> !stablehlo.token
+    stablehlo.return %iterArg : tensor<i64>
+  }
+  return %arg0 : tensor<i64>
+}
+
+// CHECK-LABEL: while_op_dce_no_side_effect
+func.func @while_op_dce_no_side_effect(%arg0: tensor<i64>) -> tensor<i64> {
+  // CHECK-NOT: stablehlo.while
+  %0 = stablehlo.while(%iterArg = %arg0) : tensor<i64>
+    cond {
+    %1 = stablehlo.compare LT, %iterArg, %iterArg, SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    stablehlo.return %1 : tensor<i1>
+  } do {
+    %1 = stablehlo.create_token : !stablehlo.token
+    stablehlo.return %iterArg : tensor<i64>
+  }
+  return %arg0 : tensor<i64>
+}
+
+// CHECK-LABEL: dce_while_false_condition
+func.func @dce_while_false_condition(%arg0: tensor<i64>) -> tensor<i64> {
+  // CHECK-NOT: stablehlo.while
+  %0 = stablehlo.while(%iterArg = %arg0) : tensor<i64>
+    cond {
+    %1 = stablehlo.compare LT, %arg0, %arg0, SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    stablehlo.return %1 : tensor<i1>
+  } do {
+    %1 = stablehlo.custom_call @something(%iterArg) {has_side_effect = false} : (tensor<i64>) -> tensor<i64>
+    stablehlo.return %1 : tensor<i64>
+  }
+  return %0 : tensor<i64>
+}

--- a/stablehlo/transforms/optimization/StablehloAggressiveSimplification.cpp
+++ b/stablehlo/transforms/optimization/StablehloAggressiveSimplification.cpp
@@ -13,6 +13,7 @@
 #include <iterator>
 #include <memory>
 #include <optional>
+#include <type_traits>
 #include <utility>
 
 #include "llvm/ADT/APInt.h"
@@ -22,6 +23,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/SmallVectorExtras.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Block.h"
@@ -135,7 +137,9 @@ static ComparisonDirection invertDirection(ComparisonDirection direction) {
       return ComparisonDirection::GT;
   }
 
-  llvm::report_fatal_error("Unhandled case");
+  llvm::report_fatal_error(llvm::formatv(
+      "Undefined enum value for `ComparisonDirection`: {0}",
+      static_cast<std::underlying_type_t<ComparisonDirection>>(direction)));
 }
 
 struct CompareOpCanon final : SimplifyOpRewritePattern<CompareOp> {


### PR DESCRIPTION
If a `stablehlo.while` op's condition is a constant with a value of `false`, replace the op with its input.

Make an exception for preserving dead ops with side effects, which can't currently be DCE'd safely despite being unreachable. This is because dependent code is currently allowed to depend on the existence of ops with hypothetical side effects that show up in the unoptimized IR but can't actually occur.

Issue: #2736