### PR TITLE
Typo fix on cholesky op, bool attr is not a 0-d tensor

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1612,7 +1612,7 @@ For quantized types, performs
 | Label | Name    | Type                                                                    | Constraints |
 |-------|---------|-------------------------------------------------------------------------|-------------|
 | (I1)  | `a`     | tensor of floating-point or complex type or per-tensor quantized tensor | (C1-C3)     |
-| (I2)  | `lower` | 0-dimensional tensor constant of type `i1`                              |             |
+| (I2)  | `lower` | constant of type `i1`                                                   |             |
 
 #### Outputs
 


### PR DESCRIPTION
Thanks to @joelberkeley for pointing this out on discord