### PR TITLE
Fix LLVM_DEFINITIONS not being parsed correctly in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,14 +167,19 @@ if(STABLEHLO_ENABLE_SPLIT_DWARF)
     endif()
 endif()
 
-#TODO: Where should these be?
+# This is the typical out-of-tree configuration sequence, see
+# https://llvm.org/docs/CMake.html#embedding-llvm-in-your-project.
+# These lines just need tobe positioned after the find_package({MLIR,LLVM})
+# calls and prior to any new targets being defined.
 include_directories(${LLVM_INCLUDE_DIRS})
 include_directories(${MLIR_INCLUDE_DIRS})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 link_directories(${LLVM_BUILD_LIBRARY_DIR})
-add_definitions(${LLVM_DEFINITIONS})
-
+# Note LLVM_DEFINITIONS needs to be transformed into semicolon-separated list.
+# LLVM defines it as a space-separated list.
+separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
+add_definitions(${LLVM_DEFINITIONS_LIST})
 
 #-------------------------------------------------------------------------------
 # Sanitizer configuration


### PR DESCRIPTION
LLVM_DEFINITIONS is a space-separated string, but add_definitions()
expects a semicolon-separated CMake list. Passing it directly could
silently drop definitions or concatenate flags incorrectly, leading
to subtle build bugs. Use separate_arguments() to convert it into a
proper list before passing it to add_definitions().

Also replaces the TODO comment with a reference to the upstream LLVM
CMake embedding documentation.
