### PR TITLE
Refactor vhlo::TensorV1Attr to store DenseElementsAttr

### DIFF
--- a/stablehlo/dialect/VhloAttrs.td
+++ b/stablehlo/dialect/VhloAttrs.td
@@ -132,11 +132,11 @@ def VHLO_TensorDataV1 : AttrParameter<"::llvm::ArrayRef<char>", ""> {
 }
 def VHLO_TensorAttrV1 : VHLO_AttrDef<"TensorV1", "0.9.0", "current"> {
   let mnemonic = "tensor_v1";
-  let parameters = (ins "::mlir::Type":$type, VHLO_TensorDataV1:$data);
+  let parameters = (ins "::mlir::Type":$type, "DenseElementsAttr":$data);
   let genVerifyDecl = 1;
   let extraClassDefinition = [{
     LogicalResult TensorV1Attr::verify(
-        llvm::function_ref<mlir::InFlightDiagnostic ()> errFn, mlir::Type type, ArrayRef<char>) {
+        llvm::function_ref<mlir::InFlightDiagnostic ()> errFn, mlir::Type type, DenseElementsAttr) {
       if (!isFromVhlo(type)) errFn() << "expected VHLO type";
       return success();
     }

--- a/stablehlo/dialect/VhloBytecode.cpp
+++ b/stablehlo/dialect/VhloBytecode.cpp
@@ -1049,13 +1049,13 @@ static LogicalResult readVhloTensorV1Attr(DialectBytecodeReader& reader,
 static void writeVhloTensorV1Attr(DialectBytecodeWriter& writer,
                                   vhlo::TensorV1Attr attr) {
   if (!isBooleanType(attr.getType())) {
-    writer.writeOwnedBlob(attr.getData());
+    writer.writeOwnedBlob(attr.getData().getRawData());
     return;
   }
 
   // Pack the data if i1
   SmallVector<char> data;
-  ArrayRef<char> rawData = attr.getData();
+  ArrayRef<char> rawData = attr.getData().getRawData();
   auto numElements = cast<RankedTensorV1Type>(attr.getType()).getNumElements();
 
   // If the attribute is a splat, we can just splat the value directly.
@@ -1085,7 +1085,19 @@ TensorV1Attr VhloBytecodeInterface::readTensorV1Attr(
   if (failed(reader.readType(type)) ||
       failed(readVhloTensorV1Attr(reader, type, blob)))
     return TensorV1Attr();
-  return TensorV1Attr::get(getContext(), type, blob);
+
+  struct VhloToBuiltinPrintConverter : VhloTypeConverter {
+    VhloToBuiltinPrintConverter() : VhloTypeConverter() {
+      addVhloToBuiltinConversions();
+    }
+    Attribute convertEncoding(Attribute attr) const override { return attr; }
+  };
+
+  VhloToBuiltinPrintConverter conv;
+  auto builtinType = cast<ShapedType>(conv.convertType(type));
+  return TensorV1Attr::get(
+      getContext(), type,
+      DenseElementsAttr::getFromRawBuffer(builtinType, blob));
 }
 
 void VhloBytecodeInterface::write(TensorV1Attr attr,

--- a/stablehlo/dialect/VhloOps.cpp
+++ b/stablehlo/dialect/VhloOps.cpp
@@ -185,12 +185,7 @@ ParseResult parseFunctionBody(OpAsmParser& parser, Attribute& name,
 }
 
 void TensorV1Attr::print(mlir::AsmPrinter& odsPrinter) const {
-  odsPrinter << '<'
-             << DenseTypedElementsAttr::getFromRawBuffer(
-                    llvm::cast<ShapedType>(
-                        convertTypeToBuiltinForPrint(getType())),
-                    getData())
-             << '>';
+  odsPrinter << '<' << getData() << '>';
 }
 
 // Parse tensor elements using DenseTypedElementsAttr printing.
@@ -202,7 +197,7 @@ Attribute TensorV1Attr::parse(AsmParser& parser, mlir::Type) {
   }
   return TensorV1Attr::get(parser.getContext(),
                            convertTypeToVhloForParse(attr.getType()),
-                           attr.getRawData());
+                           attr);
 }
 
 void printEscapedString(AsmPrinter& p, llvm::StringRef value) {

--- a/stablehlo/dialect/VhloOps.cpp
+++ b/stablehlo/dialect/VhloOps.cpp
@@ -196,8 +196,7 @@ Attribute TensorV1Attr::parse(AsmParser& parser, mlir::Type) {
     return TensorV1Attr();
   }
   return TensorV1Attr::get(parser.getContext(),
-                           convertTypeToVhloForParse(attr.getType()),
-                           attr);
+                           convertTypeToVhloForParse(attr.getType()), attr);
 }
 
 void printEscapedString(AsmPrinter& p, llvm::StringRef value) {

--- a/stablehlo/transforms/StablehloLegalizeToVhlo.cpp
+++ b/stablehlo/transforms/StablehloLegalizeToVhlo.cpp
@@ -253,7 +253,7 @@ Attribute convertGeneric(Attribute stablehloAttr,
     LLVM_DEBUG(llvm::dbgs() << "Converted " << vhloType << '\n');
     if (!vhloType) return {};
     return vhlo::TensorV1Attr::get(attr.getContext(), vhloType,
-                                   attr.getRawData());
+                                   attr);
   }
   if (auto attr = dyn_cast<DenseI64ArrayAttr>(stablehloAttr)) {
     // Leverage the serialization for DenseElements.

--- a/stablehlo/transforms/StablehloLegalizeToVhlo.cpp
+++ b/stablehlo/transforms/StablehloLegalizeToVhlo.cpp
@@ -252,8 +252,7 @@ Attribute convertGeneric(Attribute stablehloAttr,
     auto vhloType = typeConverter->convertType(attr.getType());
     LLVM_DEBUG(llvm::dbgs() << "Converted " << vhloType << '\n');
     if (!vhloType) return {};
-    return vhlo::TensorV1Attr::get(attr.getContext(), vhloType,
-                                   attr);
+    return vhlo::TensorV1Attr::get(attr.getContext(), vhloType, attr);
   }
   if (auto attr = dyn_cast<DenseI64ArrayAttr>(stablehloAttr)) {
     // Leverage the serialization for DenseElements.

--- a/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
+++ b/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
@@ -618,7 +618,8 @@ SpecialResult convertDenseArray(const vhlo::VhloTypeConverter* typeConverter,
       typeConverter->convertType(tensorAttr.getType()));
   if (!type) return specialFailure();
 
-  auto elems = DenseElementsAttr::getFromRawBuffer(type, tensorAttr.getData().getRawData());
+  auto elems = DenseElementsAttr::getFromRawBuffer(
+      type, tensorAttr.getData().getRawData());
 
   stablehloAttrs.emplace_back(
       vhloName, DenseArrayAttr::get(vhloAttr.getContext(),

--- a/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
+++ b/stablehlo/transforms/VhloLegalizeToStablehlo.cpp
@@ -173,8 +173,7 @@ Attribute convertGeneric(Attribute vhloAttr,
     auto builtinType =
         cast<ShapedType>(typeConverter->convertType(attr.getType()));
     if (!builtinType) return {};
-    return DenseTypedElementsAttr::getFromRawBuffer(builtinType,
-                                                    attr.getData());
+    return attr.getData();
   }
   if (auto attr = dyn_cast<vhlo::TransposeV1Attr>(vhloAttr)) {
     RETURN_CONVERTED_ENUM_ATTR(Transpose, V1);
@@ -619,7 +618,7 @@ SpecialResult convertDenseArray(const vhlo::VhloTypeConverter* typeConverter,
       typeConverter->convertType(tensorAttr.getType()));
   if (!type) return specialFailure();
 
-  auto elems = DenseElementsAttr::getFromRawBuffer(type, tensorAttr.getData());
+  auto elems = DenseElementsAttr::getFromRawBuffer(type, tensorAttr.getData().getRawData());
 
   stablehloAttrs.emplace_back(
       vhloName, DenseArrayAttr::get(vhloAttr.getContext(),
@@ -806,7 +805,7 @@ bool isEmptyString(Attribute vhloAttr) {
 
 bool isEmptyTensor(Attribute vhloAttr) {
   auto attr = dyn_cast_or_null<vhlo::TensorV1Attr>(vhloAttr);
-  return attr && attr.getData().empty();
+  return attr && attr.getData().getRawData().empty();
 }
 
 bool isEnum(Attribute vhloAttr, Attribute value) { return vhloAttr == value; }

--- a/stablehlo/transforms/VhloToVersion.cpp
+++ b/stablehlo/transforms/VhloToVersion.cpp
@@ -364,12 +364,15 @@ TensorV1Attr getEmptyI64Tensor(OpBuilder& builder) {
   auto shape = vhlo::RankedTensorV1Type::get(
       builder.getContext(), {0},
       vhlo::IntegerSI64V1Type::get(builder.getContext()), {});
-  return vhlo::TensorV1Attr::get(builder.getContext(), shape, {});
+  auto denseElements = DenseIntElementsAttr::get(
+      RankedTensorType::get({0}, builder.getI64Type()),
+      llvm::ArrayRef<int64_t>{});
+  return vhlo::TensorV1Attr::get(builder.getContext(), shape, denseElements);
 }
 
 bool isEmptyTensor(Attribute attr) {
   auto tensor = dyn_cast<TensorV1Attr>(attr);
-  if (tensor) return tensor.getData().empty();
+  if (tensor) return tensor.getData().getRawData().empty();
   return false;
 }
 
@@ -400,7 +403,7 @@ TensorV1Attr getDefaultConvPadding(OpBuilder& builder, Value lhs) {
       RankedTensorV1Type::get(builder.getContext(), paddingShape,
                               IntegerSI64V1Type::get(builder.getContext()),
                               nullptr),
-      denseElements.getRawData());
+      denseElements);
 }
 
 bool isDefaultResultAccuracy(Attribute attr) {


### PR DESCRIPTION
This change updates the internal representation of vhlo::TensorV1Attr to hold a DenseElementsAttr instead of just an ArrayRef<char>. This aligns better with MLIR's built-in attribute types. Call sites are updated to access the raw data via getData().getRawData() when interacting with bytecode or other formats requiring raw buffers.