### PR TITLE
Separated stablehlo pass utils into separate dialect library to fix cmake build for stablehlo optimization passes library

### DIFF
--- a/stablehlo/transforms/CMakeLists.txt
+++ b/stablehlo/transforms/CMakeLists.txt
@@ -39,6 +39,21 @@ set(LLVM_TARGET_DEFINITIONS VhloToVersionPatterns.td)
 mlir_tablegen(VhloToVersionPatterns.h.inc --gen-rewriters)
 add_public_tablegen_target(VhloToVersionPatterns)
 
+add_mlir_dialect_library(StablehloPassUtils
+  PARTIAL_SOURCES_INTENDED
+  PassUtils.cpp
+
+  DEPENDS
+  PassesIncGen
+
+  LINK_LIBS PUBLIC
+  ChloOps
+  StablehloBase
+  StablehloOps
+  MLIRSupport
+  MLIRComplexDialect
+  MLIRIR
+)
 
 add_mlir_dialect_library(StablehloPasses
   PARTIAL_SOURCES_INTENDED
@@ -60,7 +75,6 @@ add_mlir_dialect_library(StablehloPasses
   StablehloWrapInComposite.cpp
   VhloLegalizeToStablehlo.cpp
   VhloToVersion.cpp
-  PassUtils.cpp
 
   DEPENDS
   ChloDecompositionPatternsIncGen
@@ -69,6 +83,7 @@ add_mlir_dialect_library(StablehloPasses
   StablehloComplexMathExpanderPatternsIncGen
   StablehloLegalizeDeprecatedOpsPatternsIncGen
   VhloToVersionPatterns
+  StablehloPassUtils
 
   LINK_LIBS PUBLIC
   ChloOps
@@ -93,4 +108,5 @@ add_mlir_dialect_library(StablehloPasses
   StablehloOptimizationPasses
   StablehloTypeInference
   VhloOps
+  StablehloPassUtils
 )

--- a/stablehlo/transforms/optimization/CMakeLists.txt
+++ b/stablehlo/transforms/optimization/CMakeLists.txt
@@ -29,6 +29,7 @@ add_mlir_dialect_library(StablehloOptimizationPasses
   DEPENDS
   OptimizationPassesIncGen
   StablehloAggressiveSimplificationPatternsIncGen
+  StablehloPassUtils
 
   LINK_LIBS PUBLIC
   ChloOps
@@ -42,4 +43,5 @@ add_mlir_dialect_library(StablehloOptimizationPasses
   StablehloBase
   StablehloOps
   StablehloTypeInference
+  StablehloPassUtils
 )


### PR DESCRIPTION
When attempting to link against `StablehloOptimizationPasses`, it throws a linker error for functionality found in `PassUtils.cpp`. 

Error
```
/usr/bin/ld: lib/libStablehloOptimizationPasses.a(StablehloAggressiveSimplification.cpp.o): in function `mlir::Value mlir::stablehlo::getConstantLike<int>(mlir::OpBuilder&, mlir::Location, int, mlir::Value)':
StablehloAggressiveSimplification.cpp:(.text._ZN4mlir9stablehlo15getConstantLikeIiEENS_5ValueERNS_9OpBuilderENS_8LocationET_S2_[_ZN4mlir9stablehlo15getConstantLikeIiEENS_5ValueERNS_9OpBuilderENS_8LocationET_S2_]+0x5c): undefined reference to `mlir::stablehlo::getConstantLikeImpl(mlir::OpBuilder&, mlir::Location, mlir::Attribute, mlir::Value)'
clang++-17: error: linker command failed with exit code 1 (use -v to see invocation)
```

The bazel build creates a separate pass utils library

```
cc_library(
    name = "stablehlo_pass_utils",
    srcs = [
        "stablehlo/transforms/PassUtils.cpp",
    ],
    hdrs = [
        "stablehlo/transforms/PassUtils.h",
    ],
    strip_include_prefix = ".",
    deps = [
        ":base",
        ":chlo_ops",
        ":stablehlo_ops",
        ":stablehlo_pass_inc_gen",
        "@llvm-project//llvm:Support",
        "@llvm-project//mlir:ComplexDialect",
        "@llvm-project//mlir:IR",
        "@llvm-project//mlir:Support",
    ],
)
```

This change mimics the same behavior but for cmake based build to fix the build error.