### PR TITLE
Guard against integer division-by-zero in stablehlo transforms

### DIFF
--- a/stablehlo/tests/transforms/stablehlo_aggressive_folder.mlir
+++ b/stablehlo/tests/transforms/stablehlo_aggressive_folder.mlir
@@ -666,6 +666,39 @@ func.func @div_fold_cst_nan() -> (tensor<f32>) {
 
 // -----
 
+// Integer division by a zero constant must not be folded (it would crash the
+// folder with a divide-by-zero); the op is left in place.
+// CHECK-LABEL: @div_no_fold_int_zero
+func.func @div_no_fold_int_zero() -> (tensor<i32>, tensor<ui32>) {
+  %cst = stablehlo.constant dense<6> : tensor<i32>
+  %cst_0 = stablehlo.constant dense<0> : tensor<i32>
+  %cst_u = stablehlo.constant dense<6> : tensor<ui32>
+  %cst_u0 = stablehlo.constant dense<0> : tensor<ui32>
+  // CHECK: stablehlo.divide
+  // CHECK: stablehlo.divide
+  %0 = stablehlo.divide %cst, %cst_0 : tensor<i32>
+  %1 = stablehlo.divide %cst_u, %cst_u0 : tensor<ui32>
+  return %0, %1 : tensor<i32>, tensor<ui32>
+}
+
+// -----
+
+// Integer remainder by a zero constant must not be folded.
+// CHECK-LABEL: @rem_no_fold_int_zero
+func.func @rem_no_fold_int_zero() -> (tensor<i32>, tensor<ui32>) {
+  %cst = stablehlo.constant dense<6> : tensor<i32>
+  %cst_0 = stablehlo.constant dense<0> : tensor<i32>
+  %cst_u = stablehlo.constant dense<6> : tensor<ui32>
+  %cst_u0 = stablehlo.constant dense<0> : tensor<ui32>
+  // CHECK: stablehlo.remainder
+  // CHECK: stablehlo.remainder
+  %0 = stablehlo.remainder %cst, %cst_0 : tensor<i32>
+  %1 = stablehlo.remainder %cst_u, %cst_u0 : tensor<ui32>
+  return %0, %1 : tensor<i32>, tensor<ui32>
+}
+
+// -----
+
 ////////
 // MaximumOp
 

--- a/stablehlo/tests/transforms/stablehlo_refine_shapes.mlir
+++ b/stablehlo/tests/transforms/stablehlo_refine_shapes.mlir
@@ -1126,6 +1126,25 @@ func.func @refine_reduce_scatter_cross_replica(%data: tensor<4x16xf32>) -> tenso
 
 // -----
 
+// An empty replica_groups (zero shard count) must not crash the reduce_scatter
+// shape refinement with a divide-by-zero; the result is left unrefined.
+// CHECK-LABEL: @refine_reduce_scatter_empty_replica_groups
+func.func @refine_reduce_scatter_empty_replica_groups(%data: tensor<4x16xf32>) -> tensor<4x?xf32> {
+  // CHECK: "stablehlo.reduce_scatter"{{.*}}
+  // CHECK: -> tensor<4x?xf32>
+  %0 = "stablehlo.reduce_scatter"(%data) ({
+  ^bb0(%arg2: tensor<f32>, %arg3: tensor<f32>):
+    %1 = stablehlo.add %arg2, %arg3 : tensor<f32>
+    stablehlo.return %1 : tensor<f32>
+  }) {
+    replica_groups = dense<0> : tensor<1x0xi64>,
+    scatter_dimension = 1 : i64
+  } : (tensor<4x16xf32>) -> tensor<4x?xf32>
+  func.return %0 : tensor<4x?xf32>
+}
+
+// -----
+
 // CHECK-LABEL: @refine_reduce_scatter_cross_replica_and_partition
 func.func @refine_reduce_scatter_cross_replica_and_partition(%data: tensor<4x16xf32>) -> tensor<4x?xf32> {
   // CHECK: "stablehlo.reduce_scatter"{{.*}}

--- a/stablehlo/transforms/StablehloRefineShapes.cpp
+++ b/stablehlo/transforms/StablehloRefineShapes.cpp
@@ -923,6 +923,12 @@ struct RefineReduceScatterOpPattern : public OpRewritePattern<ReduceScatterOp> {
       shardCount = (*flattenedGroupsOr)[0].size();
     }
 
+    // A zero shard count (e.g. an empty-column dense replica_groups) would make
+    // the division below a divide-by-zero; the mesh-axes branch already guards
+    // its empty case above.
+    if (shardCount == 0)
+      return rewriter.notifyMatchFailure(op, "zero shard count");
+
     SmallVector<int64_t> refinement(operandType.getShape());
     if (!operandType.isDynamicDim(op.getScatterDimension()))
       refinement[op.getScatterDimension()] /= shardCount;

--- a/stablehlo/transforms/optimization/StablehloAggressiveFolder.cpp
+++ b/stablehlo/transforms/optimization/StablehloAggressiveFolder.cpp
@@ -1000,6 +1000,20 @@ struct FoldConvertOpPattern : public ShapeOpRewritePattern<ConvertOp> {
   }
 };
 
+// Returns true if the divisor (second operand) of `op` is a constant integer
+// tensor with any zero element. Integer udiv/sdiv/urem/srem by zero would crash
+// the constant folder (APInt asserts in debug, SIGFPE in release), so such ops
+// must not be folded.
+static bool integerDivisorHasZeroElement(Operation* op) {
+  TypedAttr rhsAttr;
+  matchPattern(op->getOperand(1), m_Constant(&rhsAttr));
+  auto denseRhs = dyn_cast_or_null<DenseIntElementsAttr>(rhsAttr);
+  if (!denseRhs) return false;
+  for (const APInt& value : denseRhs.getValues<APInt>())
+    if (value.isZero()) return true;
+  return false;
+}
+
 struct FoldDivOpPattern : public ShapeOpRewritePattern<DivOp> {
   using ShapeOpRewritePattern::ShapeOpRewritePattern;
 
@@ -1008,6 +1022,10 @@ struct FoldDivOpPattern : public ShapeOpRewritePattern<DivOp> {
     auto resultType = op.getType();
     if (failed(validateShapeFoldDtype(rewriter, op, resultType)))
       return failure();
+
+    if (isa<IntegerType>(resultType.getElementType()) &&
+        integerDivisorHasZeroElement(op))
+      return rewriter.notifyMatchFailure(op, "integer division by zero");
 
     bool isUnsignedInt = resultType.getElementType().isUnsignedInteger();
     auto res = foldBinaryOpIntOrFloat(rewriter, op, FoldDivide(isUnsignedInt));
@@ -1224,6 +1242,10 @@ struct FoldRemOpPattern : public ShapeOpRewritePattern<RemOp> {
     auto resultType = op.getType();
     if (failed(validateShapeFoldDtype(rewriter, op, resultType)))
       return failure();
+
+    if (isa<IntegerType>(resultType.getElementType()) &&
+        integerDivisorHasZeroElement(op))
+      return rewriter.notifyMatchFailure(op, "integer remainder by zero");
 
     bool isUnsignedInt = resultType.getElementType().isUnsignedInteger();
     auto res = foldBinaryOpIntOrFloat(rewriter, op, FoldRem(isUnsignedInt));


### PR DESCRIPTION
### Problem
Three transforms crash the compiler with an integer divide-by-zero on verifier-valid IR:
1. `RefineReduceScatterOpPattern` divides the scatter dimension by the shard count without checking it is nonzero — an empty-column `replica_groups` (shard count 0) crashes the shape-refinement pass.
2. `FoldDivOpPattern` folds `stablehlo.divide` on integer constants via `APInt::udiv/sdiv` with no zero-divisor guard — `divide(x, 0)` crashes the folder.
3. `FoldRemOpPattern` has the identical issue via `APInt::urem/srem`.

### Details
- **reduce_scatter refinement** (`StablehloRefineShapes.cpp`): `shardCount` comes from `denseGroups.getType().getDimSize(1)` (the `replica_groups` column count), which is 0 for `tensor<Nx0xi64>`. `verifyReplicaGroups` only rejects an empty `replica_groups` when `use_global_device_ids` is set, so a `reduce_scatter` with no `channel_handle`, `use_global_device_ids = false`, and `replica_groups = dense<0> : tensor<1x0xi64>` verifies, and then `refinement[scatterDim] /= 0` is a SIGFPE. The sibling mesh-axes branch already guards its empty case.
- **divide/remainder folders** (`StablehloAggressiveFolder.cpp`): the folders apply `APInt::udiv/sdiv/urem/srem` element-wise with no zero-divisor check; `APInt` asserts in debug and executes a hardware divide-by-zero (SIGFPE) in release. `stablehlo.divide %a, %z` / `stablehlo.remainder %a, %z` with `%z = dense<0>` integer constant is verifier-valid and crashes the folder. (Upstream `arith::DivSIOp::fold` guards the same case.)

### Fix
- reduce_scatter: bail (`notifyMatchFailure`) when the shard count is 0.
- folders: decline to fold when the integer divisor constant has any zero element (a shared `integerDivisorHasZeroElement` helper), leaving the op in place. The float path is unaffected (division by zero yields inf/nan).

### Tests
Added lit tests: `@div_no_fold_int_zero` / `@rem_no_fold_int_zero` (integer divide/remainder by a zero constant is not folded) and `@refine_reduce_scatter_empty_replica_groups` (empty `replica_groups` leaves the result unrefined). Each previously crashed the pass.

---
Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
