### PR TITLE
Allow reduce-like ops to type infer without body region

### DIFF
--- a/stablehlo/dialect/StablehloOps.h
+++ b/stablehlo/dialect/StablehloOps.h
@@ -179,7 +179,8 @@ SortOp createSortOp(PatternRewriter *rewriter, const Location &loc,
 template <typename OpTy>
 void buildReduceBody(Type elementType, Region &body, OpBuilder &builder) {
   OpBuilder::InsertionGuard guard(builder);
-  Block *block = builder.createBlock(&body);
+  if (body.getBlocks().empty()) builder.createBlock(&body);
+  Block *block = &body.getBlocks().front();
 
   // Block arguments are scalars of the given element type.
   Type type = RankedTensorType::get(/*shape=*/{}, elementType);

--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -957,12 +957,12 @@ LogicalResult verifyReduceOpInputsAndInferShape(
 
 // Returns the types of the terminator arguments of the input  mlir::Block
 // 'block'.
-FailureOr<SmallVector<ShapedType>> getAccumulatorTypes(
-    std::optional<Location> loc, Region& region) {
-  if (region.empty()) {
-    return emitOptionalError(
-        loc, "Expects non-empty reduction block for type inference");
-  }
+// Falls back to using the input types if the region is not set.
+// If different precision body is required, don't use TypeInference APIs.
+SmallVector<ShapedType> getAccumulatorTypesOrInputTypes(
+    std::optional<Location> loc, Region& region,
+    ArrayRef<ShapedType> inputTypes) {
+  if (region.empty()) return llvm::to_vector(inputTypes);
 
   Block& block = region.front();
   return llvm::map_to_vector(
@@ -1894,12 +1894,11 @@ LogicalResult inferAllReduceOp(
   auto inputArgTensorTypes = llvm::map_to_vector(
       inputTypes, [](Type t) { return cast<ShapedType>(t); });
   // all_reduce_c6, all_reduce_c7
-  auto accumulatorTypesOrErr = getAccumulatorTypes(location, computation);
-  if (failed(accumulatorTypesOrErr)) return failure();
+  auto accumulatorTypes = getAccumulatorTypesOrInputTypes(location, computation,
+                                                          inputArgTensorTypes);
   for (size_t inputIdx = 0; inputIdx < inputTypes.size(); ++inputIdx) {
-    inferredReturnShapes.emplace_back(
-        getSameShapeTensorType(inputArgTensorTypes[inputIdx],
-                               (*accumulatorTypesOrErr)[0].getElementType()));
+    inferredReturnShapes.emplace_back(getSameShapeTensorType(
+        inputArgTensorTypes[inputIdx], accumulatorTypes[0].getElementType()));
   }
 
   return success();
@@ -3089,10 +3088,10 @@ LogicalResult inferReduceOp(
           location, inputArgTensorTypes, dimensions, newDimensions, encoding)))
     return failure();
   // reduce_c3, reduce_c7, reduce_c8
-  auto accumulatorTypesOrErr = getAccumulatorTypes(location, body);
-  if (failed(accumulatorTypesOrErr)) return failure();
+  auto accumulatorTypes =
+      getAccumulatorTypesOrInputTypes(location, body, inputArgTensorTypes);
   for (uint64_t inputIdx = 0; inputIdx < inputTypes.size(); ++inputIdx) {
-    Type elementType = (*accumulatorTypesOrErr)[inputIdx].getElementType();
+    Type elementType = accumulatorTypes[inputIdx].getElementType();
     inferredReturnShapes.emplace_back(newDimensions, elementType, encoding);
   }
 
@@ -3122,20 +3121,20 @@ LogicalResult inferReduceWindowOp(
     return failure();
 
   // reduce_window_c1, reduce_window_c14...reduce_window_c16
-  auto accumulatorTypesOrErr = getAccumulatorTypes(location, body);
-  if (failed(accumulatorTypesOrErr)) return failure();
+  auto accumulatorTypes =
+      getAccumulatorTypesOrInputTypes(location, body, inputTypes);
   for (size_t i = 0; i < inputTypes.size(); ++i) {
     auto inputRankedType = cast<RankedTensorType>(inputs[i].getType());
     auto resultShape =
         inferWindowOutputShape(inputTypes[i].getShape(), inferredWindow);
     auto inputBounds = encodingToBounds(inputRankedType.getEncoding());
     if (inputBounds.empty()) {
-      inferredReturnShapes.emplace_back(
-          resultShape, (*accumulatorTypesOrErr)[i].getElementType());
+      inferredReturnShapes.emplace_back(resultShape,
+                                        accumulatorTypes[i].getElementType());
     } else {
       auto resultBounds = inferWindowOutputShape(inputBounds, inferredWindow);
       inferredReturnShapes.emplace_back(
-          resultShape, (*accumulatorTypesOrErr)[i].getElementType(),
+          resultShape, accumulatorTypes[i].getElementType(),
           boundsToEncoding(inputRankedType.getEncoding(), resultBounds));
     }
   }
@@ -3196,12 +3195,14 @@ LogicalResult inferScatterOp(std::optional<Location> location,
                              ValueRange inputs, Region& updateComputation,
                              SmallVectorImpl<Type>& inferredReturnTypes) {
   // scatter_c24, scatter_c25
-  auto accumulatorTypesOrErr = getAccumulatorTypes(location, updateComputation);
-  if (failed(accumulatorTypesOrErr)) return failure();
+  auto inputTypes = llvm::map_to_vector(
+      inputs.getTypes(), [](Type t) { return cast<ShapedType>(t); });
+  auto accumulatorTypes =
+      getAccumulatorTypesOrInputTypes(location, updateComputation, inputTypes);
   for (uint64_t inputIdx = 0; inputIdx < inputs.size(); ++inputIdx) {
     auto inputShapedTy = cast<ShapedType>(inputs[inputIdx].getType());
     inferredReturnTypes.push_back(getSameShapeTensorType(
-        inputShapedTy, (*accumulatorTypesOrErr)[inputIdx].getElementType()));
+        inputShapedTy, accumulatorTypes[inputIdx].getElementType()));
   }
   return success();
 }
@@ -3235,11 +3236,12 @@ LogicalResult inferSelectAndScatterOp(
     std::optional<Location> location, Value operand, Region& scatter,
     SmallVectorImpl<Type>& inferredReturnTypes) {
   // select_and_scatter_c11, select_and_scatter_c12
-  auto accumulatorTypesOrErr = getAccumulatorTypes(location, scatter);
-  if (failed(accumulatorTypesOrErr)) return failure();
+  auto inputType = cast<ShapedType>(operand.getType());
+  auto accumulatorTypes =
+      getAccumulatorTypesOrInputTypes(location, scatter, {inputType});
   auto operandShapedTy = cast<ShapedType>(operand.getType());
   inferredReturnTypes.push_back(getSameShapeTensorType(
-      operandShapedTy, (*accumulatorTypesOrErr)[0].getElementType()));
+      operandShapedTy, accumulatorTypes[0].getElementType()));
   return success();
 }
 
@@ -4618,13 +4620,12 @@ LogicalResult verifyReduceScatterOp(std::optional<Location> location,
   }
 
   // reduce_scatter_c9
-  auto accumulatorTypesOrErr = getAccumulatorTypes(location, computation);
-  if (failed(accumulatorTypesOrErr)) return failure();
-  if (resultType.getElementType() !=
-      (*accumulatorTypesOrErr)[0].getElementType()) {
+  auto accumulatorTypes =
+      getAccumulatorTypesOrInputTypes(location, computation, {operandType});
+  if (resultType.getElementType() != accumulatorTypes[0].getElementType()) {
     return emitOptionalError(location, "result element-type is expected to be ",
-                             (*accumulatorTypesOrErr)[0].getElementType(),
-                             ", but got ", resultType.getElementType());
+                             accumulatorTypes[0].getElementType(), ", but got ",
+                             resultType.getElementType());
   }
 
   return success();


### PR DESCRIPTION
We want to be able to use the `create<ReduceOp>(values,inits,dim)` API that relies on type inference, but type inference relies on a body existing.

Today, most users expect the reduce body to have arguments similar to the input types, with the _option_ to use different precisions in the body. If using type inference APIs we should still allow this and you cannot use a body region with different types. If you use the API where you explicitly set output type (no reliance on type inference) then you can have body region with different input argument element types.