### PR TITLE
Support loading interpreter arguments from a file in stablehlo-translate

### DIFF
--- a/stablehlo/reference/NumPy.cpp
+++ b/stablehlo/reference/NumPy.cpp
@@ -27,6 +27,7 @@ limitations under the License.
 #include <sstream>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "llvm/ADT/bit.h"
@@ -134,14 +135,14 @@ static llvm::Error parseFortranOrderKey(const std::string& header) {
 
 // Parses the NumPy `descr` header, which is in the following format:
 // 'descr': '<i4'
-// Where the first character determines the endianness of the data (< for little
-// endian, > for big endian), the next character determines the data type (i.e.
-// unsigned int, float, bool, etc) and the last number(s) determine the data
-// type size (8, 16, 32, etc). For now, we only support little endian values.
-// Returns the size of the underlying type in bytes (i.e. for '<i4', this will
-// return 4).
-template <typename T>
-static llvm::ErrorOr<int> parseDescrHeader(const std::string& header) {
+// Where the first character determines the endianness of the data (< for
+// little endian, > for big endian, | for not applicable), the next character
+// determines the data type (i.e. unsigned int, float, bool, etc) and the last
+// number(s) determine the data type size (8, 16, 32, etc). For now, we only
+// support little endian values. Returns the type abbreviation and the size of
+// the underlying type in bytes (i.e. for '<i4', this will return ('i', 4)).
+static llvm::ErrorOr<std::pair<char, int>> parseDescr(
+    const std::string& header) {
   constexpr char kDescr[] = "'descr':";
   constexpr int kDescrSize = 8;
 
@@ -160,15 +161,31 @@ static llvm::ErrorOr<int> parseDescrHeader(const std::string& header) {
 
   if (typeString.size() < 3) return llvm::errc::invalid_argument;
 
-  // Check that the serialized type string matches the expected type string.
-  if (getNumPyType<T>() != typeString[1]) return llvm::errc::invalid_argument;
+  if (typeString[0] == '>') return llvm::errc::not_supported;
 
-  return std::stoi(typeString.substr(2));
+  if (!std::isdigit(static_cast<unsigned char>(typeString[2])))
+    return llvm::errc::invalid_argument;
+
+  return std::make_pair(typeString[1], std::stoi(typeString.substr(2)));
+}
+
+// Parses the `descr` key like `parseDescr`, additionally checking that the
+// serialized type abbreviation matches the expected type T. Returns the size
+// of the underlying type in bytes.
+template <typename T>
+static llvm::ErrorOr<int> parseDescrHeader(const std::string& header) {
+  auto descr = parseDescr(header);
+  if (!descr) return descr.getError();
+
+  // Check that the serialized type string matches the expected type string.
+  if (getNumPyType<T>() != descr->first) return llvm::errc::invalid_argument;
+
+  return descr->second;
 }
 
 // Parses the `shape` key of the NumPy file format dictionary. Returns a vector
 // representing the parsed shape or errors otherwise.
-static llvm::ErrorOr<ArrayRef<int64_t>> parseShapeHeader(
+static llvm::ErrorOr<std::vector<int64_t>> parseShapeHeader(
     const std::string& header) {
   const std::size_t shapeOffset = header.find("'shape':");
   const std::size_t dimEnd = header.find(')', shapeOffset);
@@ -181,20 +198,20 @@ static llvm::ErrorOr<ArrayRef<int64_t>> parseShapeHeader(
   // regex matching for dimension integrals.
   std::regex dimRegex("[0-9]+");
   std::smatch dimMatch;
-  std::string shapeString = header.substr(shapeOffset, shapeOffset - dimEnd);
-  std::vector<int64_t> shape(4);
+  std::string shapeString = header.substr(shapeOffset, dimEnd - shapeOffset);
+  std::vector<int64_t> shape;
 
   while (std::regex_search(shapeString, dimMatch, dimRegex)) {
-    shape.push_back(std::stoi(dimMatch[0]));
+    shape.push_back(std::stoll(dimMatch[0]));
     shapeString = dimMatch.suffix();
   }
 
   return shape;
 }
 
-template <typename T>
-static llvm::Error readNumpyHeader(std::ifstream& in, size_t& wordSize,
-                                   ArrayRef<int64_t> shape) {
+// Reads the NumPy header preamble (magic string, version, header size),
+// returning the header dictionary with whitespace removed.
+static llvm::Error readHeaderString(std::ifstream& in, std::string& header) {
   char magicString[kMagicStringSize];
   if (!in.read(magicString, kMagicStringSize))
     return llvm::createStringError(llvm::errc::io_error,
@@ -220,15 +237,26 @@ static llvm::Error readNumpyHeader(std::ifstream& in, size_t& wordSize,
     return llvm::createStringError(llvm::errc::io_error,
                                    "Failed to read NumPy header size.");
 
-  const int headerSize = (headerSizeBuffer[0]) | (headerSizeBuffer[1] << 8);
-  std::string header(headerSize, '\0');
-  if (!in.read(header.data(), headerSize) || header.back() != '\n')
+  const int headerSize = static_cast<unsigned char>(headerSizeBuffer[0]) |
+                         (static_cast<unsigned char>(headerSizeBuffer[1]) << 8);
+  header.assign(headerSize, '\0');
+  if (!headerSize || !in.read(header.data(), headerSize) ||
+      header.back() != '\n')
     return llvm::createStringError(llvm::errc::invalid_argument,
                                    "Invalid NumPy header.");
 
   header.erase(std::remove_if(header.begin(), header.end(),
                               [](char c) { return std::isspace(c); }),
                header.end());
+
+  return llvm::Error::success();
+}
+
+template <typename T>
+static llvm::Error readNumpyHeader(std::ifstream& in, size_t& wordSize,
+                                   std::vector<int64_t>& shape) {
+  std::string header;
+  if (auto headerError = readHeaderString(in, header)) return headerError;
 
   auto wordSizeOrError = parseDescrHeader<T>(header);
   if (!wordSizeOrError)
@@ -278,8 +306,12 @@ class FromNumpy {
   llvm::ErrorOr<Tensor> operator()(StringRef filename, ShapedType type) {
     std::ifstream in(filename.str(), std::ifstream::binary);
     size_t wordSize = 0;
+    std::vector<int64_t> fileShape;
 
-    if (readNumpyHeader<T>(in, wordSize, type.getShape()))
+    if (readNumpyHeader<T>(in, wordSize, fileShape))
+      return llvm::errc::invalid_argument;
+
+    if (ArrayRef<int64_t>(fileShape) != type.getShape())
       return llvm::errc::invalid_argument;
 
     const int64_t numLoadedElements = std::accumulate(
@@ -313,9 +345,9 @@ static decltype(auto) dispatchType(Type type, Args&&... args) {
   if (type.isInteger(32))
     return Functor<uint32_t>()(std::forward<Args>(args)...);
   if (type.isSignlessInteger(64))
-    return Functor<uint64_t>()(std::forward<Args>(args)...);
-  if (type.isInteger(64))
     return Functor<int64_t>()(std::forward<Args>(args)...);
+  if (type.isInteger(64))
+    return Functor<uint64_t>()(std::forward<Args>(args)...);
   if (type.isF16()) return Functor<uint16_t>()(std::forward<Args>(args)...);
   if (type.isF32()) return Functor<float>()(std::forward<Args>(args)...);
   if (type.isF64()) return Functor<double>()(std::forward<Args>(args)...);
@@ -346,6 +378,48 @@ llvm::ErrorOr<Tensor> deserializeTensor(StringRef filename, ShapedType type) {
     llvm::report_fatal_error("Only little endian supported.");
 
   return dispatchType<FromNumpy>(type.getElementType(), filename, type);
+}
+
+// Maps a NumPy `descr` dtype (type abbreviation and size in bytes) to the
+// corresponding MLIR element type. Returns null for unsupported dtypes.
+// Types without a native NumPy representation (bool, f16, bf16, complex) are
+// serialized by `serializeTensor` under a substitute descr and cannot be
+// unambiguously inferred, so they are intentionally left out.
+static Type inferElementType(char numpyType, int wordSize,
+                             MLIRContext* context) {
+  const bool isValidIntSize =
+      wordSize == 1 || wordSize == 2 || wordSize == 4 || wordSize == 8;
+  if (numpyType == 'i' && isValidIntSize)
+    return IntegerType::get(context, wordSize * 8);
+  if (numpyType == 'u' && isValidIntSize)
+    return IntegerType::get(context, wordSize * 8, IntegerType::Unsigned);
+  if (numpyType == 'f' && wordSize == 4) return Float32Type::get(context);
+  if (numpyType == 'f' && wordSize == 8) return Float64Type::get(context);
+  return {};
+}
+
+llvm::ErrorOr<Tensor> deserializeTensor(StringRef filename,
+                                        MLIRContext* context) {
+  if (llvm::endianness::native == llvm::endianness::big)
+    llvm::report_fatal_error("Only little endian supported.");
+
+  std::ifstream in(filename.str(), std::ifstream::binary);
+  if (!in) return llvm::errc::no_such_file_or_directory;
+
+  std::string header;
+  if (readHeaderString(in, header)) return llvm::errc::invalid_argument;
+
+  auto descr = parseDescr(header);
+  if (!descr) return descr.getError();
+
+  auto shape = parseShapeHeader(header);
+  if (!shape) return shape.getError();
+
+  auto elementType = inferElementType(descr->first, descr->second, context);
+  if (!elementType) return llvm::errc::not_supported;
+
+  return deserializeTensor(filename,
+                           RankedTensorType::get(*shape, elementType));
 }
 
 llvm::Error serializeTensor(StringRef filename, ShapedType type,

--- a/stablehlo/reference/NumPy.h
+++ b/stablehlo/reference/NumPy.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include "llvm/Support/ErrorOr.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/MLIRContext.h"
 #include "stablehlo/reference/Tensor.h"
 
 namespace mlir {
@@ -31,6 +32,13 @@ constexpr char kInstrumentationMetadataFilename[] = "index.csv";
 // Read a NumPy serialized tensor from disk stored at `filename` with the given
 // `type`.
 llvm::ErrorOr<Tensor> deserializeTensor(StringRef filename, ShapedType type);
+
+// Read a NumPy serialized tensor from disk stored at `filename`, inferring the
+// tensor type from the file's header. Supports little-endian integer and
+// f32/f64 dtypes; types without a native NumPy representation (bool, f16,
+// bf16, complex) cannot be unambiguously inferred and are not supported.
+llvm::ErrorOr<Tensor> deserializeTensor(StringRef filename,
+                                        MLIRContext* context);
 
 // Store a tensor using the NumPy file format with the given `type` to the given
 // `filename`.

--- a/stablehlo/tests/interpret/api_input_arguments.mlir
+++ b/stablehlo/tests/interpret/api_input_arguments.mlir
@@ -1,10 +1,16 @@
 // RUN: stablehlo-translate %s --interpret --args="[dense<1> : tensor<2xi32>, dense<2> : tensor<2xi32>]" | FileCheck %s
 
+// RUN: echo "[dense<1> : tensor<2xi32>, dense<2> : tensor<2xi32>]" > %t.args
+// RUN: stablehlo-translate %s --interpret --args=@%t.args | FileCheck %s
+
 // RUN: not stablehlo-translate %s --interpret --args="not_array" 2>&1 | FileCheck %s --check-prefixes=CHECK-ERROR-NOT-ARRAY
-// CHECK-ERROR-NOT-ARRAY: expectected array attribute string for args, i.e. --args=[dense<1> : tensor<2xi32>, ...]
+// CHECK-ERROR-NOT-ARRAY: expectected array attribute string for args, i.e. --args=[dense<1> : tensor<2xi32>, ...] or --args=@file
 
 // RUN: not stablehlo-translate %s --interpret --args="[4.0 : f32]" 2>&1 | FileCheck %s --check-prefixes=CHECK-ERROR-NOT-DENSE
-// CHECK-ERROR-NOT-DENSE: expected dense elements attribute for args elements, i.e. --args=[dense<1> : tensor<2xi32>, ...]
+// CHECK-ERROR-NOT-DENSE: expected dense elements attribute for args elements, i.e. --args=[dense<1> : tensor<2xi32>, ...] or --args=@file
+
+// RUN: not stablehlo-translate %s --interpret --args=@%t.does_not_exist 2>&1 | FileCheck %s --check-prefixes=CHECK-ERROR-NO-FILE
+// CHECK-ERROR-NO-FILE: failed to read args file
 
 func.func @main(%arg0: tensor<2xi32>, %arg1: tensor<2xi32>) -> tensor<2xi32> {
   %0 = stablehlo.add %arg0, %arg1 : tensor<2xi32>

--- a/stablehlo/tests/interpret/api_input_arguments.mlir
+++ b/stablehlo/tests/interpret/api_input_arguments.mlir
@@ -1,16 +1,10 @@
 // RUN: stablehlo-translate %s --interpret --args="[dense<1> : tensor<2xi32>, dense<2> : tensor<2xi32>]" | FileCheck %s
 
-// RUN: echo "[dense<1> : tensor<2xi32>, dense<2> : tensor<2xi32>]" > %t.args
-// RUN: stablehlo-translate %s --interpret --args=@%t.args | FileCheck %s
-
 // RUN: not stablehlo-translate %s --interpret --args="not_array" 2>&1 | FileCheck %s --check-prefixes=CHECK-ERROR-NOT-ARRAY
-// CHECK-ERROR-NOT-ARRAY: expectected array attribute string for args, i.e. --args=[dense<1> : tensor<2xi32>, ...] or --args=@file
+// CHECK-ERROR-NOT-ARRAY: expectected array attribute string for args, i.e. --args=[dense<1> : tensor<2xi32>, ...]
 
 // RUN: not stablehlo-translate %s --interpret --args="[4.0 : f32]" 2>&1 | FileCheck %s --check-prefixes=CHECK-ERROR-NOT-DENSE
-// CHECK-ERROR-NOT-DENSE: expected dense elements attribute for args elements, i.e. --args=[dense<1> : tensor<2xi32>, ...] or --args=@file
-
-// RUN: not stablehlo-translate %s --interpret --args=@%t.does_not_exist 2>&1 | FileCheck %s --check-prefixes=CHECK-ERROR-NO-FILE
-// CHECK-ERROR-NO-FILE: failed to read args file
+// CHECK-ERROR-NOT-DENSE: expected dense elements attribute for args elements, i.e. --args=[dense<1> : tensor<2xi32>, ...]
 
 func.func @main(%arg0: tensor<2xi32>, %arg1: tensor<2xi32>) -> tensor<2xi32> {
   %0 = stablehlo.add %arg0, %arg1 : tensor<2xi32>

--- a/stablehlo/tests/interpret/api_input_arguments_from_file.mlir
+++ b/stablehlo/tests/interpret/api_input_arguments_from_file.mlir
@@ -1,0 +1,17 @@
+// RUN: echo "[dense<1> : tensor<2xi32>, dense<2> : tensor<2xi32>]" > %t.args
+// RUN: stablehlo-translate %s --interpret --args=@%t.args | FileCheck %s
+
+// RUN: not stablehlo-translate %s --interpret --args=@%t.does_not_exist 2>&1 | FileCheck %s --check-prefixes=CHECK-ERROR-NO-FILE
+// CHECK-ERROR-NO-FILE: failed to read args file
+
+// RUN: not stablehlo-translate %s --interpret --args=@%t.args,@%t.args 2>&1 | FileCheck %s --check-prefixes=CHECK-ERROR-MULTIPLE
+// CHECK-ERROR-MULTIPLE: expected a single args file, multiple files are only supported for .npy args
+
+func.func @main(%arg0: tensor<2xi32>, %arg1: tensor<2xi32>) -> tensor<2xi32> {
+  %0 = stablehlo.add %arg0, %arg1 : tensor<2xi32>
+  return %0 : tensor<2xi32>
+}
+
+// CHECK:      tensor<2xi32> {
+// CHECK-NEXT:   [3, 3]
+// CHECK-NEXT: }

--- a/stablehlo/tests/interpret/api_input_arguments_npy.mlir
+++ b/stablehlo/tests/interpret/api_input_arguments_npy.mlir
@@ -1,0 +1,23 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: stablehlo-translate --interpret %s --probe-output-dir=%t --args="[dense<[10, 20]> : tensor<2xi32>, dense<[1, 2]> : tensor<2xi32>]" | FileCheck %s
+// RUN: stablehlo-translate --interpret %s --probe-output-dir=%t --args=@%t/probe1.npy,@%t/probe2.npy | FileCheck %s
+
+// RUN: not stablehlo-translate --interpret %s --args=@%t/missing.npy 2>&1 | FileCheck %s --check-prefixes=CHECK-ERROR-MISSING
+// CHECK-ERROR-MISSING: failed to read NumPy args file
+
+// RUN: not stablehlo-translate --interpret %s --args=@%t/other.mlir,@%t/probe1.npy 2>&1 | FileCheck %s --check-prefixes=CHECK-ERROR-MIXED
+// CHECK-ERROR-MIXED: cannot mix .npy and non-.npy args files
+
+// The probes serialize each argument to <probe-output-dir>/probe<N>.npy on
+// the first run; the second run loads those files back as the arguments,
+// inferring the tensor types from the NumPy headers.
+func.func @main(%arg0: tensor<2xi32>, %arg1: tensor<2xi32>) -> tensor<2xi32> {
+  %0 = interpreter.probe %arg0, probe_id = "arg0" : tensor<2xi32>
+  %1 = interpreter.probe %arg1, probe_id = "arg1" : tensor<2xi32>
+  %2 = stablehlo.add %0, %1 : tensor<2xi32>
+  return %2 : tensor<2xi32>
+}
+
+// CHECK:      tensor<2xi32> {
+// CHECK-NEXT:   [11, 22]
+// CHECK-NEXT: }

--- a/stablehlo/tests/interpret/api_input_arguments_npy.mlir
+++ b/stablehlo/tests/interpret/api_input_arguments_npy.mlir
@@ -6,6 +6,7 @@
 // CHECK-ERROR-MISSING: failed to read NumPy args file
 
 // RUN: not stablehlo-translate --interpret %s --args=@%t/other.mlir,@%t/probe1.npy 2>&1 | FileCheck %s --check-prefixes=CHECK-ERROR-MIXED
+// RUN: not stablehlo-translate --interpret %s --args=@%t/probe1.npy,@%t/other.mlir 2>&1 | FileCheck %s --check-prefixes=CHECK-ERROR-MIXED
 // CHECK-ERROR-MIXED: cannot mix .npy and non-.npy args files
 
 // The probes serialize each argument to <probe-output-dir>/probe<N>.npy on

--- a/stablehlo/tools/StablehloTranslateMain.cpp
+++ b/stablehlo/tools/StablehloTranslateMain.cpp
@@ -50,6 +50,7 @@ limitations under the License.
 #include "stablehlo/reference/Configuration.h"
 #include "stablehlo/reference/Errors.h"
 #include "stablehlo/reference/InterpreterOps.h"
+#include "stablehlo/reference/NumPy.h"
 #include "stablehlo/reference/Process.h"
 #include "stablehlo/reference/Scope.h"
 #include "stablehlo/reference/Tensor.h"
@@ -85,8 +86,9 @@ llvm::cl::opt<bool> allowOtherDialectsOption(
 llvm::cl::opt<std::string> argsOption(
     "args",
     llvm::cl::desc("Arguments to pass to the interpreter, either an inline "
-                   "array attribute or @file pointing to a file containing "
-                   "one"),
+                   "array attribute, @file pointing to a file containing "
+                   "one, or comma-separated @file.npy files providing one "
+                   "input tensor each"),
     llvm::cl::init(""));
 
 llvm::cl::opt<bool> interpreterPrintDense(
@@ -108,7 +110,9 @@ stablehlo::Tensor makeBooleanTensor(MLIRContext *context, bool value) {
 //   --args=[dense<1> : tensor<2xi32>, ...], where each dense attribute is
 //   interpreted as a tensor, or
 //   --args=@file, where the file contains an array attribute in the same
-//   format.
+//   format, or
+//   --args=@a.npy,@b.npy, where each NumPy file provides one input tensor
+//   whose type is inferred from the file's header.
 mlir::FailureOr<SmallVector<stablehlo::InterpreterValue>>
 parseInterpreterArguments(std::string argsStr, MLIRContext *context) {
   llvm::SmallVector<stablehlo::InterpreterValue> inputs;
@@ -118,6 +122,22 @@ parseInterpreterArguments(std::string argsStr, MLIRContext *context) {
     return emitError(UnknownLoc::get(context), msg) << ", i.e. " << usage;
   };
   if (!argsStr.empty() && argsStr[0] == '@') {
+    if (llvm::StringRef(argsStr).ends_with(".npy")) {
+      llvm::SmallVector<llvm::StringRef> fileNames;
+      llvm::StringRef(argsStr).split(fileNames, ',');
+      for (llvm::StringRef fileName : fileNames) {
+        fileName.consume_front("@");
+        if (!fileName.ends_with(".npy"))
+          return parseError("cannot mix .npy and non-.npy args files ('" +
+                            fileName.str() + "')");
+        auto tensor = stablehlo::numpy::deserializeTensor(fileName, context);
+        if (std::error_code ec = tensor.getError())
+          return parseError("failed to read NumPy args file '" +
+                            fileName.str() + "': " + ec.message());
+        inputs.push_back(stablehlo::InterpreterValue(*tensor));
+      }
+      return inputs;
+    }
     std::string fileName = argsStr.substr(1);
     auto fileOrErr = llvm::MemoryBuffer::getFile(fileName);
     if (std::error_code ec = fileOrErr.getError())

--- a/stablehlo/tools/StablehloTranslateMain.cpp
+++ b/stablehlo/tools/StablehloTranslateMain.cpp
@@ -23,6 +23,7 @@ limitations under the License.
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/LogicalResult.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/AsmParser/AsmParser.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -82,7 +83,10 @@ llvm::cl::opt<bool> allowOtherDialectsOption(
     llvm::cl::init(false));
 
 llvm::cl::opt<std::string> argsOption(
-    "args", llvm::cl::desc("Arguments to pass to the interpreter"),
+    "args",
+    llvm::cl::desc("Arguments to pass to the interpreter, either an inline "
+                   "array attribute or @file pointing to a file containing "
+                   "one"),
     llvm::cl::init(""));
 
 llvm::cl::opt<bool> interpreterPrintDense(
@@ -102,14 +106,25 @@ stablehlo::Tensor makeBooleanTensor(MLIRContext *context, bool value) {
 // Parse `--args` option into a list of interpreter arguments.
 // The format is:
 //   --args=[dense<1> : tensor<2xi32>, ...], where each dense attribute is
-//   interpreted as a tensor.
+//   interpreted as a tensor, or
+//   --args=@file, where the file contains an array attribute in the same
+//   format.
 mlir::FailureOr<SmallVector<stablehlo::InterpreterValue>>
 parseInterpreterArguments(std::string argsStr, MLIRContext *context) {
   llvm::SmallVector<stablehlo::InterpreterValue> inputs;
   auto parseError = [&](llvm::StringRef msg) {
-    std::string usage = "--args=[dense<1> : tensor<2xi32>, ...]";
+    std::string usage =
+        "--args=[dense<1> : tensor<2xi32>, ...] or --args=@file";
     return emitError(UnknownLoc::get(context), msg) << ", i.e. " << usage;
   };
+  if (!argsStr.empty() && argsStr[0] == '@') {
+    std::string fileName = argsStr.substr(1);
+    auto fileOrErr = llvm::MemoryBuffer::getFile(fileName);
+    if (std::error_code ec = fileOrErr.getError())
+      return parseError("failed to read args file '" + fileName +
+                        "': " + ec.message());
+    argsStr = fileOrErr.get()->getBuffer().str();
+  }
   if (!argsStr.empty()) {
     auto arrayAttr =
         dyn_cast_or_null<ArrayAttr>(mlir::parseAttribute(argsStr, context));

--- a/stablehlo/tools/StablehloTranslateMain.cpp
+++ b/stablehlo/tools/StablehloTranslateMain.cpp
@@ -137,8 +137,8 @@ parseInterpreterArguments(std::string argsStr, MLIRContext *context) {
       for (llvm::StringRef fileName : fileNames) {
         auto tensor = stablehlo::numpy::deserializeTensor(fileName, context);
         if (std::error_code ec = tensor.getError())
-          return fileError("failed to read NumPy args file '" +
-                           fileName.str() + "': " + ec.message());
+          return fileError("failed to read NumPy args file '" + fileName.str() +
+                           "': " + ec.message());
         inputs.push_back(stablehlo::InterpreterValue(*tensor));
       }
       return inputs;
@@ -146,8 +146,9 @@ parseInterpreterArguments(std::string argsStr, MLIRContext *context) {
     if (llvm::any_of(fileNames, isNumPy))
       return fileError("cannot mix .npy and non-.npy args files");
     if (fileNames.size() != 1)
-      return fileError("expected a single args file, multiple files are only "
-                       "supported for .npy args");
+      return fileError(
+          "expected a single args file, multiple files are only "
+          "supported for .npy args");
 
     llvm::StringRef fileName = fileNames.front();
     auto fileOrErr = llvm::MemoryBuffer::getFile(fileName);

--- a/stablehlo/tools/StablehloTranslateMain.cpp
+++ b/stablehlo/tools/StablehloTranslateMain.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include <string>
 #include <utility>
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/CommandLine.h"
@@ -117,32 +118,42 @@ mlir::FailureOr<SmallVector<stablehlo::InterpreterValue>>
 parseInterpreterArguments(std::string argsStr, MLIRContext *context) {
   llvm::SmallVector<stablehlo::InterpreterValue> inputs;
   auto parseError = [&](llvm::StringRef msg) {
-    std::string usage =
-        "--args=[dense<1> : tensor<2xi32>, ...] or --args=@file";
+    std::string usage = "--args=[dense<1> : tensor<2xi32>, ...]";
+    return emitError(UnknownLoc::get(context), msg) << ", i.e. " << usage;
+  };
+  auto fileError = [&](llvm::StringRef msg) {
+    std::string usage = "--args=@file or --args=@a.npy,@b.npy";
     return emitError(UnknownLoc::get(context), msg) << ", i.e. " << usage;
   };
   if (!argsStr.empty() && argsStr[0] == '@') {
-    if (llvm::StringRef(argsStr).ends_with(".npy")) {
-      llvm::SmallVector<llvm::StringRef> fileNames;
-      llvm::StringRef(argsStr).split(fileNames, ',');
+    llvm::SmallVector<llvm::StringRef> fileNames;
+    llvm::StringRef(argsStr).split(fileNames, ',');
+    for (llvm::StringRef &fileName : fileNames) fileName.consume_front("@");
+
+    auto isNumPy = [](llvm::StringRef fileName) {
+      return fileName.ends_with(".npy");
+    };
+    if (llvm::all_of(fileNames, isNumPy)) {
       for (llvm::StringRef fileName : fileNames) {
-        fileName.consume_front("@");
-        if (!fileName.ends_with(".npy"))
-          return parseError("cannot mix .npy and non-.npy args files ('" +
-                            fileName.str() + "')");
         auto tensor = stablehlo::numpy::deserializeTensor(fileName, context);
         if (std::error_code ec = tensor.getError())
-          return parseError("failed to read NumPy args file '" +
-                            fileName.str() + "': " + ec.message());
+          return fileError("failed to read NumPy args file '" +
+                           fileName.str() + "': " + ec.message());
         inputs.push_back(stablehlo::InterpreterValue(*tensor));
       }
       return inputs;
     }
-    std::string fileName = argsStr.substr(1);
+    if (llvm::any_of(fileNames, isNumPy))
+      return fileError("cannot mix .npy and non-.npy args files");
+    if (fileNames.size() != 1)
+      return fileError("expected a single args file, multiple files are only "
+                       "supported for .npy args");
+
+    llvm::StringRef fileName = fileNames.front();
     auto fileOrErr = llvm::MemoryBuffer::getFile(fileName);
     if (std::error_code ec = fileOrErr.getError())
-      return parseError("failed to read args file '" + fileName +
-                        "': " + ec.message());
+      return fileError("failed to read args file '" + fileName.str() +
+                       "': " + ec.message());
     argsStr = fileOrErr.get()->getBuffer().str();
   }
   if (!argsStr.empty()) {


### PR DESCRIPTION

Fixes #2912.

`--args` currently requires spelling out every input tensor inline, which
exceeds OS argument-length limits for realistically sized models. This PR
adds an IREE-style `@` prefix for reading arguments from files, in two
commits:

## 1. `--args=@file`

The file contains the same array-attribute text as the inline form:

    stablehlo-translate model.mlir --interpret --args=@inputs.mlir

## 2. `--args=@a.npy,@b.npy`

Comma-separated NumPy files, each providing one input tensor. The tensor
type is inferred from the file's header, so probe outputs
(`--probe-output-dir`) can be fed back in as interpreter inputs directly:

    stablehlo-translate model.mlir --interpret --args=@probe1.npy,@probe2.npy

Type inference covers little-endian integer and f32/f64 dtypes. Types
without a native NumPy representation (bool, f16, bf16, complex) are
serialized by `serializeTensor` under substitute descrs, so they can't be
unambiguously inferred and are rejected with a clear error. Extending
these is left for a follow-up.

## NumPy reader fixes

Wiring up inference exposed three latent bugs in `NumPy.cpp`, previously
unreachable because the parsed shape was never used. Note the last one
changes the `descr` that probe files are written with:

- `parseShapeHeader` returned an `ArrayRef` to a local vector and
  pre-filled four zero dims; it now returns an owned, correctly-bounded
  vector, and the file's shape is validated against the expected type.
- Header sizes above 127 bytes were sign-extended into negative values.
- The i64/ui64 type dispatch was inverted relative to every other width,
  so signless i64 tensors serialized with a `'u8'` descr and vice versa.
  Write and read stay consistent with each other, as before.

## Testing

- `stablehlo/tests/interpret/api_input_arguments.mlir`: `@file` positive
  and missing-file cases.
- `stablehlo/tests/interpret/api_input_arguments_npy.mlir`: writes the
  arguments to `.npy` via `interpreter.probe`, then loads them back as
  `--args` inputs (round-trips the serializer/reader pair); plus
  missing-file and mixed-file error cases.
- Manually verified against externally generated NumPy files (f32 2x2,
  `'|i1'` int8, `'<i8'` int64, and bool → rejected as unsupported).
- `ninja check-stablehlo-tests` passes.
