### PR TITLE
Remove unused LINK_LIBS in cmake

### DIFF
--- a/stablehlo/transforms/conversions/CMakeLists.txt
+++ b/stablehlo/transforms/conversions/CMakeLists.txt
@@ -18,7 +18,6 @@ add_mlir_library(StablehloTypeConversion
   TypeConversion.cpp
 
   LINK_LIBS PUBLIC
-  LLVMSupport
   MLIRIR
   MLIRSupport
   MLIRTransformUtils


### PR DESCRIPTION
With `STABLEHLO_BUILD_EMBEDDED=ON`, this unused LINK_LIBS will cause a cmake issue
```
CMake Error at /project/torch-mlir/externals/llvm-project/mlir/cmake/modules/AddMLIR.cmake:265 (message):
  StablehloTypeConversion specifies LINK_LIBS LLVMSupport, but LINK_LIBS
  cannot be used for LLVM libraries.  Please use LINK_COMPONENTS instead.
```