### PR TITLE
Add patterns for folding Reduce ops.

### DIFF
--- a/stablehlo/tests/transforms/stablehlo_aggressive_folder.mlir
+++ b/stablehlo/tests/transforms/stablehlo_aggressive_folder.mlir
@@ -180,6 +180,21 @@ func.func @eval_iota_zero_dimension() -> (tensor<0xi32>, tensor<5x0x2xi32>) {
 // -----
 
 ////////
+// ReduceOp
+
+// Requires `LowerBoolSplatConstantsIntoRegion` and `ReduceOp::fold` pattern
+// Already have ReduceEmpty / UnusedResult patterns.
+func.func @reduce_op_fold(%arg0: tensor<i64>) -> tensor<i1> {
+  %c = stablehlo.constant dense<false> : tensor<4x32xi1>
+  %c_0 = stablehlo.constant dense<false> : tensor<i1>
+  // CHECK-NOT: stablehlo.reduce
+  %0 = stablehlo.reduce(%c init: %c_0) applies stablehlo.or across dimensions = [0, 1] : (tensor<4x32xi1>, tensor<i1>) -> tensor<i1>
+  return %0 : tensor<i1>
+}
+
+// -----
+
+////////
 // ReshapeOp
 
 // CHECK-LABEL: func @reshape

--- a/stablehlo/tests/transforms/stablehlo_aggressive_folder.mlir
+++ b/stablehlo/tests/transforms/stablehlo_aggressive_folder.mlir
@@ -182,8 +182,7 @@ func.func @eval_iota_zero_dimension() -> (tensor<0xi32>, tensor<5x0x2xi32>) {
 ////////
 // ReduceOp
 
-// Requires `LowerBoolSplatConstantsIntoRegion` and `ReduceOp::fold` pattern
-// Already have ReduceEmpty / UnusedResult patterns.
+// CHECK-LABEL: func @reduce_op_fold
 func.func @reduce_op_fold(%arg0: tensor<i64>) -> tensor<i1> {
   %c = stablehlo.constant dense<false> : tensor<4x32xi1>
   %c_0 = stablehlo.constant dense<false> : tensor<i1>
@@ -197,7 +196,7 @@ func.func @reduce_op_fold(%arg0: tensor<i64>) -> tensor<i1> {
 ////////
 // ReshapeOp
 
-// CHECK-LABEL: func @reshape
+// CHECK-LABEL: func @reshape_fold
 func.func @reshape_fold() -> (tensor<1xi32>, tensor<2x2xi32>) {
   %c0 = stablehlo.constant dense<2> : tensor<i32>
   %c1 = stablehlo.constant dense<[1, 2, 3, 4]> : tensor<4xi32>

--- a/stablehlo/transforms/optimization/StablehloAggressiveFolder.cpp
+++ b/stablehlo/transforms/optimization/StablehloAggressiveFolder.cpp
@@ -1164,7 +1164,8 @@ void populateStablehloAggressiveFolderPatterns(
                 FoldReduceOpToConstantInitializer,  //
                 FoldReduceOpWithRedundantResults,   //
                 FoldWhileOpPattern,                 //
-                LowerBoolSplatConstantsIntoReduceOpRegion>(context, benefit);
+                LowerBoolSplatConstantsIntoReduceOpRegion>(context, options,
+                                                           benefit);
 
   // TODO: Consolidate FoldOp patterns
   // One is used by Shape Refinement, the other is a generic folder.

--- a/stablehlo/transforms/optimization/StablehloAggressiveFolder.cpp
+++ b/stablehlo/transforms/optimization/StablehloAggressiveFolder.cpp
@@ -958,8 +958,8 @@ struct EvalTransposeOpPattern : public FoldOpRewritePattern<TransposeOp> {
 };
 
 struct LowerBoolSplatConstantsIntoReduceOpRegion
-    : public OpRewritePattern<ReduceOp> {
-  using OpRewritePattern::OpRewritePattern;
+    : public FoldOpRewritePattern<ReduceOp> {
+  using FoldOpRewritePattern::FoldOpRewritePattern;
 
   LogicalResult matchAndRewrite(ReduceOp op,
                                 PatternRewriter& rewriter) const override {
@@ -999,8 +999,8 @@ struct LowerBoolSplatConstantsIntoReduceOpRegion
   }
 };
 
-struct FoldReduceOpReducingZeroDims : public OpRewritePattern<ReduceOp> {
-  using OpRewritePattern::OpRewritePattern;
+struct FoldReduceOpReducingZeroDims : public FoldOpRewritePattern<ReduceOp> {
+  using FoldOpRewritePattern::FoldOpRewritePattern;
 
   LogicalResult matchAndRewrite(ReduceOp op,
                                 PatternRewriter& rewriter) const override {
@@ -1017,8 +1017,9 @@ struct FoldReduceOpReducingZeroDims : public OpRewritePattern<ReduceOp> {
   }
 };
 
-struct FoldReduceOpToConstantInitializer : public OpRewritePattern<ReduceOp> {
-  using OpRewritePattern::OpRewritePattern;
+struct FoldReduceOpToConstantInitializer
+    : public FoldOpRewritePattern<ReduceOp> {
+  using FoldOpRewritePattern::FoldOpRewritePattern;
 
   LogicalResult matchAndRewrite(ReduceOp op,
                                 PatternRewriter& rewriter) const override {
@@ -1058,8 +1059,9 @@ struct FoldReduceOpToConstantInitializer : public OpRewritePattern<ReduceOp> {
   }
 };
 
-struct FoldReduceOpWithRedundantResults : public OpRewritePattern<ReduceOp> {
-  using OpRewritePattern::OpRewritePattern;
+struct FoldReduceOpWithRedundantResults
+    : public FoldOpRewritePattern<ReduceOp> {
+  using FoldOpRewritePattern::FoldOpRewritePattern;
 
   LogicalResult matchAndRewrite(ReduceOp op,
                                 PatternRewriter& rewriter) const override {


### PR DESCRIPTION
Add four missing patterns targeting Reduce ops:
- FoldReduceOpReducingZeroDims
- FoldReduceOpToConstantInitializer
- FoldReduceOpWithRedundantResults
- LowerBoolSplatConstantsIntoReduceOpRegion

Issue: #2736