### PR TITLE
Clean up LIT test syntax

### DIFF
--- a/stablehlo/tests/ops_chlo_roundtrip.mlir
+++ b/stablehlo/tests/ops_chlo_roundtrip.mlir
@@ -1,7 +1,7 @@
 // RUN: stablehlo-opt %s | FileCheck %s
 // RUN: stablehlo-opt -emit-bytecode %s | stablehlo-opt | FileCheck %s
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt -emit-bytecode -debug-only=chlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt -emit-bytecode %s | stablehlo-opt -debug-only=chlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt -emit-bytecode -debug-only=chlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt -emit-bytecode %s | stablehlo-opt -debug-only=chlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1,5 +1,5 @@
 // RUN: stablehlo-opt %s -verify-diagnostics -split-input-file -allow-unregistered-dialect | FileCheck %s
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt %s -verify-diagnostics -split-input-file -allow-unregistered-dialect -emit-bytecode -debug-only=stablehlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt %s -verify-diagnostics -split-input-file -allow-unregistered-dialect -emit-bytecode -debug-only=stablehlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/ops_stablehlo_roundtrip.mlir
+++ b/stablehlo/tests/ops_stablehlo_roundtrip.mlir
@@ -2,8 +2,8 @@
 // RUN: stablehlo-opt %s > %t.0
 // RUN: stablehlo-opt -emit-bytecode %s | stablehlo-opt > %t.1
 // RUN: diff %t.0 %t.1
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt -emit-bytecode -debug-only=stablehlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt -emit-bytecode %s | stablehlo-opt -debug-only=stablehlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt -emit-bytecode -debug-only=stablehlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt -emit-bytecode %s | stablehlo-opt -debug-only=stablehlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_10_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_10_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=0.10.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_11_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_11_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=0.11.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_12_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_12_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=0.12.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_13_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_13_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=0.13.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_14_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_14_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=0.14.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_15_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_15_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=0.15.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_16_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_16_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=0.16.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_17_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_17_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=0.17.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_18_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_18_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=0.18.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_19_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_19_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=0.19.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_20_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_20_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=0.20.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_9_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.0_9_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=0.9.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_0_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_0_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=1.0.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_10_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_10_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=1.10.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_11_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_11_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=1.11.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_12_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_12_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=1.12.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_13_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_13_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=1.13.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_14_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_14_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=1.14.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_15_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_15_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=1.15.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_16_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_16_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=1.16.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_18_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_18_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=1.18.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_1_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_1_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=1.1.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_2_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_2_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=1.2.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_3_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_3_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=1.3.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_4_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_4_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=1.4.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_5_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_5_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=1.5.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_6_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_6_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=1.6.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_7_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_7_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=1.7.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_8_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_8_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=1.8.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_9_0.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.1_9_0.mlir
@@ -5,8 +5,8 @@
 // RUN: diff %t.0 %t.1
 // RUN: stablehlo-translate --serialize --target=1.9.0 --strip-debuginfo %s > %t.2
 // RUN: diff %s.bc %t.2
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 

--- a/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.mlir
+++ b/stablehlo/tests/vhlo/stablehlo_legalize_to_vhlo.mlir
@@ -5,8 +5,8 @@
 // RUN: stablehlo-translate --serialize --target=current %s | stablehlo-opt --pass-pipeline='builtin.module(stablehlo-deserialize)' > %t.0
 // RUN: stablehlo-opt %s > %t.1
 // RUN: diff %t.0 %t.1
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
-// RUN: stablehlo-opt --help-hidden | grep -q "debug-only" && stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s || echo "Skip in release mode"
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode -debug-only=vhlo-bytecode %s 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
+// RUN: %if asserts %{ stablehlo-opt --stablehlo-legalize-to-vhlo -emit-bytecode %s | stablehlo-opt -debug-only=vhlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
 


### PR DESCRIPTION
Clean up syntax used for detecting the availability of assertions in StableHLO-to-VHLO legalization LIT tests.