### PR TITLE
reference/NumPy: harden .npy header parsing against malformed input

### DIFF
--- a/stablehlo/reference/NumPy.cpp
+++ b/stablehlo/reference/NumPy.cpp
@@ -29,6 +29,7 @@ limitations under the License.
 #include <type_traits>
 #include <vector>
 
+#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/bit.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/Error.h"
@@ -152,7 +153,8 @@ static llvm::ErrorOr<int> parseDescrHeader(const std::string& header) {
   std::string typeString = header.substr(
       descrOffset + kDescrSize, needleSize - (descrOffset + kDescrSize));
 
-  if (typeString.front() != '\'' || typeString.back() != '\'')
+  if (typeString.size() < 2 || typeString.front() != '\'' ||
+      typeString.back() != '\'')
     return llvm::errc::invalid_argument;
 
   // Strip quotes from type string (i.e. '<i8' to <i8).
@@ -163,7 +165,10 @@ static llvm::ErrorOr<int> parseDescrHeader(const std::string& header) {
   // Check that the serialized type string matches the expected type string.
   if (getNumPyType<T>() != typeString[1]) return llvm::errc::invalid_argument;
 
-  return std::stoi(typeString.substr(2));
+  int typeSize;
+  if (llvm::StringRef(typeString).substr(2).getAsInteger(/*Radix=*/10, typeSize))
+    return llvm::errc::invalid_argument;
+  return typeSize;
 }
 
 // Parses the `shape` key of the NumPy file format dictionary. Returns a vector
@@ -181,7 +186,7 @@ static llvm::ErrorOr<ArrayRef<int64_t>> parseShapeHeader(
   // regex matching for dimension integrals.
   std::regex dimRegex("[0-9]+");
   std::smatch dimMatch;
-  std::string shapeString = header.substr(shapeOffset, shapeOffset - dimEnd);
+  std::string shapeString = header.substr(shapeOffset, dimEnd - shapeOffset);
   std::vector<int64_t> shape(4);
 
   while (std::regex_search(shapeString, dimMatch, dimRegex)) {

--- a/stablehlo/reference/NumPy.cpp
+++ b/stablehlo/reference/NumPy.cpp
@@ -166,7 +166,9 @@ static llvm::ErrorOr<int> parseDescrHeader(const std::string& header) {
   if (getNumPyType<T>() != typeString[1]) return llvm::errc::invalid_argument;
 
   int typeSize;
-  if (llvm::StringRef(typeString).substr(2).getAsInteger(/*Radix=*/10, typeSize))
+  if (llvm::StringRef(typeString)
+          .substr(2)
+          .getAsInteger(/*Radix=*/10, typeSize))
     return llvm::errc::invalid_argument;
   return typeSize;
 }


### PR DESCRIPTION
## Description

Hardening `reference/NumPy.cpp` against malformed `.npy` headers (reachable via `stablehlo-translate --interpret` on a crafted or foreign `.npy`), in the same spirit as #2962:

1. **Uncaught `std::stoi` → abort (DoS).** `parseDescrHeader` ends with `return std::stoi(typeString.substr(2));`. `std::stoi` throws `std::invalid_argument` on a non-numeric size (e.g. a header `'descr': '<ixy'`); nothing catches it, so the interpreter terminates:
   ```
   terminate called after throwing an instance of 'std::invalid_argument'
     what():  stoi
   Aborted (core dumped)
   ```
   Replaced with `llvm::StringRef::getAsInteger`, returning `errc::invalid_argument`.

2. **`front()`/`back()` before the length check.** `typeString.front()`/`.back()` are read before any size guard; a header whose `descr` value is empty makes these a precondition violation. Guard `typeString.size() < 2` first (the existing `< 3` check comes afterward).

3. **`substr` length underflow in `parseShapeHeader`.** `header.substr(shapeOffset, shapeOffset - dimEnd)` — since `dimEnd > shapeOffset`, the length underflows `size_t` to a huge value, so the shape regex scans the whole remaining header instead of just the shape tuple (defeating the intended "tight bound" noted in the comment). Corrected to `dimEnd - shapeOffset`.

## Testing

I don't have a local StableHLO/Bazel build. The abort in (1) is demonstrated with a standalone repro (uncaught `std::stoi` on a non-numeric string aborts, as above); (2) and (3) are straightforward. Happy to add a lit/unit test for `reference/` if you can point me at the preferred harness.
