### PR TITLE
reference: use the batched diagonal index in triangular_solve

### DIFF
--- a/stablehlo/reference/Ops.cpp
+++ b/stablehlo/reference/Ops.cpp
@@ -2773,7 +2773,7 @@ Tensor triangularSolveOp(const Tensor& A, const Tensor& b, bool leftSide,
           x = x - a * xj;
         }
         if (!unitDiagonal) {
-          auto a = tA.get(Index{i, i});
+          auto a = tA.get(a_index(batchIndex, i, i));
           x = x / a;
         }
 


### PR DESCRIPTION
### Problem
The reference interpreter aborts on any **batched** `triangular_solve` (rank > 2) with `unit_diagonal = false`.

### Root cause
In `reference/Ops.cpp`, `triangularSolveOp` fetches the diagonal element `A[i, i]` in the non-unit-diagonal branch with a hard-coded rank-2 index:
```cpp
if (!unitDiagonal) {
  auto a = tA.get(Index{i, i});   // wrong: size-2 index into a rank>2 tensor
  x = x / a;
}
```
`tA` has rank `A.getRank()`. For a batched input (rank > 2), `Index{i, i}` has the wrong size (2) and ignores the batch dimensions, so `Tensor::get` → `flattenIndex` fails `Sizes::inBounds` (`size() != bounds.size()`) and calls `report_fatal_error("Incompatible index and shape found while flattening index")`. The off-diagonal access one line above already uses the correct `a_index(batchIndex, i, j)`. `Index{i, i}` coincides with the right index only for the rank-2 unbatched case, which is why the existing (non-batched) tests pass.

### Fix
Use `a_index(batchIndex, i, i)`, matching the off-diagonal access.

### Verification
Static reasoning from the `inBounds` size-mismatch guard; a batched input such as `a: tensor<2x3x3>, b: tensor<2x3x4>, unit_diagonal=false` deterministically hits it. (No local MLIR/stablehlo build set up — happy to add an interpreter test with a rank-3 `triangular_solve`.)
