### PR TITLE
Use tf-nightly in jax notebook

### DIFF
--- a/docs/tutorials/jax-export.ipynb
+++ b/docs/tutorials/jax-export.ipynb
@@ -36,7 +36,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -U jax jaxlib flax transformers tensorflow-cpu"
+    "!pip install -U jax jaxlib flax transformers tf-nightly"
    ]
   },
   {


### PR DESCRIPTION
`tensorflow-cpu` is far outside of the compat window, last release was in March. This leads to errors like:
https://github.com/openxla/stablehlo/actions/runs/16919652788

Instead lets use nightly since TF releases seem to be slowing down otherwise.