### PR TITLE
Allow overriding MLIR_BUILDER_TABLEGEN_EXE for cross compilation

### DIFF
--- a/stablehlo/integrations/cpp/builder/MlirBuilderTblgen.cmake
+++ b/stablehlo/integrations/cpp/builder/MlirBuilderTblgen.cmake
@@ -14,7 +14,10 @@
 
 include(TableGen)
 
-set(MLIR_BUILDER_TABLEGEN_EXE mlir_builder_tblgen)
+# We specifically declare this as a cache variable in order to allow users
+# to override this (e.g. for cross compilation builds).
+set(MLIR_BUILDER_TABLEGEN_EXE mlir_builder_tblgen CACHE STRING
+     "The target name or path to the executable to use for mlir_builder_tblgen")
 
 function(mlir_builder_tblgen ofn)
   tablegen(MLIR_BUILDER ${ARGV})


### PR DESCRIPTION
Declare MLIR_BUILDER_TABLEGEN_EXE as a CMake cache variable so that
users can override the tablegen executable path, which is often needed
for two-stage cross-compilation builds.
