### PR TITLE
[RFC] Add WEAKORDER to ComparisonType and Deprecate SIGNED/UNSIGNED

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2060,6 +2060,19 @@ For floating-point element types with `compare_type = TOTALORDER`, the op
 uses the combination of `totalOrder` and `compareQuietEqual` operations from
 IEEE-754.
 
+For floating-point element types with `compare_type = WEAKORDER`, the op
+implements a total preorder (strict weak ordering) where `-0.0` and `+0.0` are
+treated as equal, and all `NaN` representations are treated as equal to each
+other and greater than `+infinity`:
+
+* `EQ`: `compareQuietEqual(lhs, rhs) || (is_nan(lhs) && is_nan(rhs))`.
+* `NE`: `!EQ(lhs, rhs)`.
+* `GE`: `GT(lhs, rhs) || EQ(lhs, rhs)`.
+* `GT`: `LT(rhs, lhs)`.
+* `LE`: `LT(lhs, rhs) || EQ(lhs, rhs)`.
+* `LT`: `(!is_nan(lhs) && is_nan(rhs)) ||`
+  `(!is_nan(lhs) && !is_nan(rhs) && compareQuietLess(lhs, rhs))`.
+
 For complex element types, lexicographic comparison of `(real, imag)` pairs is
 performed using the provided `comparison_direction` and `compare_type`.
 Imposing an ordering on complex numbers involves surprising semantics,
@@ -2072,12 +2085,12 @@ comparison_direction)`.
 
 #### Inputs
 
-| Label | Name                   | Type                                                    | Constraints |
-|-------|------------------------|---------------------------------------------------------|-------------|
-| (I1)  | `lhs`                  | tensor or per-tensor quantized tensor                   | (C1-C3)     |
-| (I2)  | `rhs`                  | tensor or per-tensor quantized tensor                   | (C1-C2)     |
-| (I3)  | `comparison_direction` | enum of `EQ`, `NE`, `GE`, `GT`, `LE`, and `LT`          |             |
-| (I4)  | `compare_type`         | enum of `FLOAT`, `TOTALORDER`, `SIGNED`, and `UNSIGNED` | (C3)        |
+| Label | Name                   | Type                                                                                    | Constraints |
+|-------|------------------------|-----------------------------------------------------------------------------------------|-------------|
+| (I1)  | `lhs`                  | tensor or per-tensor quantized tensor                                                   | (C1-C3)     |
+| (I2)  | `rhs`                  | tensor or per-tensor quantized tensor                                                   | (C1-C2)     |
+| (I3)  | `comparison_direction` | enum of `EQ`, `NE`, `GE`, `GT`, `LE`, and `LT`                                          |             |
+| (I4)  | `compare_type`         | optional enum of `NOTYPE`, `FLOAT`, `TOTALORDER`, `WEAKORDER`, `SIGNED`, and `UNSIGNED` | (C3)        |
 
 #### Outputs
 
@@ -2090,10 +2103,11 @@ comparison_direction)`.
 * (C1) `baseline_element_type(lhs) = baseline_element_type(rhs)`.
 * (C2) `shape(lhs) = shape(rhs) = shape(result)`.
 * (C3) `compare_type` is defined as:
-  * `SIGNED` if `is_signed_integer(element_type(lhs))`.
-  * `UNSIGNED` if `is_unsigned_integer(element_type(lhs)) or
-    is_boolean(element_type(lhs))`.
-  * `FLOAT` or `TOTALORDER` if `is_float(element_type(lhs))`.
+  * `NOTYPE`, `SIGNED` (deprecated), or `UNSIGNED` (deprecated) if
+    `is_signed_integer(element_type(lhs))`,
+    `is_unsigned_integer(element_type(lhs))`, or
+    `is_boolean(element_type(lhs))`.
+  * `FLOAT`, `TOTALORDER`, or `WEAKORDER` if `is_float(element_type(lhs))`.
   * `FLOAT` if `is_complex(element_type(lhs))`.
 
 #### Examples

--- a/rfcs/20260901-numpy-comparison-type.md
+++ b/rfcs/20260901-numpy-comparison-type.md
@@ -1,8 +1,8 @@
-# [RFC] Add NUMPY to ComparisonType and Deprecate SIGNED/UNSIGNED
+# [RFC] Add WEAKORDER to ComparisonType and Deprecate SIGNED/UNSIGNED
 
 Status: In Review
 Initial version: 2026-09-01
-Last updated: 2026-09-01
+Last updated: 2026-09-03
 Discussion thread:
 [GitHub PR #3003](https://github.com/openxla/stablehlo/pull/3003)
 
@@ -10,19 +10,19 @@ Discussion thread:
 
 This RFC proposes:
 
-1. Adding `NUMPY` (or `FLOAT_NUMPY`) to `ComparisonType` (`compare_type`
-   attribute on `stablehlo.compare`).
-2. Formally deprecating the `SIGNED` and `UNSIGNED` enum values in
+1. Adding `WEAKORDER` to `ComparisonType` (`compare_type` attribute on
+   `stablehlo.compare`).
+3. Formally deprecating the `SIGNED` and `UNSIGNED` enum values in
    `ComparisonType`.
-3. Updating the StableHLO specification for `compare` to support
-   NumPy/Python-style total ordering semantics.
+4. Updating the StableHLO specification for `compare` to support strict weak
+   ordering semantics for floating-point types.
 
 ## Motivation & Background
 
-### 1. The Need for NUMPY Comparison Order
+### 1. The Need for WEAKORDER Comparison Order
 
-Machine learning frontends (JAX, PyTorch, NumPy) require NumPy sorting and
-ranking semantics:
+Machine learning frontends (JAX, PyTorch, NumPy) require array sorting and
+ranking semantics that differ from standard IEEE-754:
 
 - -0.0 and +0.0 are treated as equivalent keys (preserving stability in stable
   sorts).
@@ -41,7 +41,7 @@ detect this subgraph and emit fast CUB `DeviceRadixSort` (see b/376918731).
 If any compiler optimization alters the AST, pattern matching fails and falls
 back to a 10x-25x slower bitonic sort.
 
-Adding `NUMPY` directly to `ComparisonType` eliminates frontend
+Adding `WEAKORDER` directly to `ComparisonType` eliminates frontend
 canonicalization bloat and provides a clean, robust contract for compiler
 backends.
 
@@ -74,7 +74,7 @@ def STABLEHLO_COMPARISON_TYPE_SIGNED :
     I32EnumAttrCase<"SIGNED", 3>; // Deprecated
 def STABLEHLO_COMPARISON_TYPE_UNSIGNED :
     I32EnumAttrCase<"UNSIGNED", 4>; // Deprecated
-def STABLEHLO_COMPARISON_TYPE_NUMPY : I32EnumAttrCase<"NUMPY", 5>;
+def STABLEHLO_COMPARISON_TYPE_WEAK_ORDER : I32EnumAttrCase<"WEAKORDER", 5>;
 
 def StableHLO_ComparisonType : I32EnumAttr<"ComparisonType",
     "Which comparison type to use.",
@@ -84,7 +84,7 @@ def StableHLO_ComparisonType : I32EnumAttr<"ComparisonType",
       STABLEHLO_COMPARISON_TYPE_FLOAT_TOTAL_ORDER,
       STABLEHLO_COMPARISON_TYPE_SIGNED,
       STABLEHLO_COMPARISON_TYPE_UNSIGNED,
-      STABLEHLO_COMPARISON_TYPE_NUMPY
+      STABLEHLO_COMPARISON_TYPE_WEAK_ORDER
     ]>
 ```
 
@@ -92,8 +92,8 @@ def StableHLO_ComparisonType : I32EnumAttr<"ComparisonType",
 
 Update `compare` semantics:
 
-- For floating-point element types with `compare_type = NUMPY`:
-  - Implements total weak ordering:
+- For floating-point element types with `compare_type = WEAKORDER`:
+  - Implements strict weak ordering:
     -infinity < finite < -0.0 == +0.0 < finite < +infinity < NaN.
   - -0.0 and +0.0 compare as equal (`EQ` is true; neither is `<` the other).
   - All NaN representations (positive, negative, signaling, quiet) compare as
@@ -101,14 +101,14 @@ Update `compare` semantics:
 - Constraints (C3) updated:
   - `SIGNED` and `UNSIGNED` marked deprecated.
   - `NOTYPE` is the standard for integer and boolean types.
-  - `FLOAT`, `TOTALORDER`, or `NUMPY` valid for floating-point types.
+  - `FLOAT`, `TOTALORDER`, or `WEAKORDER` valid for floating-point types.
 
 ### 3. Compatibility & Versioning
 
 - **Backward Compatibility**: Existing VHLO bytecodes with `SIGNED`/`UNSIGNED`
   will continue to deserialize. On upgrade, they are preserved or mapped to
   `NOTYPE`.
-- **Forward Compatibility**: `NUMPY` will be added to `VhloEnums.td`
+- **Forward Compatibility**: `WEAKORDER` will be added to `VhloEnums.td`
   (`VHLO_ComparisonTypeV1`) with appropriate versioning.
 
 ## Alternatives Considered
@@ -116,13 +116,13 @@ Update `compare` semantics:
 ### Alternative 1: Replace `compare_type` with `comparison_order` attribute
 
 Rather than extending `ComparisonType`, deprecate `compare_type` entirely and
-introduce `comparison_order` with values `PARTIAL`, `TOTAL`, `NUMPY`.
+introduce `comparison_order` with values `PARTIAL`, `TOTAL`, `WEAK`.
 
 - **Pros**: Cleaner conceptual model (separates data type from ordering; 1:1
   match with XLA IR's `Comparison::Order`).
 - **Cons**: Substantial churn for all existing StableHLO producers and
   consumers, requiring op signature migration (`CompareOpV2` or complex
-  bytecode upgrade rules). Option A achieves the required semantic
+  bytecode upgrade rules). The proposal achieves the required semantic
   expressiveness with zero disruption.
 
 ### Alternative 2: Keep frontend canonicalization

--- a/rfcs/20260901-numpy-comparison-type.md
+++ b/rfcs/20260901-numpy-comparison-type.md
@@ -4,11 +4,12 @@ Status: In Review
 Initial version: 2026-09-01
 Last updated: 2026-09-01
 Discussion thread:
-https://github.com/openxla/stablehlo/pull/3003
+[GitHub PR #3003](https://github.com/openxla/stablehlo/pull/3003)
 
 ## Overview
 
 This RFC proposes:
+
 1. Adding `NUMPY` (or `FLOAT_NUMPY`) to `ComparisonType` (`compare_type`
    attribute on `stablehlo.compare`).
 2. Formally deprecating the `SIGNED` and `UNSIGNED` enum values in
@@ -22,6 +23,7 @@ This RFC proposes:
 
 Machine learning frontends (JAX, PyTorch, NumPy) require NumPy sorting and
 ranking semantics:
+
 - -0.0 and +0.0 are treated as equivalent keys (preserving stability in stable
   sorts).
 - All NaNs (both positive and negative) are sorted to the end of the sequence
@@ -58,6 +60,7 @@ integer/boolean operands.
 ### 1. Dialect & Attributes
 
 Update `StableHLO_ComparisonType`:
+
 ```tablegen
 def STABLEHLO_COMPARISON_TYPE_NOTYPE : I32EnumAttrCase<"NOTYPE", 0>;
 def STABLEHLO_COMPARISON_TYPE_FLOAT : I32EnumAttrCase<"FLOAT", 1>;
@@ -83,6 +86,7 @@ def StableHLO_ComparisonType : I32EnumAttr<"ComparisonType",
 ### 2. Specification (`docs/spec.md`)
 
 Update `compare` semantics:
+
 - For floating-point element types with `compare_type = NUMPY`:
   - Implements total weak ordering:
     -infinity < finite < -0.0 == +0.0 < finite < +infinity < NaN.
@@ -108,6 +112,7 @@ Update `compare` semantics:
 
 Rather than extending `ComparisonType`, deprecate `compare_type` entirely and
 introduce `comparison_order` with values `PARTIAL`, `TOTAL`, `NUMPY`.
+
 - **Pros**: Cleaner conceptual model (separates data type from ordering; 1:1
   match with XLA IR's `Comparison::Order`).
 - **Cons**: Substantial churn for all existing StableHLO producers and
@@ -119,5 +124,6 @@ introduce `comparison_order` with values `PARTIAL`, `TOTAL`, `NUMPY`.
 
 Continue lowering NumPy sorts in JAX/PyTorch via select/compare ASTs and
 relying on XLA backend pattern matching.
+
 - **Cons**: Brittle compiler pattern matching logic, risk of having lower
   performance, unnecessary IR complexity.

--- a/rfcs/20260901-numpy-comparison-type.md
+++ b/rfcs/20260901-numpy-comparison-type.md
@@ -28,9 +28,12 @@ ranking semantics:
   sorts).
 - All NaNs (both positive and negative) are sorted to the end of the sequence
   (> +infinity).
+- Complex numbers are ordered lexicographically by (real, imag).
+
 StableHLO currently supports only `FLOAT` (standard IEEE-754 partial order)
 and `TOTALORDER` (IEEE-754 totalOrder, where -NaN < -infinity and
 -0.0 < +0.0).
+
 Because of this, frontends like JAX must emit a 7+ instruction boilerplate
 subgraph per scalar comparison in every sort comparator to canonicalize zeros
 and NaNs before calling `TOTALORDER`. In turn, downstream compiler backends
@@ -38,6 +41,7 @@ and NaNs before calling `TOTALORDER`. In turn, downstream compiler backends
 detect this subgraph and emit fast CUB `DeviceRadixSort` (see b/376918731).
 If any compiler optimization alters the AST, pattern matching fails and falls
 back to a 10x-25x slower bitonic sort.
+
 Adding `NUMPY` directly to `ComparisonType` eliminates frontend
 canonicalization bloat and provides a clean, robust contract for compiler
 backends.
@@ -48,12 +52,12 @@ In StableHLO and MLIR, operand types explicitly encode signedness
 (`si8`..`si64`, `ui8`..`ui64`, `i1`). Integer comparisons are mathematically
 total, and their sign interpretation is strictly dictated by the operand's
 `IntegerType`.
-Having `SIGNED` and `UNSIGNED` in `ComparisonType` is copied from XLA internals.
-XLA is migrating away from this by separating data type from ordering. In the
-future, the data type will always be derived from the operands of the
-comparison. In StableHLO, `SIGNED` and `UNSIGNED` are redundant and should be
-deprecated in favor of omitting `compare_type` (or using `NOTYPE`) for
-integer/boolean operands.
+
+Having `SIGNED` and `UNSIGNED` in `ComparisonType` is a legacy artifact of
+older XLA IR where operands were signless. XLA is migrating away from this by
+separating data type from ordering (see cl/974361549). In StableHLO, `SIGNED`
+and `UNSIGNED` are redundant and should be deprecated in favor of omitting
+`compare_type` (or using `NOTYPE`) for integer/boolean operands.
 
 ## Proposed Changes
 
@@ -71,6 +75,7 @@ def STABLEHLO_COMPARISON_TYPE_SIGNED :
 def STABLEHLO_COMPARISON_TYPE_UNSIGNED :
     I32EnumAttrCase<"UNSIGNED", 4>; // Deprecated
 def STABLEHLO_COMPARISON_TYPE_NUMPY : I32EnumAttrCase<"NUMPY", 5>;
+
 def StableHLO_ComparisonType : I32EnumAttr<"ComparisonType",
     "Which comparison type to use.",
     [
@@ -93,10 +98,14 @@ Update `compare` semantics:
   - -0.0 and +0.0 compare as equal (`EQ` is true; neither is `<` the other).
   - All NaN representations (positive, negative, signaling, quiet) compare as
     equal to each other and greater than all non-NaN values.
+- For complex element types with `compare_type = NUMPY`:
+  - Lexicographical comparison: compare real parts with `NUMPY` float
+    ordering; if equal, compare imaginary parts with `NUMPY` float ordering.
 - Constraints (C3) updated:
   - `SIGNED` and `UNSIGNED` marked deprecated.
   - `NOTYPE` is the standard for integer and boolean types.
-  - `FLOAT`, `TOTALORDER`, or `NUMPY` valid for floating-point types.
+  - `FLOAT`, `TOTALORDER`, or `NUMPY` valid for floating-point and complex
+    types.
 
 ### 3. Compatibility & Versioning
 
@@ -105,7 +114,7 @@ Update `compare` semantics:
   `NOTYPE`.
 - **Forward Compatibility**: `NUMPY` will be added to `VhloEnums.td`
   (`VHLO_ComparisonTypeV1`) with appropriate versioning.
-  
+
 ## Alternatives Considered
 
 ### Alternative 1: Replace `compare_type` with `comparison_order` attribute
@@ -119,11 +128,11 @@ introduce `comparison_order` with values `PARTIAL`, `TOTAL`, `NUMPY`.
   consumers, requiring op signature migration (`CompareOpV2` or complex
   bytecode upgrade rules). Option A achieves the required semantic
   expressiveness with zero disruption.
-  
+
 ### Alternative 2: Keep frontend canonicalization
 
 Continue lowering NumPy sorts in JAX/PyTorch via select/compare ASTs and
 relying on XLA backend pattern matching.
 
-- **Cons**: Brittle compiler pattern matching logic, risk of having lower
-  performance, unnecessary IR complexity.
+- **Cons**: Brittle compiler heuristics, risk of 10x-25x regressions,
+  unnecessary IR complexity.

--- a/rfcs/20260901-numpy-comparison-type.md
+++ b/rfcs/20260901-numpy-comparison-type.md
@@ -12,9 +12,9 @@ This RFC proposes:
 
 1. Adding `WEAKORDER` to `ComparisonType` (`compare_type` attribute on
    `stablehlo.compare`).
-3. Formally deprecating the `SIGNED` and `UNSIGNED` enum values in
+2. Formally deprecating the `SIGNED` and `UNSIGNED` enum values in
    `ComparisonType`.
-4. Updating the StableHLO specification for `compare` to support strict weak
+3. Updating the StableHLO specification for `compare` to support strict weak
    ordering semantics for floating-point types.
 
 ## Motivation & Background

--- a/rfcs/20260901-numpy-comparison-type.md
+++ b/rfcs/20260901-numpy-comparison-type.md
@@ -4,7 +4,7 @@ Status: In Review
 Initial version: 2026-09-01
 Last updated: 2026-09-01
 Discussion thread:
-https://github.com/openxla/stablehlo/pull/XXXX
+https://github.com/openxla/stablehlo/pull/3003
 
 ## Overview
 

--- a/rfcs/20260901-numpy-comparison-type.md
+++ b/rfcs/20260901-numpy-comparison-type.md
@@ -1,0 +1,123 @@
+# [RFC] Add NUMPY to ComparisonType and Deprecate SIGNED/UNSIGNED
+
+Status: In Review
+Initial version: 2026-09-01
+Last updated: 2026-09-01
+Discussion thread:
+https://github.com/openxla/stablehlo/pull/XXXX
+
+## Overview
+
+This RFC proposes:
+1. Adding `NUMPY` (or `FLOAT_NUMPY`) to `ComparisonType` (`compare_type`
+   attribute on `stablehlo.compare`).
+2. Formally deprecating the `SIGNED` and `UNSIGNED` enum values in
+   `ComparisonType`.
+3. Updating the StableHLO specification for `compare` to support
+   NumPy/Python-style total ordering semantics.
+
+## Motivation & Background
+
+### 1. The Need for NUMPY Comparison Order
+
+Machine learning frontends (JAX, PyTorch, NumPy) require NumPy sorting and
+ranking semantics:
+- -0.0 and +0.0 are treated as equivalent keys (preserving stability in stable
+  sorts).
+- All NaNs (both positive and negative) are sorted to the end of the sequence
+  (> +infinity).
+StableHLO currently supports only `FLOAT` (standard IEEE-754 partial order)
+and `TOTALORDER` (IEEE-754 totalOrder, where -NaN < -infinity and
+-0.0 < +0.0).
+Because of this, frontends like JAX must emit a 7+ instruction boilerplate
+subgraph per scalar comparison in every sort comparator to canonicalize zeros
+and NaNs before calling `TOTALORDER`. In turn, downstream compiler backends
+(such as XLA GPU's `SortRewriter`) rely on fragile AST pattern matching to
+detect this subgraph and emit fast CUB `DeviceRadixSort` (see b/376918731).
+If any compiler optimization alters the AST, pattern matching fails and falls
+back to a 10x-25x slower bitonic sort.
+Adding `NUMPY` directly to `ComparisonType` eliminates frontend
+canonicalization bloat and provides a clean, robust contract for compiler
+backends.
+
+### 2. Redundancy of SIGNED and UNSIGNED
+
+In StableHLO and MLIR, operand types explicitly encode signedness
+(`si8`..`si64`, `ui8`..`ui64`, `i1`). Integer comparisons are mathematically
+total, and their sign interpretation is strictly dictated by the operand's
+`IntegerType`.
+Having `SIGNED` and `UNSIGNED` in `ComparisonType` is copied from XLA internals.
+XLA is migrating away from this by separating data type from ordering. In the
+future, the data type will always be derived from the operands of the
+comparison. In StableHLO, `SIGNED` and `UNSIGNED` are redundant and should be
+deprecated in favor of omitting `compare_type` (or using `NOTYPE`) for
+integer/boolean operands.
+
+## Proposed Changes
+
+### 1. Dialect & Attributes
+
+Update `StableHLO_ComparisonType`:
+```tablegen
+def STABLEHLO_COMPARISON_TYPE_NOTYPE : I32EnumAttrCase<"NOTYPE", 0>;
+def STABLEHLO_COMPARISON_TYPE_FLOAT : I32EnumAttrCase<"FLOAT", 1>;
+def STABLEHLO_COMPARISON_TYPE_FLOAT_TOTAL_ORDER :
+    I32EnumAttrCase<"TOTALORDER", 2>;
+def STABLEHLO_COMPARISON_TYPE_SIGNED :
+    I32EnumAttrCase<"SIGNED", 3>; // Deprecated
+def STABLEHLO_COMPARISON_TYPE_UNSIGNED :
+    I32EnumAttrCase<"UNSIGNED", 4>; // Deprecated
+def STABLEHLO_COMPARISON_TYPE_NUMPY : I32EnumAttrCase<"NUMPY", 5>;
+def StableHLO_ComparisonType : I32EnumAttr<"ComparisonType",
+    "Which comparison type to use.",
+    [
+      STABLEHLO_COMPARISON_TYPE_NOTYPE,
+      STABLEHLO_COMPARISON_TYPE_FLOAT,
+      STABLEHLO_COMPARISON_TYPE_FLOAT_TOTAL_ORDER,
+      STABLEHLO_COMPARISON_TYPE_SIGNED,
+      STABLEHLO_COMPARISON_TYPE_UNSIGNED,
+      STABLEHLO_COMPARISON_TYPE_NUMPY
+    ]>
+```
+
+### 2. Specification (`docs/spec.md`)
+
+Update `compare` semantics:
+- For floating-point element types with `compare_type = NUMPY`:
+  - Implements total weak ordering:
+    -infinity < finite < -0.0 == +0.0 < finite < +infinity < NaN.
+  - -0.0 and +0.0 compare as equal (`EQ` is true; neither is `<` the other).
+  - All NaN representations (positive, negative, signaling, quiet) compare as
+    equal to each other and greater than all non-NaN values.
+- Constraints (C3) updated:
+  - `SIGNED` and `UNSIGNED` marked deprecated.
+  - `NOTYPE` is the standard for integer and boolean types.
+  - `FLOAT`, `TOTALORDER`, or `NUMPY` valid for floating-point types.
+
+### 3. Compatibility & Versioning
+
+- **Backward Compatibility**: Existing VHLO bytecodes with `SIGNED`/`UNSIGNED`
+  will continue to deserialize. On upgrade, they are preserved or mapped to
+  `NOTYPE`.
+- **Forward Compatibility**: `NUMPY` will be added to `VhloEnums.td`
+  (`VHLO_ComparisonTypeV1`) with appropriate versioning.
+  
+## Alternatives Considered
+
+### Alternative 1: Replace `compare_type` with `comparison_order` attribute
+
+Rather than extending `ComparisonType`, deprecate `compare_type` entirely and
+introduce `comparison_order` with values `PARTIAL`, `TOTAL`, `NUMPY`.
+- **Pros**: Cleaner conceptual model (separates data type from ordering; 1:1
+  match with XLA IR's `Comparison::Order`).
+- **Cons**: Substantial churn for all existing StableHLO producers and
+  consumers, requiring op signature migration (`CompareOpV2` or complex
+  bytecode upgrade rules). Option A achieves the required semantic
+  expressiveness with zero disruption.
+  
+### Alternative 2: Keep frontend canonicalization
+
+Continue lowering NumPy sorts in JAX/PyTorch via select/compare ASTs and
+relying on XLA backend pattern matching.
+- **Cons**: Brittle compiler pattern matching logic, risk of having lower
+  performance, unnecessary IR complexity.

--- a/rfcs/20260901-numpy-comparison-type.md
+++ b/rfcs/20260901-numpy-comparison-type.md
@@ -28,7 +28,6 @@ ranking semantics:
   sorts).
 - All NaNs (both positive and negative) are sorted to the end of the sequence
   (> +infinity).
-- Complex numbers are ordered lexicographically by (real, imag).
 
 StableHLO currently supports only `FLOAT` (standard IEEE-754 partial order)
 and `TOTALORDER` (IEEE-754 totalOrder, where -NaN < -infinity and
@@ -53,11 +52,12 @@ In StableHLO and MLIR, operand types explicitly encode signedness
 total, and their sign interpretation is strictly dictated by the operand's
 `IntegerType`.
 
-Having `SIGNED` and `UNSIGNED` in `ComparisonType` is a legacy artifact of
-older XLA IR where operands were signless. XLA is migrating away from this by
-separating data type from ordering (see cl/974361549). In StableHLO, `SIGNED`
-and `UNSIGNED` are redundant and should be deprecated in favor of omitting
-`compare_type` (or using `NOTYPE`) for integer/boolean operands.
+Having `SIGNED` and `UNSIGNED` in `ComparisonType` is copied from XLA internals.
+XLA is migrating away from this by separating data type from ordering. In the
+future, the data type will always be derived from the operands of the
+comparison. In StableHLO, `SIGNED` and `UNSIGNED` are redundant and should be
+deprecated in favor of omitting `compare_type` (or using `NOTYPE`) for
+integer/boolean operands.
 
 ## Proposed Changes
 
@@ -98,14 +98,10 @@ Update `compare` semantics:
   - -0.0 and +0.0 compare as equal (`EQ` is true; neither is `<` the other).
   - All NaN representations (positive, negative, signaling, quiet) compare as
     equal to each other and greater than all non-NaN values.
-- For complex element types with `compare_type = NUMPY`:
-  - Lexicographical comparison: compare real parts with `NUMPY` float
-    ordering; if equal, compare imaginary parts with `NUMPY` float ordering.
 - Constraints (C3) updated:
   - `SIGNED` and `UNSIGNED` marked deprecated.
   - `NOTYPE` is the standard for integer and boolean types.
-  - `FLOAT`, `TOTALORDER`, or `NUMPY` valid for floating-point and complex
-    types.
+  - `FLOAT`, `TOTALORDER`, or `NUMPY` valid for floating-point types.
 
 ### 3. Compatibility & Versioning
 
@@ -134,5 +130,5 @@ introduce `comparison_order` with values `PARTIAL`, `TOTAL`, `NUMPY`.
 Continue lowering NumPy sorts in JAX/PyTorch via select/compare ASTs and
 relying on XLA backend pattern matching.
 
-- **Cons**: Brittle compiler heuristics, risk of 10x-25x regressions,
-  unnecessary IR complexity.
+- **Cons**: Brittle compiler pattern matching logic, risk of having lower
+  performance, unnecessary IR complexity.

--- a/rfcs/20260901-numpy-comparison-type.md
+++ b/rfcs/20260901-numpy-comparison-type.md
@@ -90,18 +90,8 @@ def StableHLO_ComparisonType : I32EnumAttr<"ComparisonType",
 
 ### 2. Specification (`docs/spec.md`)
 
-Update `compare` semantics:
-
-- For floating-point element types with `compare_type = WEAKORDER`:
-  - Implements strict weak ordering:
-    -infinity < finite < -0.0 == +0.0 < finite < +infinity < NaN.
-  - -0.0 and +0.0 compare as equal (`EQ` is true; neither is `<` the other).
-  - All NaN representations (positive, negative, signaling, quiet) compare as
-    equal to each other and greater than all non-NaN values.
-- Constraints (C3) updated:
-  - `SIGNED` and `UNSIGNED` marked deprecated.
-  - `NOTYPE` is the standard for integer and boolean types.
-  - `FLOAT`, `TOTALORDER`, or `WEAKORDER` valid for floating-point types.
+Please refer to the `docs/spec.md` changes included in this PR to view the
+exact specification diff vs. the original spec.
 
 ### 3. Compatibility & Versioning
 


### PR DESCRIPTION
This PR adds an RFC proposing to extend `ComparisonType` in StableHLO with `WEAKORDER` comparison ordering and deprecate the redundant `SIGNED` and `UNSIGNED` attributes.

### Summary

1. **Add `WEAKORDER` to `ComparisonType`**: Supports NumPy/Python total ordering semantics (-0.0 == +0.0, NaNs sorted to the end). This eliminates the 7+ op canonicalization boilerplate in frontend sort comparators (such as JAX) and avoids fragile compiler AST pattern matching.
2. **Deprecate `SIGNED` and `UNSIGNED`**: In StableHLO, operand types explicitly encode signedness (`si32`, `ui32`, `i1`), and integer comparisons are inherently total order. `SIGNED` and `UNSIGNED` are legacy artifacts of XLA internals and should be deprecated in favor of `NOTYPE` (or omitting the attribute).
3. **Alternatives Considered**: Evaluates replacing `compare_type` with `comparison_order` (PARTIAL, TOTAL, WEAK) to align with XLA's internal migration, but chooses in-place `ComparisonType` extension to avoid syntax/API churn for existing StableHLO users. This PR introduces the RFC markdown document in `rfcs/` for community review and feedback prior to implementation.

CC @gleasonk @phawkins