### PR TITLE
Fix chlo.zeta lowering returning NaN for q == +inf

### DIFF
--- a/stablehlo/tests/chlo/chlo_legalize_to_stablehlo.mlir
+++ b/stablehlo/tests/chlo/chlo_legalize_to_stablehlo.mlir
@@ -2538,10 +2538,12 @@ func.func @digamma_f16(%arg : tensor<f16>) -> tensor<f16> {
 // CHECK:           %[[ADD_55:.*]] = stablehlo.add %[[ADD_54]], %[[MULTIPLY_36]] : tensor<f32>
 // CHECK:           %[[ABS_0:.*]] = stablehlo.abs %[[POWER_10]] : tensor<f32>
 // CHECK:           %[[ABS_1:.*]] = stablehlo.abs %[[ADD_17]] : tensor<f32>
+// CHECK:           %[[COMPARE_ZETA_EQ:.*]] = stablehlo.compare  EQ, %[[POWER_10]], %[[CONSTANT_0]] : (tensor<f32>, tensor<f32>) -> tensor<i1>
 // CHECK:           %[[CONSTANT_38:.*]] = stablehlo.constant dense<1.401300e-45> : tensor<f32>
 // CHECK:           %[[MULTIPLY_37:.*]] = stablehlo.multiply %[[ABS_1]], %[[CONSTANT_38]] : tensor<f32>
 // CHECK:           %[[COMPARE_0:.*]] = stablehlo.compare  LT, %[[ABS_0]], %[[MULTIPLY_37]] : (tensor<f32>, tensor<f32>) -> tensor<i1>
-// CHECK:           %[[SELECT_0:.*]] = stablehlo.select %[[COMPARE_0]], %[[ADD_17]], %[[ADD_55]] : tensor<i1>, tensor<f32>
+// CHECK:           %[[OR_ZETA:.*]] = stablehlo.or %[[COMPARE_ZETA_EQ]], %[[COMPARE_0]] : tensor<i1>
+// CHECK:           %[[SELECT_0:.*]] = stablehlo.select %[[OR_ZETA]], %[[ADD_17]], %[[ADD_55]] : tensor<i1>, tensor<f32>
 // CHECK:           %[[CONSTANT_39:.*]] = stablehlo.constant dense<0x7FC00000> : tensor<f32>
 // CHECK:           %[[COMPARE_1:.*]] = stablehlo.compare  LT, %[[CONVERT_0]], %[[CONSTANT_2]] : (tensor<f32>, tensor<f32>) -> tensor<i1>
 // CHECK:           %[[SELECT_1:.*]] = stablehlo.select %[[COMPARE_1]], %[[CONSTANT_39]], %[[SELECT_0]] : tensor<i1>, tensor<f32>

--- a/stablehlo/transforms/ChloLegalizeToStablehlo.cpp
+++ b/stablehlo/transforms/ChloLegalizeToStablehlo.cpp
@@ -1753,16 +1753,28 @@ static Value materializeZeta(OpBuilder& rewriter, Location loc,
 
   // Use the initial zeta sum without the correction term coming
   // from Euler-Maclaurin if it is accurate enough.
+  //
+  // When `qNegPower` has underflowed to exactly zero (for example when `q` is
+  // +inf, or `q` is so large that `pow(q, -x)` underflows), the Euler-Maclaurin
+  // correction degenerates: `correctionEulerMaclaurin = qNegPower * acc / (x-1)`
+  // becomes `0 * inf = NaN` for `q == +inf`, poisoning `accurateResult`. In
+  // that regime `powerSum` is already the answer, so fall back to it whenever
+  // `qNegPower == 0`. This mirrors the `if (b == 0) return s;` guard in Eigen's
+  // CPU Cephes implementation and fixes `Zeta(x, +inf)` returning NaN instead of
+  // 0 (https://github.com/tensorflow/tensorflow/issues/121501).
   Value absQNegPower = AbsOp::create(rewriter, loc, qNegPower);
   Value absPowerSum = AbsOp::create(rewriter, loc, powerSum);
-  Value output = SelectOp::create(
-      rewriter, loc,
+  Value qNegPowerIsZero =
+      CompareOp::create(rewriter, loc, qNegPower, zero, ComparisonDirection::EQ);
+  Value useSeries = mlir::stablehlo::OrOp::create(
+      rewriter, loc, qNegPowerIsZero,
       CompareOp::create(
           rewriter, loc, absQNegPower,
           MulOp::create(rewriter, loc, absPowerSum,
                         getConstantLikeSmallestFiniteValue(rewriter, loc, acc)),
-          ComparisonDirection::LT),
-      powerSum, accurateResult);
+          ComparisonDirection::LT));
+  Value output =
+      SelectOp::create(rewriter, loc, useSeries, powerSum, accurateResult);
 
   // Function is not defined for x < 1.
   Value nan = getConstantLike(rewriter, loc,


### PR DESCRIPTION
### Summary

Fixes tensorflow/tensorflow#121501 — `tf.math.zeta(s, +inf)` returns NaN on GPU instead of `0`.

ζ(s, q) = Σ_k (k+q)^-s → 0 as q → +∞ for s > 1, but `materializeZeta`'s Euler–Maclaurin expansion returns NaN: `correctionEulerMaclaurin = qNegPower * acc / (x - 1)` evaluates to `0 * inf = NaN` when `q == +inf` (`qNegPower` underflows to 0 while `acc` is `+inf`), and the "accurate enough" early-out `abs(qNegPower) < abs(powerSum) * smallest` is `false` when both `qNegPower` and `powerSum` are `0`, so the NaN `accurateResult` is selected instead of the partial sum `powerSum` (= 0).

This is the GPU code path for `tf.math.zeta`: the `mlir_generated` kernels lower `chlo.zeta` through this decomposition. The eager-CPU path uses Eigen's Cephes zeta, which already guards this with `if (b == 0) return s;` — which is exactly why the bug is GPU-only.

### Fix

Fall back to `powerSum` whenever `qNegPower == 0`, mirroring Eigen's guard. Normal inputs are unaffected. The CHLO→StableHLO FileCheck test is updated for the two added ops (`compare EQ` + `or`).

### Verification

A float32 simulation of the exact algorithm: `zeta(2, inf)` and `zeta(3, inf)` go `nan → 0.0`; `zeta(2, 1) = π²/6 = 1.644934`, `zeta(2, 5) = 0.2213230`, `zeta(4, 2.5) = 0.0373176` unchanged.

Note: I was unable to build MLIR/LLVM locally, so the FileCheck update is logic- and numerically-verified but not build-verified; please run `bazel test //stablehlo/tests:chlo_legalize_to_stablehlo` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)