### PR TITLE
Fix Bazel link issue

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1411,7 +1411,7 @@ cc_binary(
         "//stablehlo/tests:check_ops",
         "//stablehlo/tests:test_utils",
         "@llvm-project//llvm:Support",
-        "@llvm-project//mlir:AllPassesAndDialects",
+        "@llvm-project//mlir:RegisterAllDialects",
         "@llvm-project//mlir:AsmParser",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",


### PR DESCRIPTION
```
ERROR: /private/var/tmp/_bazel_wmoses/fc23347ca89ccc877582708f22eb94c3/external/stablehlo/BUILD.bazel:1390:10: Linking external/stablehlo/stablehlo-translate failed: (Exit 1): cc_wrapper.sh failed: error executing CppLink command (from target @@stablehlo//:stablehlo-translate) external/local_config_cc/cc_wrapper.sh @bazel-out/darwin_arm64-dbg/bin/external/stablehlo/stablehlo-translate-2.params

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
Undefined symbols for architecture arm64:
  "mlir::registerAllDialects(mlir::DialectRegistry&)", referenced from:
      mlir::$_2::operator()(mlir::DialectRegistry&) const in StablehloTranslateMain.o
      mlir::$_5::operator()(mlir::DialectRegistry&) const in StablehloTranslateMain.o
ld: symbol(s) not found for architecture arm64
```