### PR TITLE
Convert stablehlo.dynamic_slice into tosa.slice when indices are const

### DIFF
--- a/stablehlo/conversions/tosa/tests/unary.mlir
+++ b/stablehlo/conversions/tosa/tests/unary.mlir
@@ -114,6 +114,28 @@ func.func @slice_rank_seven(%arg : tensor<2x3x4x5x6x7x8xf32>) -> tensor<1x2x3x4x
   return %0 : tensor<1x2x3x4x5x6x7xf32>
 }
 
+// CHECK-LABEL: @dynamic_slice_constant_start
+func.func @dynamic_slice_constant_start(%arg : tensor<10x10xf32>) -> tensor<2x3xf32> {
+  // CHECK-DAG: %[[START:.*]] = tosa.const_shape {values = dense<[1, 2]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  // CHECK-DAG: %[[SIZE:.*]] = tosa.const_shape {values = dense<[2, 3]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  // CHECK: tosa.slice %arg0, %[[START]], %[[SIZE]]
+  %start0 = "stablehlo.constant"() {value = dense<1> : tensor<i32>} : () -> tensor<i32>
+  %start1 = "stablehlo.constant"() {value = dense<2> : tensor<i32>} : () -> tensor<i32>
+  %0 = "stablehlo.dynamic_slice"(%arg, %start0, %start1) {
+    slice_sizes = array<i64: 2, 3>
+  } : (tensor<10x10xf32>, tensor<i32>, tensor<i32>) -> tensor<2x3xf32>
+  return %0 : tensor<2x3xf32>
+}
+
+// CHECK-LABEL: @dynamic_slice_runtime_start
+func.func @dynamic_slice_runtime_start(%arg0 : tensor<10x10xf32>, %arg1 : tensor<i32>, %arg2 : tensor<i32>) -> tensor<2x3xf32> {
+  // CHECK: stablehlo.dynamic_slice
+  %0 = "stablehlo.dynamic_slice"(%arg0, %arg1, %arg2) {
+    slice_sizes = array<i64: 2, 3>
+  } : (tensor<10x10xf32>, tensor<i32>, tensor<i32>) -> tensor<2x3xf32>
+  return %0 : tensor<2x3xf32>
+}
+
 // CHECK-LABEL: @tanh
 func.func @tanh(%arg : tensor<10xf32>) -> tensor<10xf32> {
   // CHECK: tosa.tanh

--- a/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.cpp
+++ b/stablehlo/conversions/tosa/transforms/StablehloLegalizeToTosa.cpp
@@ -505,16 +505,7 @@ struct ConvertStablehloReshapeOp
     auto resultShape = resultType.getShape();
     SmallVector<int64_t, 8> dimensions(resultShape.begin(), resultShape.end());
 
-    RankedTensorType shapeTensorType = RankedTensorType::get(
-        {static_cast<int64_t>(dimensions.size())}, rewriter.getIndexType());
-
-    auto denseAttr = DenseIntElementsAttr::get(shapeTensorType, dimensions);
-    auto shapeType =
-        tosa::shapeType::get(rewriter.getContext(), dimensions.size());
-
-    auto constShapeOp =
-        tosa::ConstShapeOp::create(rewriter, op.getLoc(), shapeType, denseAttr);
-
+    auto constShapeOp = getTosaConstShape(rewriter, op.getLoc(), dimensions);
     auto reshapeOp = tosa::ReshapeOp::create(rewriter, op.getLoc(), resultType,
                                              op.getOperand(), constShapeOp);
 


### PR DESCRIPTION
If the `stablehlo`->`tosa` transformation is applied without stablehlo dynamism canonicalization (as a part of e.g. `stablehlo-canonicalize-dynamism` or `stablehlo-aggressive-simplification`) `stablehlo.dynamic_slice` can be converted into `tosa.slice` if the indices are const. 