### PR TITLE
Fix out-of-bounds insert in ScanOp shape inference

### DIFF
--- a/stablehlo/dialect/ChloOps.cpp
+++ b/stablehlo/dialect/ChloOps.cpp
@@ -850,6 +850,14 @@ LogicalResult ScanOp::inferReturnTypeComponents(
     SmallVector<int64_t> shape(resultType.getShape().begin(),
                                resultType.getShape().end());
     if (i < numOutputs) {
+      // `dim` is validated only against the input ranks above (and not at all
+      // when there are no inputs), so guard the insert position against the
+      // output element rank to avoid an out-of-bounds insert.
+      if (dim > static_cast<int64_t>(shape.size())) {
+        return emitOptionalError(
+            location, "scan dimension is out of bounds for terminator operand ",
+            i);
+      }
       shape.insert(std::next(shape.begin(), dim), dimSize);
     }
     inferredReturnShapes.emplace_back(shape, resultType.getElementType());


### PR DESCRIPTION
### Problem
`ScanOp::inferReturnTypeComponents` (CHLO) can perform an out-of-bounds vector insert when the scan `dimension` exceeds the rank of a terminator (output) operand, crashing during verification.

### Root cause
```cpp
SmallVector<int64_t> shape(resultType.getShape().begin(),
                           resultType.getShape().end());
if (i < numOutputs) {
  shape.insert(std::next(shape.begin(), dim), dimSize);   // dim can exceed shape.size()
}
```
`dim = adaptor.getDimension()` is validated only against the **input** ranks (in the `inputs` loop: `if (dim >= inputType.getRank()) …`). It is never checked against `shape.size()`, the **output** element rank used here. Two ways this is reachable from parseable IR that clears `ScanOp::verify()` (which only checks input ranks and requires at least one of inputs/outputs):
- **Empty inputs** + non-empty outputs: the input loop never runs, so `dim` is entirely unvalidated.
- **Non-empty inputs** where a terminator/output operand has rank `< dim` (input rank can be `> dim` while an output body result is lower-rank).

When `dim > shape.size()`, `std::next(shape.begin(), dim)` is past `end()`, and `SmallVectorImpl::insert` at a position beyond `end()` is an out-of-bounds insert (assertion failure in asserts builds, memory corruption in release). `dim >= 0` is guaranteed by ODS, so only the upper bound is unguarded.

### Fix
Bounds-check `dim` against the output element rank before the insert (valid positions are `[0, shape.size()]`, where `dim == size` appends the scan axis at the end), emitting a clean diagnostic instead of the OOB insert. Matches the sibling `emitOptionalError` calls in the same function.

### Testing
Verified by static reasoning (no local build here). The existing `chlo.scan` tests in `tests/ops_chlo.mlir` are all equal-input/output-rank; happy to add a negative test (rank-reduced output body or empty-inputs form) that reaches this path if you'd like — it needs a custom scan body region so I left it out of this minimal fix rather than guess the IR without a build.
