### PR TITLE
Fix self-comparison in isSameQuantPerAxisScaleZeroPoint scale-count check

### DIFF
--- a/stablehlo/dialect/TypeInference.cpp
+++ b/stablehlo/dialect/TypeInference.cpp
@@ -236,7 +236,7 @@ bool isSameQuantPerAxisScaleZeroPoint(Type ty1, Type ty2) {
       dyn_cast<quant::UniformQuantizedPerAxisType>(getElementTypeOrSelf(ty2));
   if (!qty1 || !qty2) return false;
 
-  if (qty1.getScales().size() != qty1.getScales().size()) return false;
+  if (qty1.getScales().size() != qty2.getScales().size()) return false;
 
   for (auto [lhs, rhs] : llvm::zip(qty1.getScales(), qty2.getScales()))
     if (lhs != rhs) return false;


### PR DESCRIPTION
## What

`isSameQuantPerAxisScaleZeroPoint()` is meant to compare two per-axis quantized types, but its scale-count guard compares `qty1` to itself:

```cpp
if (qty1.getScales().size() != qty1.getScales().size()) return false;
```

This condition is always false, so the check is dead. The loops immediately below `llvm::zip` `qty1` and `qty2` over scales and zero-points, and `llvm::zip` truncates to the shorter range — so two `UniformQuantizedPerAxisType`s that differ only in their number of scales/zero-points are reported as "same".

This is reachable through `verifyQPerAxisScaleAndZeroPointConstraints` (used by e.g. reshape / dynamic_reshape `_c1`): a quantized type with a dynamic quantized dimension may legitimately carry an arbitrary number of scales (`isValidQuantizedDimension` allows `numScales != dimSize` when the quantized dimension is dynamic), so a reshape whose operand and result per-axis quant types share a common prefix of scales but differ in length passes the verifier when it should be rejected.

## Fix

Compare `qty2`, matching the `zip(qty1, qty2)` loops below and the function's intent:

```cpp
if (qty1.getScales().size() != qty2.getScales().size()) return false;
```

(A `UniformQuantizedPerAxisType`'s scale and zero-point arrays always have equal length, so the single size check on the scales suffices.)

## Testing

This is a one-token correctness fix verifiable by inspection. I was not able to build StableHLO locally (the from-source LLVM/MLIR build is impractical on my machine), so I have **not** run the lit suite. Happy to add a regression test — a `reshape` with a dynamic quantized dimension and mismatched scale counts, expecting the `expect same quantization scales and zero_points` error — or to adjust as preferred.
