### PR TITLE
Use result element type for accumulation for integer convolution

### DIFF
--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -96,7 +96,8 @@ SmallVector<T> extractAttributeOrDefault(std::optional<ArrayRef<T>> attr,
 
 Tensor dotGeneralOp(const Tensor& lhs, const Tensor& rhs,
                     const Axes& lhsContractingDimensions,
-                    const Axes& rhsContractingDimensions) {
+                    const Axes& rhsContractingDimensions,
+                    const Type resultElementType) {
   SmallVector<ShapedTypeComponents> inferredDotGeneralType;
   if (failed(hlo::inferDotGeneralOp(
           /*location=*/{}, lhs.getType(), rhs.getType(),
@@ -110,7 +111,7 @@ Tensor dotGeneralOp(const Tensor& lhs, const Tensor& rhs,
                       /*rhsBatchingDimensions*/ {}, lhsContractingDimensions,
                       rhsContractingDimensions,
                       RankedTensorType::get(inferredDotGeneralType[0].getDims(),
-                                            lhs.getElementType()));
+                                            resultElementType));
 }
 
 Tensor padOp(const Tensor& operand, const Tensor& paddingValue,
@@ -1650,7 +1651,7 @@ Tensor convolutionOp(
 
     auto dotProduct =
         dotGeneralOp(reversedLhsWindow, rhs, lhsContractingDimensions,
-                     rhsContractingDimensions);
+                     rhsContractingDimensions, resultType.getElementType());
 
     Sizes resultNonSpatialDims;
     for (auto i = 0; i < result.getRank(); ++i)

--- a/stablehlo/tests/interpret/convolution.mlir
+++ b/stablehlo/tests/interpret/convolution.mlir
@@ -28,6 +28,34 @@ func.func @convolution_op_test_si64() {
 
 // -----
 
+func.func @convolution_op_test_si8() {
+  %lhs = stablehlo.constant dense<[[
+                                    [[1], [2], [5], [6]],
+                                    [[3], [4], [7], [8]],
+                                    [[10], [11], [14], [15]],
+                                    [[12], [13], [16], [17]]
+                                  ]]> : tensor<1x4x4x1xi8>
+  %rhs = stablehlo.constant dense<10> : tensor<3x3x1x1xi8>
+  %result = stablehlo.convolution(%lhs, %rhs)
+    dim_numbers = [b, 0, 1, f]x[0, 1, i, o]->[b, 0, 1, f],
+    window = {
+      stride = [4, 4],
+      lhs_dilate = [2, 2]
+    } {
+      batch_group_count = 1 : i64,
+      feature_group_count = 1 : i64,
+      precision_config = [#stablehlo<precision DEFAULT>, #stablehlo<precision DEFAULT>]
+    }
+  : (tensor<1x4x4x1xi8>, tensor<3x3x1x1xi8>) -> tensor<1x2x2x1xi32>
+  check.expect_eq_const %result, dense<[[
+                                         [[100], [260]],
+                                         [[460], [620]]
+                                        ]]> : tensor<1x2x2x1xi32>
+  func.return
+}
+
+// -----
+
 func.func @convolution_op_test_padding() {
   %lhs = stablehlo.constant dense<[[
                                     [[1], [2], [5], [6]],


### PR DESCRIPTION
This changes the stablehlo interpreter implementation of convolution to accumulate to the result element type instead of the LHS element type (e.g. i8xi8=>i32 accumulates to i32 instead of i8).