### PR TITLE
Guard readTensorV1Attr against a non-shaped deserialized type

### DIFF
--- a/stablehlo/dialect/VhloBytecode.cpp
+++ b/stablehlo/dialect/VhloBytecode.cpp
@@ -1093,7 +1093,11 @@ TensorV1Attr VhloBytecodeInterface::readTensorV1Attr(
   };
 
   VhloToBuiltinPrintConverter conv;
-  auto builtinType = cast<ShapedType>(conv.convertType(type));
+  // The type is read from the (possibly crafted) bytecode and is not required
+  // to be shaped, so guard the cast: a non-shaped type (e.g. a scalar) would
+  // otherwise crash here / feed a non-shaped type to getFromRawBuffer.
+  auto builtinType = dyn_cast<ShapedType>(conv.convertType(type));
+  if (!builtinType) return TensorV1Attr();
   return TensorV1Attr::get(
       getContext(), type,
       DenseElementsAttr::getFromRawBuffer(builtinType, blob));


### PR DESCRIPTION
### Problem
`VhloBytecodeInterface::readTensorV1Attr` reads a type from the bytecode and unconditionally `cast<ShapedType>`s the converted builtin type. A crafted `TensorV1Attr` whose type field encodes a non-shaped VHLO type (e.g. a scalar `FloatF32V1Type`) crashes the reader.

### Details
```cpp
Type type;
... reader.readType(type) ...            // attacker-controlled: any VHLO type
auto builtinType = cast<ShapedType>(conv.convertType(type));
return TensorV1Attr::get(..., DenseElementsAttr::getFromRawBuffer(builtinType, blob));
```
`readType` returns whatever type code the bytecode supplies, including scalar/function/token types. `readVhloTensorV1Attr` does not require a shaped type on the non-boolean path (it just copies the blob). `conv.convertType` maps a scalar VHLO type to a non-null but non-`ShapedType` builtin type (e.g. `Float32Type`), so `cast<ShapedType>` fails: it asserts in debug builds, and in release it yields a `ShapedType` over the wrong storage that `getFromRawBuffer` then dereferences. The write side only ever emits shaped types, so valid round-trips are unaffected — only crafted/corrupt artifacts loaded via `deserializePortableArtifact` reach it.

### Fix
Use `dyn_cast<ShapedType>` and return an empty `TensorV1Attr()` (the reader's existing error convention, already used a few lines above) when the type is not shaped, so a malformed artifact is rejected rather than crashing the reader.

### Testing
Static reasoning only (no local build). This triggers only on hand-crafted/corrupt bytecode — the writer never emits a non-shaped `TensorV1Attr` type, so a normal round-trip test can't reach it, and crafting a malformed `.mlirbc` for a lit test isn't practical. The fix mirrors the null-return convention already used for read failures in this function.

---
Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
