### PR TITLE
Fix RefineCallOpPattern in StablehloRefineShapes to preserve side-effecting callees

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1215,6 +1215,7 @@ cc_library(
         "@llvm-project//mlir:ReconcileUnrealizedCasts",
         "@llvm-project//mlir:Rewrite",
         "@llvm-project//mlir:ShapeDialect",
+        "@llvm-project//mlir:SideEffectInterfaces",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TransformUtils",

--- a/stablehlo/tests/transforms/stablehlo_refine_shapes.mlir
+++ b/stablehlo/tests/transforms/stablehlo_refine_shapes.mlir
@@ -885,6 +885,22 @@ module @refine_call_dimension_argument_not_integer {
 
 // -----
 
+// CHECK-LABEL: module @refine_call_side_effecting_callee
+module @refine_call_side_effecting_callee {
+  func.func public @main() {
+    // CHECK: call @callee()
+    call @callee() : () -> ()
+    return
+  }
+  func.func private @callee() {
+    %0 = stablehlo.constant dense<0> : tensor<i32>
+    stablehlo.custom_call @side_effect(%0) {has_side_effect = true} : (tensor<i32>) -> ()
+    return
+  }
+}
+
+// -----
+
 // CHECK-LABEL: func @refine_convert
 func.func @refine_convert(%arg0 : tensor<4xf32>) -> tensor<?xi32> {
   // CHECK: stablehlo.convert{{.*}} -> tensor<4xi32>

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -45,6 +45,7 @@ limitations under the License.
 #include "mlir/IR/Value.h"
 #include "mlir/IR/ValueRange.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Rewrite/FrozenRewritePatternSet.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
@@ -566,13 +567,21 @@ struct RefineCallOpPattern : public OpRewritePattern<func::CallOp> {
     std::optional<SmallVector<DenseIntElementsAttr>> constantAttrs =
         isConstantFunction(callee);
     if (constantAttrs.has_value()) {
-      SmallVector<Value> constants;
-      for (auto constAttr : constantAttrs.value()) {
-        constants.push_back(
-            ConstantOp::create(rewriter, op.getLoc(), constAttr));
+      auto sideEffectResult = callee.walk([](Operation* nestedOp) {
+        auto effectInterface = dyn_cast<MemoryEffectOpInterface>(nestedOp);
+        if (effectInterface && !effectInterface.hasNoEffect())
+          return WalkResult::interrupt();
+        return WalkResult::advance();
+      });
+      if (!sideEffectResult.wasInterrupted()) {
+        SmallVector<Value> constants;
+        for (auto constAttr : constantAttrs.value()) {
+          constants.push_back(
+              ConstantOp::create(rewriter, op.getLoc(), constAttr));
+        }
+        rewriter.replaceOp(op, constants);
+        return success();
       }
-      rewriter.replaceOp(op, constants);
-      return success();
     }
     if (!refinementKey->getGlobalConstants().empty()) {
       // Drop the global-constant arguments, but only if necessary, or else we


### PR DESCRIPTION
The constant-function replacement in RefineCallOpPattern did not check
whether the callee contains side-effecting operations. This caused calls
to functions with side effects (e.g. custom_call with
has_side_effect=true) to be silently erased. Guard the replacement with
a walk that checks for MemoryEffectOpInterface declarations.
