### PR TITLE
README.md: fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Here's how to build the StableHLO repo on Linux or macOS:
 
    ```sh
    # On Linux
-   sudo apt install cmake ninja-build lld
+   sudo apt install cmake ninja-build lld ccache
 
    # On macOS
-   brew install cmake ninja
+   brew install cmake ninja ccache
    ```
 
 2. Set the `LLVM_ENABLE_LLD` shell variable depending on your preferences. We
@@ -73,7 +73,7 @@ Here's how to build the StableHLO repo on Linux or macOS:
 4. Make sure you check out the correct commit in the LLVM repository:
 
    ```sh
-   (hash="$(cat ../build_tools/llvm_version.txt)"; cd llvm-project && git fetch "$hash" && git checkout "$hash")
+   (hash="$(cat ./build_tools/llvm_version.txt)"; cd llvm-project && git fetch origin "$hash" && git checkout "$hash")
    ```
 
    You need to do this every time `llvm_version.txt` changes.
@@ -141,8 +141,10 @@ Here's how to build the StableHLO repo on Linux or macOS:
    You should see results like this:
 
    ```txt
-   Testing Time: 5.99s
-     Passed: 47
+   Testing Time: 6.60s
+
+   Total Discovered Tests: 246
+   Passed: 246 (100.00%)
    ```
 
    This runs all the tests in `stablehlo/tests/`.


### PR DESCRIPTION
This PR resolves two issues in the build instructions and updates the test results.

```bash
/bin/sh: 1: ccache: not found
[11/156] Building CXX object stablehlo/transforms/conversions/CMakeFiles/obj.StablehloTypeConversion.dir/TypeConversion.cpp.o
FAILED: stablehlo/transforms/conversions/CMakeFiles/obj.StablehloTypeConversion.dir/TypeConversion.cpp.o
ccache /usr/bin/c++ -DGTEST_HAS_RTTI=0 -D_DEBUG -D_GLIBCXX_ASSERTIONS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__SHORT_FILE__=\"TypeConversion.cpp\" -I/root/stablehlo/llvm-project/llvm/include -I/root/stablehlo/llvm-build/include -I/root/stablehlo/llvm-project/mlir/include -I/root/stablehlo/llvm-build/tools/mlir/include -I/root/stablehlo -I/root/stablehlo/build -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -Wimplicit-fallthrough -Wno-nonnull -Wno-class-memaccess -Wno-redundant-move -Wno-pessimizing-move -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wsuggest-override -Wno-comment -Wno-misleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -O2 -g -DNDEBUG -std=gnu++17   -D_DEBUG -D_GLIBCXX_ASSERTIONS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS  -fno-exceptions -funwind-tables -fno-rtti -UNDEBUG -gsplit-dwarf -ggnu-pubnames -fsanitize=address -fsanitize=undefined -fsanitize=leak -fno-omit-frame-pointer -MD -MT stablehlo/transforms/conversions/CMakeFiles/obj.StablehloTypeConversion.dir/TypeConversion.cpp.o -MF stablehlo/transforms/conversions/CMakeFiles/obj.StablehloTypeConversion.dir/TypeConversion.cpp.o.d -o stablehlo/transforms/conversions/CMakeFiles/obj.StablehloTypeConversion.dir/TypeConversion.cpp.o -c /root/stablehlo/stablehlo/transforms/conversions/TypeConversion.cpp
/bin/sh: 1: ccache: not found
[20/156] Building StablehloOps.cpp.inc...
ninja: build stopped: subcommand failed.
```

### Testing Done

```
root@0-4-35-gpu-mi300x1-192gb-devcloud-atl1:~/stablehlo# (hash="$(cat ./build_tools/llvm_version.txt)"; cd llvm-project && git fetch origin "$hash" && git checkout "$hash")
From https://github.com/llvm/llvm-project
 * branch                      6d4a0935c850ec3ddfc70c4ba97b98adc35c676e -> FETCH_HEAD
HEAD is now at 6d4a0935c850 [lldb][test] Skip TestExprDefinitionInDylib on Windows
```