### PR TITLE
Fix typo in `InfeedResource::getName()`.

### DIFF
--- a/stablehlo/dialect/StablehloOps.h
+++ b/stablehlo/dialect/StablehloOps.h
@@ -143,7 +143,7 @@ struct RecvResource : ::mlir::SideEffects::Resource::Base<RecvResource> {
   StringRef getName() final { return "RecvResource"; }
 };
 struct InfeedResource : ::mlir::SideEffects::Resource::Base<InfeedResource> {
-  StringRef getName() final { return "OutfeedResource"; }
+  StringRef getName() final { return "InfeedResource"; }
 };
 struct OutfeedResource : ::mlir::SideEffects::Resource::Base<OutfeedResource> {
   StringRef getName() final { return "OutfeedResource"; }


### PR DESCRIPTION
`::mlir::stablehlo::side_effects::InfeedResource::getName()` previously returned "OutfeedResource" instead of "InfeedResource"; this fixes it.