### PR TITLE
Add a (theoretically redundant) null check.

### DIFF
--- a/stablehlo/tests/transforms/stablehlo_aggressive_simplification.mlir
+++ b/stablehlo/tests/transforms/stablehlo_aggressive_simplification.mlir
@@ -299,6 +299,19 @@ func.func @convert(%arg0: tensor<2xf32>) -> tensor<2xf32> {
 // -----
 
 /////////
+// CustomCallOp
+
+// CHECK-LABEL: @fix_mhlo_backend_config_attribute
+func.func @fix_mhlo_backend_config_attribute(%arg0: tensor<1xf32>) -> (tensor<1xf32>) {
+  // CHECK-NEXT: %[[CC:.*]] = stablehlo.custom_call @foo(%arg0) {api_version = 4 : i32, backend_config = {bar = 1 : i32}} : (tensor<1xf32>) -> tensor<1xf32>
+  %0 = stablehlo.custom_call @foo(%arg0) {api_version = 1 : i32, mhlo.backend_config = {bar = 1: i32}} : (tensor<1xf32>) -> tensor<1xf32>
+  // CHECK-NEXT: return %[[CC]]
+  return %0 : tensor<1xf32>
+}
+
+// -----
+
+/////////
 // DynamicBroadcastInDimOp
 
 // CHECK-LABEL: func @dynamic_broadcast_in_dim_all_dims_non_expanding

--- a/stablehlo/tests/transforms/stablehlo_aggressive_simplification.mlir
+++ b/stablehlo/tests/transforms/stablehlo_aggressive_simplification.mlir
@@ -301,8 +301,8 @@ func.func @convert(%arg0: tensor<2xf32>) -> tensor<2xf32> {
 /////////
 // CustomCallOp
 
-// CHECK-LABEL: @fix_mhlo_backend_config_attribute
-func.func @fix_mhlo_backend_config_attribute(%arg0: tensor<1xf32>) -> (tensor<1xf32>) {
+// CHECK-LABEL: @custom_call_unregistered_backend_config_to_ffi
+func.func @custom_call_unregistered_backend_config_to_ffi(%arg0: tensor<1xf32>) -> (tensor<1xf32>) {
   // CHECK-NEXT: %[[CC:.*]] = stablehlo.custom_call @foo(%arg0) {api_version = 4 : i32, backend_config = {bar = 1 : i32}} : (tensor<1xf32>) -> tensor<1xf32>
   %0 = stablehlo.custom_call @foo(%arg0) {api_version = 1 : i32, mhlo.backend_config = {bar = 1: i32}} : (tensor<1xf32>) -> tensor<1xf32>
   // CHECK-NEXT: return %[[CC]]

--- a/stablehlo/transforms/optimization/StablehloAggressiveSimplification.cpp
+++ b/stablehlo/transforms/optimization/StablehloAggressiveSimplification.cpp
@@ -309,7 +309,7 @@ struct CustomCallUnregisteredBackendConfigToFfi final
         dyn_cast<StringAttr>(op.getBackendConfigOrDefault());
     if (!oldBackendConfig)
       return rewriter.notifyMatchFailure(
-          op, "`op.getBackendConfigOrDefault()` returned a null attribute.");
+          op, "`op.getBackendConfigOrDefault()` didn't return a `StringAttr`.");
     if (!oldBackendConfig.empty())
       return rewriter.notifyMatchFailure(
           op, "Non-empty `backend_config` attribute shouldn't be overwritten.");

--- a/stablehlo/transforms/optimization/StablehloAggressiveSimplification.cpp
+++ b/stablehlo/transforms/optimization/StablehloAggressiveSimplification.cpp
@@ -305,7 +305,12 @@ struct CustomCallUnregisteredBackendConfigToFfi final
       return rewriter.notifyMatchFailure(
           op, "No `mhlo.backend_config` attribute to fix.");
 
-    if (!dyn_cast<StringAttr>(op.getBackendConfigOrDefault()).empty())
+    auto oldBackendConfig =
+        dyn_cast<StringAttr>(op.getBackendConfigOrDefault());
+    if (!oldBackendConfig)
+      return rewriter.notifyMatchFailure(
+          op, "`op.getBackendConfigOrDefault()` returned a null attribute.");
+    if (!oldBackendConfig.empty())
       return rewriter.notifyMatchFailure(
           op, "Non-empty `backend_config` attribute shouldn't be overwritten.");
 


### PR DESCRIPTION
The `CustomCallUnregisteredBackendConfigToFfi` pattern previously skipped a certain null check since the value was never supposed to be null, but checking it anyway seems prudent on second thought.