### PR TITLE
reference/NumPy: decode .npy header size as unsigned

### DIFF
--- a/stablehlo/reference/NumPy.cpp
+++ b/stablehlo/reference/NumPy.cpp
@@ -220,7 +220,8 @@ static llvm::Error readNumpyHeader(std::ifstream& in, size_t& wordSize,
     return llvm::createStringError(llvm::errc::io_error,
                                    "Failed to read NumPy header size.");
 
-  const int headerSize = (headerSizeBuffer[0]) | (headerSizeBuffer[1] << 8);
+  const int headerSize = static_cast<unsigned char>(headerSizeBuffer[0]) |
+                         (static_cast<unsigned char>(headerSizeBuffer[1]) << 8);
   std::string header(headerSize, '\0');
   if (!in.read(header.data(), headerSize) || header.back() != '\n')
     return llvm::createStringError(llvm::errc::invalid_argument,


### PR DESCRIPTION
## Description

`reference/NumPy.cpp` reads the 2-byte little-endian `.npy` header length but decodes it with signed `char`:

```cpp
const int headerSize = (headerSizeBuffer[0]) | (headerSizeBuffer[1] << 8);
```

`char` is signed on common platforms, so a length byte ≥ `0x80` sign-extends and makes `headerSize` negative. The next line, `std::string header(headerSize, '\0');`, then constructs with a huge `size_t` and throws `std::length_error`, which is uncaught in the reference read path → `std::terminate`/abort.

This is reachable both by a self round-trip (a rank ≥ 17 tensor produces a >128-byte header) and by any real NumPy-written `.npy` (headers are padded to a 16-byte boundary and routinely exceed 128 bytes). The writer at `NumPy.cpp:108-109` correctly emits the length as a little-endian `uint16_t` (`static_cast<uint16_t>` + `& 0xff`), so the reader's signed decode is asymmetric.

## Fix

Decode the two bytes as `unsigned char`, mirroring the writer:

```cpp
const int headerSize = static_cast<unsigned char>(headerSizeBuffer[0]) |
                       (static_cast<unsigned char>(headerSizeBuffer[1]) << 8);
```

## Testing

I don't have a local StableHLO/Bazel build, but reproduced the decode + throw with a standalone harness using bytes `{0x83, 0x00}` (a 131-byte header):

```
decoded headerSize: buggy=-125  fixed=131  (true value 131)
buggy std::string THREW: basic_string::_M_create   # std::length_error, uncaught -> abort
fixed std::string ok, size=131
```

Happy to add a lit/unit test if you can point me at the preferred harness for `reference/`.
