### PR TITLE
Avoid crash on quantized bitcast legalization

### DIFF
--- a/stablehlo/conversions/linalg/tests/unsupported.mlir
+++ b/stablehlo/conversions/linalg/tests/unsupported.mlir
@@ -8,3 +8,21 @@ func.func @bitcast_convert_quantized(
       : (tensor<2x2x!quant.uniform<i8:f32, 1.0:0>>) -> tensor<2x2xi8>
   func.return %result : tensor<2x2xi8>
 }
+
+// CHECK-LABEL: func.func @bitcast_convert_rank_changing_quantized
+func.func @bitcast_convert_rank_changing_quantized(
+    %input: tensor<2x2x!quant.uniform<i8:f32, 1.0:0>>) -> tensor<2xi16> {
+  // CHECK: stablehlo.bitcast_convert
+  %result = "stablehlo.bitcast_convert"(%input)
+      : (tensor<2x2x!quant.uniform<i8:f32, 1.0:0>>) -> tensor<2xi16>
+  func.return %result : tensor<2xi16>
+}
+
+// CHECK-LABEL: func.func @bitcast_convert_rank_changing_quantized_result
+func.func @bitcast_convert_rank_changing_quantized_result(
+    %input: tensor<2xi16>) -> tensor<2x2x!quant.uniform<i8:f32, 1.0:0>> {
+  // CHECK: stablehlo.bitcast_convert
+  %result = "stablehlo.bitcast_convert"(%input)
+      : (tensor<2xi16>) -> tensor<2x2x!quant.uniform<i8:f32, 1.0:0>>
+  func.return %result : tensor<2x2x!quant.uniform<i8:f32, 1.0:0>>
+}

--- a/stablehlo/conversions/linalg/tests/unsupported.mlir
+++ b/stablehlo/conversions/linalg/tests/unsupported.mlir
@@ -1,0 +1,10 @@
+// RUN: stablehlo-opt %s --stablehlo-legalize-to-linalg | FileCheck %s
+
+// CHECK-LABEL: func.func @bitcast_convert_quantized
+func.func @bitcast_convert_quantized(
+    %input: tensor<2x2x!quant.uniform<i8:f32, 1.0:0>>) -> tensor<2x2xi8> {
+  // CHECK: stablehlo.bitcast_convert
+  %result = "stablehlo.bitcast_convert"(%input)
+      : (tensor<2x2x!quant.uniform<i8:f32, 1.0:0>>) -> tensor<2x2xi8>
+  func.return %result : tensor<2x2xi8>
+}

--- a/stablehlo/conversions/linalg/transforms/MapStablehloToScalarOp.h
+++ b/stablehlo/conversions/linalg/transforms/MapStablehloToScalarOp.h
@@ -819,6 +819,10 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::BitcastConvertOp>(
   Type argType = getElementTypeOrSelf(argTypes.front());
   Type resultType = getElementTypeOrSelf(resultTypes.front());
 
+  if (!isa<IntegerType, FloatType>(argType) ||
+      !isa<IntegerType, FloatType>(resultType))
+    return nullptr;
+
   if (resultType.getIntOrFloatBitWidth() != argType.getIntOrFloatBitWidth())
     return nullptr;
 

--- a/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
@@ -909,8 +909,16 @@ struct BitcastConvertConverter final
       return failure();
     }
 
-    auto inputBitWidth = inputType.getElementType().getIntOrFloatBitWidth();
-    auto outputBitWidth = outputType.getElementType().getIntOrFloatBitWidth();
+    Type inputElementType = inputType.getElementType();
+    Type outputElementType = outputType.getElementType();
+    if (!isa<IntegerType, FloatType>(inputElementType) ||
+        !isa<IntegerType, FloatType>(outputElementType)) {
+      return rewriter.notifyMatchFailure(
+          op, "requires integer or floating-point element types");
+    }
+
+    auto inputBitWidth = inputElementType.getIntOrFloatBitWidth();
+    auto outputBitWidth = outputElementType.getIntOrFloatBitWidth();
 
     auto maxRank = std::max(inputType.getRank(), outputType.getRank());
     auto identityMap =


### PR DESCRIPTION
Fixes #2854

## Summary

- Guard the `BitcastConvertOp` scalar mapper before querying integer/float bit widths.
- Preserve unsupported quantized bitcasts during partial linalg legalization instead of aborting.
- Add regression coverage for quantized input element types.

## Test plan

- `cmake --build stablehlo-build --target check-stablehlo-linalg`
- `cmake --build stablehlo-build --target check-stablehlo-ci`
