### PR TITLE
Fold `case` ops with constant branch indices

### DIFF
--- a/stablehlo/tests/transforms/stablehlo_aggressive_folder.mlir
+++ b/stablehlo/tests/transforms/stablehlo_aggressive_folder.mlir
@@ -46,8 +46,9 @@ func.func @broadcast_in_dim_fold_splat(%arg0: tensor<3x3xi32>)
 
 // CHECK-LABEL: func.func @case_fold_constant_branch_index
 func.func @case_fold_constant_branch_index(%arg0: tensor<i32>, %arg1: tensor<i32>, %arg2: tensor<i32>) -> tensor<i32> {
-  // CHECK-NOT: stablehlo.case
-  // CHECK-DAG: {{(^ *|func\.)}}return %arg1
+  // CHECK-NOT:  stablehlo.case
+  // CHECK-NEXT: {{(^ *|func\.)}}return %arg1
+  // CHECK-NOT:  stablehlo.case
   %branch_index = stablehlo.constant dense<1> : tensor<i32>
   %result = "stablehlo.case"(%branch_index) ({
     stablehlo.return %arg0 : tensor<i32>

--- a/stablehlo/tests/transforms/stablehlo_aggressive_folder.mlir
+++ b/stablehlo/tests/transforms/stablehlo_aggressive_folder.mlir
@@ -42,6 +42,65 @@ func.func @broadcast_in_dim_fold_splat(%arg0: tensor<3x3xi32>)
 // -----
 
 ////////
+// CaseOp
+
+// CHECK-LABEL: func.func @case_fold_constant_branch_index
+func.func @case_fold_constant_branch_index(%arg0: tensor<i32>, %arg1: tensor<i32>, %arg2: tensor<i32>) -> tensor<i32> {
+  // CHECK-NOT: stablehlo.case
+  // CHECK-DAG: {{(^ *|func\.)}}return %arg1
+  %branch_index = stablehlo.constant dense<1> : tensor<i32>
+  %result = "stablehlo.case"(%branch_index) ({
+    stablehlo.return %arg0 : tensor<i32>
+  }, {
+    stablehlo.return %arg1 : tensor<i32>
+  }, {
+    stablehlo.return %arg2 : tensor<i32>
+  }) : (tensor<i32>) -> tensor<i32>
+  func.return %result: tensor<i32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @case_fold_preserve_side_effects
+func.func @case_fold_preserve_side_effects(%arg0: tensor<i32>, %arg1: tensor<i32>, %arg2: tensor<i32>) -> tensor<i32> {
+  // COM:       // Inline the executed branch of the `case` op:
+  // CHECK-DAG: [[RESULT:%.+]] = stablehlo.custom_call @bar(%arg1) {has_side_effect = true}
+
+  // COM:       // Keep the rest of the `case` op if it's non-trivially dead:
+  // CHECK-DAG: [[BRANCH_INDEX:%.+]] = stablehlo.constant
+  // CHECK-DAG: [[NON_TRIVIALLY_DEAD_CASE_OP:%.+]] = {{"?}}stablehlo.case{{"?}}([[BRANCH_INDEX]]) ({
+  // COM:         // Non-trivially dead branches are preserved but unused.
+  // CHECK-DAG:   [[FOO:%.+]] = stablehlo.custom_call @foo(%arg0) {has_side_effect = true}
+  // CHECK-DAG:   stablehlo.return [[FOO]]
+  // COM:       }, {
+  // COM:         // The executed branch is now just a trivial placeholder; its
+  // COM:         // original logic has been inlined outside of the `case` op.
+  // CHECK-DAG:   stablehlo.return [[BRANCH_INDEX]]
+  // COM:       }, {
+  // COM:         // Non-trivially dead branches are preserved but unused.
+  // CHECK-DAG:   [[BAZ:%.+]] = stablehlo.custom_call @baz(%arg2) {has_side_effect = true}
+  // CHECK-DAG:   stablehlo.return [[BAZ]]
+  // COM:       })
+
+  // COM:       // Return the result of the inlined branch.
+  // CHECK-DAG: {{(^ *|func\.)}}return [[RESULT]]
+  %branch_index = stablehlo.constant dense<1> : tensor<i32>
+  %result = "stablehlo.case"(%branch_index) ({
+    %foo = stablehlo.custom_call @foo(%arg0) {has_side_effect = true} : (tensor<i32>) -> tensor<i32>
+    stablehlo.return %foo : tensor<i32>
+  }, {
+    %bar = stablehlo.custom_call @bar(%arg1) {has_side_effect = true} : (tensor<i32>) -> tensor<i32>
+    stablehlo.return %bar : tensor<i32>
+  }, {
+    %baz = stablehlo.custom_call @baz(%arg2) {has_side_effect = true} : (tensor<i32>) -> tensor<i32>
+    stablehlo.return %baz : tensor<i32>
+  }) : (tensor<i32>) -> tensor<i32>
+  func.return %result: tensor<i32>
+}
+
+// -----
+
+////////
 // ClampOp
 
 // CHECK-LABEL: func.func @clamp_fold

--- a/stablehlo/transforms/optimization/StablehloAggressiveFolder.cpp
+++ b/stablehlo/transforms/optimization/StablehloAggressiveFolder.cpp
@@ -12,6 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
+#include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -459,26 +460,27 @@ class InlineCaseOpWithConstantBranchIndex
 
   LogicalResult matchAndRewrite(CaseOp op,
                                 PatternRewriter& rewriter) const override {
+    // Fail to match dead `case` ops. Dead-code elimination should already erase
+    // such ops whenever it's safe to do so; if we find a dead `case` op that
+    // can't be erased, we need to signal match failure or else the pattern will
+    // be reapplied ad infinitum.
+    if (op->use_empty())
+      return rewriter.notifyMatchFailure(op, "The case op's result is unused.");
+
     Value branchIndexArgument = op.getIndex();
-    DenseIntElementsAttr indexAttr;
+    SplatElementsAttr indexAttr;
     if (!matchPattern(branchIndexArgument, m_Constant(&indexAttr)))
       return rewriter.notifyMatchFailure(op, "Branch index is not a constant.");
 
     int64_t selectedBranchIndex =
         indexAttr.getSplatValue<IntegerAttr>().getValue().getSExtValue();
     // If the branch index is OOB, the last branch is executed by default:
-    // https://openxla.org/xla/operation_semantics#conditional
+    // https://openxla.org/stablehlo/spec#case
     if (selectedBranchIndex < 0 || selectedBranchIndex >= op.getNumRegions())
       selectedBranchIndex = op.getNumRegions() - 1;
 
-    if (op->use_empty())
-      return rewriter.notifyMatchFailure(op, "The case op's result is unused.");
-
     Region& region = op.getRegion(selectedBranchIndex);
-
-    if (!llvm::hasSingleElement(region))
-      return rewriter.notifyMatchFailure(op, "Expected a single-block region.");
-
+    assert(llvm::hasSingleElement(region));
     Block* block = &region.front();
     ValueRange blockArgs = {};
     Operation* terminator = block->getTerminator();


### PR DESCRIPTION
When a `case` op is given a constant branch-selection index, replace the `case` op with the contents of the always-active branch. If any branches are non-trivially dead (i.e. dead but not functionally pure), the `case` op will not be deleted but will always execute a now-empty branch (since the original contents of the active branch have been inlined).