### PR TITLE
Don't segfault verifying while without valid terminator

### DIFF
--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -5042,7 +5042,7 @@ LogicalResult verifyWhileOp(std::optional<Location> location,
 
   if (!body.front().mightHaveTerminator())
     return emitOptionalError(
-        loc, "The while body-region expected to have a terminator");
+        locaction, "The while body-region expected to have a terminator");
 
   // while_c2
   auto bodyReturnTypes = body.front().getTerminator()->getOperandTypes();

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -5039,6 +5039,11 @@ LogicalResult verifyWhileOp(std::optional<Location> location,
         location,
         "expect operands to be compatible with body block arguments but got ",
         operandTypes, " vs ", bodyArgsTypes);
+
+  if (!body.front().mightHaveTerminator())
+    return emitOptionalError(
+        loc, "The while body-region expected to have a terminator");
+
   // while_c2
   auto bodyReturnTypes = body.front().getTerminator()->getOperandTypes();
   if (!isCompatibleForHloTypeInference(operandTypes, bodyReturnTypes))

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -5042,7 +5042,7 @@ LogicalResult verifyWhileOp(std::optional<Location> location,
 
   if (!body.front().mightHaveTerminator())
     return emitOptionalError(
-        locaction, "The while body-region expected to have a terminator");
+        location, "The while body-region expected to have a terminator");
 
   // while_c2
   auto bodyReturnTypes = body.front().getTerminator()->getOperandTypes();


### PR DESCRIPTION
verification of an invalid while op otherwise causes a segfault instead of throwing the proper error message