### PR TITLE
Fix sort comparison type selection

### DIFF
--- a/stablehlo/dialect/StablehloOps.cpp
+++ b/stablehlo/dialect/StablehloOps.cpp
@@ -4346,14 +4346,10 @@ SortOp createSortOp(PatternRewriter* rewriter, const Location& loc,
   auto sortOp = SortOp::create(*rewriter, loc, operands, dimension, isStable);
 
   // Use TOTALORDER comparison type instead of the default comparison if the
-  // element type is of type float.
+  // sort key (first element type) is a float.
   std::optional<StringRef> compareType = std::nullopt;
-  for (const auto& elementType : elementTypes) {
-    if (isa<FloatType>(elementType)) {
-      compareType.emplace("TOTALORDER");
-      break;
-    }
-  }
+  if (!elementTypes.empty() && isa<FloatType>(elementTypes[0]))
+    compareType.emplace("TOTALORDER");
   buildSortComparisonBody(elementTypes, direction, compareType,
                           &sortOp.getComparator(), rewriter);
   return sortOp;

--- a/stablehlo/tests/TestUtils.cpp
+++ b/stablehlo/tests/TestUtils.cpp
@@ -94,6 +94,30 @@ struct BroadcastIfNeededPattern : public RewritePattern {
   }
 };
 
+struct CreateSortOpPattern : public RewritePattern {
+  explicit CreateSortOpPattern(MLIRContext* context)
+      : RewritePattern("hlo_test_create_sort.build", 1, context) {}
+
+  LogicalResult matchAndRewrite(Operation* op,
+                                PatternRewriter& rewriter) const override {
+    SmallVector<Value> operands = llvm::to_vector(op->getOperands());
+    SmallVector<Type> elementTypes;
+    elementTypes.reserve(operands.size());
+    for (Value operand : operands) {
+      auto shapedType = dyn_cast<ShapedType>(operand.getType());
+      if (!shapedType)
+        return rewriter.notifyMatchFailure(op, "expected shaped operands");
+      elementTypes.push_back(shapedType.getElementType());
+    }
+
+    auto sort = stablehlo::createSortOp(
+        &rewriter, op->getLoc(), operands, elementTypes, /*dimension=*/0,
+        /*isStable=*/false, stablehlo::ComparisonDirection::LT);
+    rewriter.replaceOp(op, sort.getResults());
+    return success();
+  }
+};
+
 struct InferReturnTypesPattern : public RewritePattern {
   explicit InferReturnTypesPattern(MLIRContext* context)
       : RewritePattern("hlo_test_infer.get_return_types", 1, context) {}
@@ -239,6 +263,7 @@ struct IsNotSpeculatablePattern : public RewritePattern {
 };
 
 #define GEN_PASS_DEF_HLOTESTBROADCASTPASS
+#define GEN_PASS_DEF_HLOTESTCREATESORTPASS
 #define GEN_PASS_DEF_HLOTESTINFERPASS
 #define GEN_PASS_DEF_HLOTESTSPECULATABILITYPASS
 #include "stablehlo/tests/TestUtils.h.inc"
@@ -249,6 +274,24 @@ struct HloTestBroadcastPass
     RewritePatternSet patterns(context);
     patterns.add<BroadcastValuesPattern>(context);
     patterns.add<BroadcastIfNeededPattern>(context);
+    patterns_ = std::move(patterns);
+    return success();
+  }
+
+  void runOnOperation() override {
+    if (failed(applyPatternsGreedily(getOperation(), std::move(patterns_))))
+      return signalPassFailure();
+  }
+
+ private:
+  FrozenRewritePatternSet patterns_;
+};
+
+struct HloTestCreateSortPass
+    : public impl::HloTestCreateSortPassBase<HloTestCreateSortPass> {
+  LogicalResult initialize(MLIRContext* context) override {
+    RewritePatternSet patterns(context);
+    patterns.add<CreateSortOpPattern>(context);
     patterns_ = std::move(patterns);
     return success();
   }

--- a/stablehlo/tests/TestUtils.td
+++ b/stablehlo/tests/TestUtils.td
@@ -21,6 +21,11 @@ def HloTestBroadcastPass : Pass<"hlo-test-broadcast", "func::FuncOp"> {
   let dependentDialects = ["stablehlo::StablehloDialect"];
 }
 
+def HloTestCreateSortPass : Pass<"hlo-test-create-sort", "func::FuncOp"> {
+  let summary = "Uses test ops to invoke the StableHLO sort builder.";
+  let dependentDialects = ["stablehlo::StablehloDialect"];
+}
+
 def HloTestInferPass : Pass<"hlo-test-infer", "func::FuncOp"> {
   let summary = "Uses test ops to invoke InferShapedTypeOpInterface methods.";
   let dependentDialects = ["shape::ShapeDialect"];

--- a/stablehlo/tests/ops_stablehlo.mlir
+++ b/stablehlo/tests/ops_stablehlo.mlir
@@ -1,4 +1,5 @@
 // RUN: stablehlo-opt %s -verify-diagnostics -split-input-file -allow-unregistered-dialect | FileCheck %s
+// RUN: stablehlo-opt %s --hlo-test-create-sort -verify-diagnostics -split-input-file -allow-unregistered-dialect | FileCheck --check-prefix=CHECK-CREATE-SORT %s
 // RUN: %if asserts %{ stablehlo-opt %s -verify-diagnostics -split-input-file -allow-unregistered-dialect -emit-bytecode -debug-only=stablehlo-bytecode 2>&1 | FileCheck --check-prefix=CHECK-WARN %s %}
 
 // CHECK-WARN-NOT: Not Implemented
@@ -3137,6 +3138,24 @@ func.func @sort(%input0: tensor<16x16xf32>, %input1: tensor<16x16xi32>) {
     "stablehlo.return"(%7) : (tensor<i1>) -> ()
   }) {dimension = 1 : i64, is_stable = true} : (tensor<16x16xf32>, tensor<16x16xi32>) -> (tensor<16x16xf32>, tensor<16x16xi32>)
   func.return
+}
+
+// -----
+
+// CHECK-CREATE-SORT-LABEL: func.func @create_sort_integer_key_float_payload
+// CHECK-CREATE-SORT: stablehlo.compare LT, %{{[^,]+}}, %{{[^, ]+}} : (tensor<i32>, tensor<i32>) -> tensor<i1>
+func.func @create_sort_integer_key_float_payload(%key: tensor<2xi32>, %payload: tensor<2xf32>) -> (tensor<2xi32>, tensor<2xf32>) {
+  %0:2 = "hlo_test_create_sort.build"(%key, %payload) : (tensor<2xi32>, tensor<2xf32>) -> (tensor<2xi32>, tensor<2xf32>)
+  func.return %0#0, %0#1 : tensor<2xi32>, tensor<2xf32>
+}
+
+// -----
+
+// CHECK-CREATE-SORT-LABEL: func.func @create_sort_float_key_integer_payload
+// CHECK-CREATE-SORT: stablehlo.compare LT, %{{[^,]+}}, %{{[^, ]+}}, TOTALORDER : (tensor<f32>, tensor<f32>) -> tensor<i1>
+func.func @create_sort_float_key_integer_payload(%key: tensor<2xf32>, %payload: tensor<2xi32>) -> (tensor<2xf32>, tensor<2xi32>) {
+  %0:2 = "hlo_test_create_sort.build"(%key, %payload) : (tensor<2xf32>, tensor<2xi32>) -> (tensor<2xf32>, tensor<2xi32>)
+  func.return %0#0, %0#1 : tensor<2xf32>, tensor<2xi32>
 }
 
 // -----


### PR DESCRIPTION
TensorFlow’s `tf.RandomShuffle` lowering exposed a mismatch in `createSortOp`: the helper compares only the first operand (the sort key), but selected `TOTALORDER` when any payload type was floating-point. With `i32` keys and an `f32` payload, that produces an invalid integer comparison.

This change:
- selects `TOTALORDER` only when the first element type is floating-point;
- adds FileCheck regression coverage that invokes the helper with an integer key and float payload; and
- verifies that float keys still use `TOTALORDER`.

This is the upstream prerequisite for tensorflow/tensorflow#125279. The equivalent MHLO helper was corrected by openxla/xla#40531.

Tested: `bazel build //stablehlo/tests:test_utils`.