### PR TITLE
Preserve discardable attributes when rewriting transpose to reshape

### DIFF
--- a/stablehlo/tests/transforms/stablehlo_aggressive_simplification.mlir
+++ b/stablehlo/tests/transforms/stablehlo_aggressive_simplification.mlir
@@ -1971,6 +1971,14 @@ func.func @transpose_is_reshape(%arg0: tensor<1x4x5x1xf32>) -> tensor<1x4x1x5xf3
   return %0 : tensor<1x4x1x5xf32>
 }
 
+// CHECK-LABEL: @transpose_is_reshape_preserves_discardable_attrs
+func.func @transpose_is_reshape_preserves_discardable_attrs(%arg0: tensor<99x1xf32>) -> tensor<1x99xf32> {
+  // CHECK: stablehlo.reshape
+  // CHECK-SAME: mhlo.frontend_attributes = {_xla_compute_type = "host"}
+  %0 = stablehlo.transpose %arg0, dims = [1, 0] {mhlo.frontend_attributes = {_xla_compute_type = "host"}} : (tensor<99x1xf32>) -> tensor<1x99xf32>
+  return %0 : tensor<1x99xf32>
+}
+
 // CHECK-LABEL: @transpose_is_not_reshape
 func.func @transpose_is_not_reshape(%arg0: tensor<1x4x5x2xf32>) -> tensor<2x4x1x5xf32> {
   // CHECK-NOT: stablehlo.reshape

--- a/stablehlo/transforms/optimization/StablehloAggressiveSimplification.cpp
+++ b/stablehlo/transforms/optimization/StablehloAggressiveSimplification.cpp
@@ -1386,7 +1386,14 @@ struct TransposeIsReshape final : SimplifyOpRewritePattern<TransposeOp> {
       if (nonZeroPerms[i - 1] > nonZeroPerms[i])
         return rewriter.notifyMatchFailure(op, "memory layout change");
 
-    rewriter.replaceOpWithNewOp<ReshapeOp>(op, op.getType(), input);
+    // Preserve discardable attributes (e.g. mhlo.frontend_attributes that
+    // carry _xla_compute_type for host offloading). replaceOpWithNewOp does
+    // not copy them, and dropping them silently breaks downstream consumers
+    // that group ops by frontend attribute.
+    DictionaryAttr discardableAttrs = op->getDiscardableAttrDictionary();
+    auto reshape =
+        rewriter.replaceOpWithNewOp<ReshapeOp>(op, op.getType(), input);
+    if (discardableAttrs) reshape->setDiscardableAttrs(discardableAttrs);
     return success();
   }
 };


### PR DESCRIPTION
The `TransposeIsReshape` pattern uses `rewriter.replaceOpWithNewOp<ReshapeOp>(...)` to fold a layout-equivalent transpose (one whose permutation only shuffles size-1 dims) into a reshape. `replaceOpWithNewOp` does not copy the original op's discardable attribute dictionary, so attributes such as `mhlo.frontend_attributes` are silently dropped on the resulting reshape.

This breaks downstream consumers that group ops by frontend attribute. Concretely, a JAX program using `jax.experimental.compute_on('device_host')` to host-offload a sub-graph containing a multi-output `lax.scan` followed by `expm1(moveaxis(scan_output, 0, -1))` produces stablehlo where the post-scan transpose is tagged with `_xla_compute_type=host`. After this pattern fires, the resulting reshape no longer carries the tag, fragmenting what XLA's host-offload pass expects to be a contiguous host region. The runtime then fails with `INVALID_ARGUMENT: Result shape s32[] does not match program shape ...`, as the host_execute returns a single value while its declared signature is the full while-tuple.

The fix mirrors what tablegen-defined patterns in this file already do via the `MergeDiscardableAttributes` `NativeCodeCall` helper: snapshot the discardable attribute dictionary before the rewrite and re-apply it to the new op. A regression test is added alongside `@transpose_is_reshape`.