### PR TITLE
[Draft] Fix Python build directory collision and interpreter resolution in CI

### DIFF
--- a/.github/workflows/buildAndTestCMake.yml
+++ b/.github/workflows/buildAndTestCMake.yml
@@ -24,6 +24,9 @@ on:
     - cron:  '0 */6 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # Ensure that only a single job or workflow using the same
 # concurrency group will run at a time. This would cancel
 # any in-progress jobs in the same github workflow and github
@@ -45,18 +48,21 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: ${{ github.repository == 'openxla/stablehlo' && 'linux-x86-n2-16' || 'ubuntu-22.04' }}
-    container: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-cmake:latest"
+    container: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-cmake@sha256:fa710b30f85d6167ee316a619479532f4d6184a6b4ca03170c97ba63f2a6d2ab"
 
     steps:
     - name: Checkout StableHLO
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Get LLVM Version
       id: llvm-version
       shell: bash
+      env:
+        IS_SCHEDULED: ${{ github.event_name == 'schedule' }}
       run: |
-        USE_LLVM_HEAD=${{ github.event_name == 'schedule' }}
-        if [[ $USE_LLVM_HEAD = true ]]; then
+        if [[ "$IS_SCHEDULED" == "true" ]]; then
           echo "version=main" >> $GITHUB_OUTPUT
         else
           echo "version=$(cat ./build_tools/llvm_version.txt)" >> $GITHUB_OUTPUT

--- a/.github/workflows/buildAndTestCMake.yml
+++ b/.github/workflows/buildAndTestCMake.yml
@@ -91,7 +91,7 @@ jobs:
       run: |
         python3 -m pip install tensorflow-cpu nanobind==2.9
         python3 -m pip install -r "$LLVM_PROJECT_DIR/mlir/python/requirements.txt"
-        ./build_tools/github_actions/ci_build_cmake.sh "$LLVM_BUILD_DIR" "$STABLEHLO_BUILD_DIR"
+        ./build_tools/github_actions/ci_build_cmake.sh "$LLVM_BUILD_DIR" "$STABLEHLO_PYTHON_BUILD_DIR"
       env:
           CMAKE_BUILD_TYPE: Release
           STABLEHLO_ENABLE_BINDINGS_PYTHON: ON

--- a/.github/workflows/buildAndTestCMake.yml
+++ b/.github/workflows/buildAndTestCMake.yml
@@ -24,9 +24,6 @@ on:
     - cron:  '0 */6 * * *'
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 # Ensure that only a single job or workflow using the same
 # concurrency group will run at a time. This would cancel
 # any in-progress jobs in the same github workflow and github
@@ -48,21 +45,18 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: ${{ github.repository == 'openxla/stablehlo' && 'linux-x86-n2-16' || 'ubuntu-22.04' }}
-    container: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-cmake@sha256:fa710b30f85d6167ee316a619479532f4d6184a6b4ca03170c97ba63f2a6d2ab"
+    container: "us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build-cmake:latest"
 
     steps:
     - name: Checkout StableHLO
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        persist-credentials: false
+      uses: actions/checkout@v4
 
     - name: Get LLVM Version
       id: llvm-version
       shell: bash
-      env:
-        IS_SCHEDULED: ${{ github.event_name == 'schedule' }}
       run: |
-        if [[ "$IS_SCHEDULED" == "true" ]]; then
+        USE_LLVM_HEAD=${{ github.event_name == 'schedule' }}
+        if [[ $USE_LLVM_HEAD = true ]]; then
           echo "version=main" >> $GITHUB_OUTPUT
         else
           echo "version=$(cat ./build_tools/llvm_version.txt)" >> $GITHUB_OUTPUT

--- a/build_tools/github_actions/ci_build_cmake.sh
+++ b/build_tools/github_actions/ci_build_cmake.sh
@@ -41,6 +41,8 @@ STABLEHLO_ENABLE_PYTHON_TF_TESTS="${STABLEHLO_ENABLE_PYTHON_TF_TESTS:-OFF}"
 # Note: This is not congruent with building python bindings
 STABLEHLO_ENABLE_SANITIZER="${STABLEHLO_ENABLE_SANITIZER:-OFF}"
 
+PYTHON_BIN="${Python3_EXECUTABLE:-$(python3 -c "import sys; print(sys.executable)")}"
+
 # Configure StableHLO
 # CMAKE_PLATFORM_NO_VERSIONED_SONAME Disables generation of "version soname"
 #                         (i.e. libFoo.so.<version>), which causes pure
@@ -60,8 +62,8 @@ cmake -GNinja \
   -DSTABLEHLO_ENABLE_SANITIZER="$STABLEHLO_ENABLE_SANITIZER" \
   -DSTABLEHLO_ENABLE_BINDINGS_PYTHON="$STABLEHLO_ENABLE_BINDINGS_PYTHON" \
   -DSTABLEHLO_ENABLE_PYTHON_TF_TESTS="$STABLEHLO_ENABLE_PYTHON_TF_TESTS" \
-  -DPython3_EXECUTABLE=/usr/bin/python3.12 \
-  -DPython_EXECUTABLE=/usr/bin/python3.12
+  -DPython3_EXECUTABLE="$PYTHON_BIN" \
+  -DPython_EXECUTABLE="$PYTHON_BIN"
 
 # Build and Test StableHLO
 cd "$STABLEHLO_BUILD_DIR" || exit

--- a/build_tools/github_actions/ci_build_cmake_llvm.sh
+++ b/build_tools/github_actions/ci_build_cmake_llvm.sh
@@ -33,6 +33,8 @@ CMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-RelWithDebInfo}"
 # Turn on building Python bindings
 MLIR_ENABLE_BINDINGS_PYTHON="${MLIR_ENABLE_BINDINGS_PYTHON:-OFF}"
 
+PYTHON_BIN="${Python3_EXECUTABLE:-$(python3 -c "import sys; print(sys.executable)")}"
+
 # Configure LLVM
 # LLVM_VERSION_SUFFIX to get rid of that annoying af git on the end of .17git
 # CMAKE_PLATFORM_NO_VERSIONED_SONAME Disables generation of "version soname"
@@ -58,8 +60,8 @@ cmake -GNinja \
   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
   -DCMAKE_C_COMPILER=clang \
   -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-  -DPython3_EXECUTABLE=/usr/bin/python3.12 \
-  -DPython_EXECUTABLE=/usr/bin/python3.12
+  -DPython3_EXECUTABLE="$PYTHON_BIN" \
+  -DPython_EXECUTABLE="$PYTHON_BIN"
 
 # Build LLVM/MLIR
 cmake --build "$LLVM_BUILD_DIR" --target all


### PR DESCRIPTION
### Problem

1. **Build Directory Collision in CMake CI**:
   In `.github/workflows/buildAndTestCMake.yml`, Step 7 ("Build and Test StableHLO (with AddressSanitizer)") compiles StableHLO with AddressSanitizer enabled inside `"$STABLEHLO_BUILD_DIR"`. Step 8 ("Build and Test StableHLO (with Python bindings)") was invoking `ci_build_cmake.sh` reusing `"$STABLEHLO_BUILD_DIR"` instead of the dedicated `"$STABLEHLO_PYTHON_BUILD_DIR"`.
   In `cmake/SetupSanitizers.cmake`, building Python bindings with sanitizers enabled is explicitly forbidden:
   ```cmake
   if (STABLEHLO_ENABLE_SANITIZER AND STABLEHLO_ENABLE_BINDINGS_PYTHON)
     message(FATAL_ERROR "STABLEHLO_ENABLE_SANITIZER must be set to OFF when building Python bindings")
   endif()

Reconfiguring the dirty ASan build directory corrupted CMake's cache and caused Ninja compilation/link failures.

2. Hardcoded Python Interpreter Path: In ci_build_cmake.sh and ci_build_cmake_llvm.sh, -DPython3_EXECUTABLE=/usr/bin/python3.12 and -DPython_EXECUTABLE=/usr/bin/python3.12 were hardcoded. When CI installs requirements with python3 -m pip install nanobind ... in runners or containers where the active python3 differs, CMake failed to find nanobind because it checked /usr/bin/python3.12.


Assisted-By: Gemini