### PR TITLE
Do not assert on quantized element types in bitcast_convert lowering

### DIFF
--- a/stablehlo/conversions/linalg/tests/miscellaneous.mlir
+++ b/stablehlo/conversions/linalg/tests/miscellaneous.mlir
@@ -85,6 +85,34 @@ func.func @bitcast_convert_contract(%input: tensor<7x4xi8>) -> tensor<7xi32> {
 
 // -----
 
+// stablehlo.bitcast_convert accepts quantized element types, which have no bit
+// width in the sense of getIntOrFloatBitWidth. The op must be left unconverted
+// rather than tripping the assert inside that method.
+
+// CHECK-LABEL: func @bitcast_convert_quantized_same_rank
+// CHECK: stablehlo.bitcast_convert
+// CHECK-PRIMITIVE-LABEL: func @bitcast_convert_quantized_same_rank
+// CHECK-PRIMITIVE: stablehlo.bitcast_convert
+func.func @bitcast_convert_quantized_same_rank(
+    %input: tensor<2x2x!quant.uniform<i8:f32, 1.000000e+00>>) -> tensor<2x2xi8> {
+  %result = "stablehlo.bitcast_convert"(%input) : (tensor<2x2x!quant.uniform<i8:f32, 1.000000e+00>>) -> tensor<2x2xi8>
+  func.return %result : tensor<2x2xi8>
+}
+
+// -----
+
+// CHECK-LABEL: func @bitcast_convert_quantized_expand
+// CHECK: stablehlo.bitcast_convert
+// CHECK-PRIMITIVE-LABEL: func @bitcast_convert_quantized_expand
+// CHECK-PRIMITIVE: stablehlo.bitcast_convert
+func.func @bitcast_convert_quantized_expand(
+    %input: tensor<2x!quant.uniform<i32:f32, 1.000000e+00>>) -> tensor<2x4xi8> {
+  %result = "stablehlo.bitcast_convert"(%input) : (tensor<2x!quant.uniform<i32:f32, 1.000000e+00>>) -> tensor<2x4xi8>
+  func.return %result : tensor<2x4xi8>
+}
+
+// -----
+
 // CHECK-LABEL:   func @concatenate(
 // CHECK-SAME:   %[[VAL_0:[a-zA-Z0-9_]*]]
 // CHECK-SAME:   %[[VAL_1:[a-zA-Z0-9_]*]]

--- a/stablehlo/conversions/linalg/transforms/MapStablehloToScalarOp.h
+++ b/stablehlo/conversions/linalg/transforms/MapStablehloToScalarOp.h
@@ -819,6 +819,10 @@ inline Value mapStablehloOpToStdScalarOp<stablehlo::BitcastConvertOp>(
   Type argType = getElementTypeOrSelf(argTypes.front());
   Type resultType = getElementTypeOrSelf(resultTypes.front());
 
+  // stablehlo.bitcast_convert also accepts quantized element types, which have
+  // no bit width in the sense of getIntOrFloatBitWidth (it asserts on them).
+  if (!argType.isIntOrFloat() || !resultType.isIntOrFloat()) return nullptr;
+
   if (resultType.getIntOrFloatBitWidth() != argType.getIntOrFloatBitWidth())
     return nullptr;
 

--- a/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloLegalizeToLinalg.cpp
@@ -909,8 +909,17 @@ struct BitcastConvertConverter final
       return failure();
     }
 
-    auto inputBitWidth = inputType.getElementType().getIntOrFloatBitWidth();
-    auto outputBitWidth = outputType.getElementType().getIntOrFloatBitWidth();
+    // stablehlo.bitcast_convert also accepts quantized element types, which
+    // have no bit width in the sense of getIntOrFloatBitWidth (it asserts on
+    // them).
+    Type inputElementType = inputType.getElementType();
+    Type outputElementType = outputType.getElementType();
+    if (!inputElementType.isIntOrFloat() || !outputElementType.isIntOrFloat())
+      return rewriter.notifyMatchFailure(
+          op, "expected integer or float element types");
+
+    auto inputBitWidth = inputElementType.getIntOrFloatBitWidth();
+    auto outputBitWidth = outputElementType.getIntOrFloatBitWidth();
 
     auto maxRank = std::max(inputType.getRank(), outputType.getRank());
     auto identityMap =

--- a/stablehlo/conversions/linalg/transforms/StablehloToLinalgPointwise.cpp
+++ b/stablehlo/conversions/linalg/transforms/StablehloToLinalgPointwise.cpp
@@ -153,16 +153,21 @@ struct PointwiseToLinalgMapConverter : OpConversionPattern<OpTy> {
       OpTy& op, ConversionPatternRewriter& rewriter,
       ArrayRef<Value> mappedInputs, ArrayRef<Value> scalarVals,
       Value emptyTensor, int64_t maxRank) const {
+    bool failed = false;
     Operation* mapOp = linalg::MapOp::create(
         rewriter, op.getLoc(), mappedInputs, emptyTensor,
         [&](OpBuilder& b, Location loc, ValueRange args) {
           Value innerResult = mlir::stablehlo::StablehloOpToStdScalarOp::mapOp(
               op, getElementTypeOrSelf(emptyTensor),
               interleaveScalarAndBlockArgs(scalarVals, args), &b);
-
+          if (!innerResult) {
+            failed = true;
+            return;
+          }
           linalg::YieldOp::create(b, loc, innerResult);
         },
         linalg::getPrunedAttributeList(op));
+    if (failed) return failure();
     return mapOp;
   }
 


### PR DESCRIPTION
Fixes #2854.

`stablehlo.bitcast_convert` accepts quantized element types, and `ops_stablehlo_quantized.mlir` already covers that. The linalg lowering asks for the element bit width with `Type::getIntOrFloatBitWidth`, which asserts on anything that is not an integer or a float. Two call sites are reachable from IR the op verifier accepts, because `verifyBitcastConvertOp` goes through the local `getBitWidth` helper, which unwraps quantized types to their storage type.

`BitcastConvertConverter`, when the operand and result ranks differ:

```mlir
%0 = stablehlo.bitcast_convert %arg0 : (tensor<2x!quant.uniform<i32:f32, 1.0>>) -> tensor<2x4xi8>
```

`mapStablehloOpToStdScalarOp<BitcastConvertOp>`, when the ranks match and the result element type is a plain integer:

```mlir
%0 = stablehlo.bitcast_convert %arg0 : (tensor<2x2x!quant.uniform<i8:f32, 1.0>>) -> tensor<2x2xi8>
```

The result type check in `checkOperandsAndResults` passes in the second case because the result is a signless integer, so the quantized operand type reaches the scalar mapping unchecked. Quantized to quantized at the same rank happens to be safe already, since that same result type check rejects it.

This checks for an integer or float element type at both sites and reports a match failure instead. The pass is a partial conversion that does not mark StableHLO illegal, so the op is left in place rather than crashing, which is what the new tests check.

One companion change: `PointwiseToLinalgMapConverter`, used by `enable-primitive-ops`, passed the result of the scalar mapping straight to `linalg.yield`. It now bails out on a null result the same way `PointwiseToLinalgConverter` already does. Without it the new null return would trade one crash for another under that option, and the same hole is reachable today from any op whose scalar mapping can return null, such as `IsFiniteOp` on a non-float.

Verification: I did not build StableHLO for this change, so the argument is by reading. The lit tests are written to the existing conventions in `miscellaneous.mlir` and the C++ is clang-format clean.

Assisted-by: Claude Code
