### PR TITLE
[RFC] Adds Exp2Op and Log2Op to the StableHLO specification.

### DIFF
--- a/rfcs/20260907-exp2-log2.md
+++ b/rfcs/20260907-exp2-log2.md
@@ -1,0 +1,96 @@
+# [RFC] Add Exp2Op and Log2Op to the StableHLO specification
+
+Status: Review<br/>
+Initial version: 09/07/2026<br/>
+Last updated: 09/07/2026<br/>
+Discussion thread: [GitHub](https://github.com/openxla/stablehlo/pulls)
+
+## Motivation
+
+IEEE-754 (`exp2`, `log2`), C99 `<math.h>`, and LLVM intrinsics (`llvm.exp2`, `llvm.log2`) include base-2 exponential (`exp2`) and base-2 logarithm (`log2`) as standard elementary math functions, and hardware accelerators (such as GPU special function units and TPU EUP instructions) support them directly.
+
+Currently, StableHLO lacks native `exp2` and `log2` operations:
+* Frameworks expose `exp2` and `log2` directly: JAX provides [`jnp.exp2`](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.exp2.html) / `lax.exp2` and [`jnp.log2`](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.log2.html) / `lax.log2`, and PyTorch provides [`torch.exp2`](https://pytorch.org/docs/stable/generated/torch.exp2.html) and [`torch.log2`](https://pytorch.org/docs/stable/generated/torch.log2.html).
+* Without first-class ops in StableHLO, frameworks must decompose `exp2(x)` into `exponential(x * ln(2))` and `log2(x)` into `log(x) / ln(2)`.
+* Decomposing `exp2` and `log2` into natural `exponential` and `log` scaled by $\ln(2)$ degrades numerical accuracy (introducing rounding error on integer powers of two where `exp2(n)` and `log2(2^n)` should evaluate exactly) and prevents backends from emitting single-instruction base-2 hardware operations without fragile algebraic pattern-matching.
+
+Following the precedent of `TanOp` ([20240312-tanop.md](20240312-tanop.md)) and the transcendental accuracy specification ([20241015-result-accuracy.md](20241015-result-accuracy.md)), this RFC adds `exp2` (`Exp2Op`) and `log2` (`Log2Op`) to StableHLO with optional `result_accuracy` attributes.
+
+## Proposed Specification
+
+### exp2
+
+#### Semantics
+
+Performs element-wise base-2 exponential operation ($2^x$) on `operand` tensor and produces a `result` tensor. Depending on the element type, does the following:
+
+* For floats: `exp2` from IEEE-754.
+* For complex numbers: complex base-2 exponential.
+* For quantized types: `dequantize_op_quantize(exp2, operand, type(result))`.
+
+#### Inputs
+
+| Label | Name              | Type                                                                    | Constraints |
+|-------|-------------------|-------------------------------------------------------------------------|-------------|
+| (I1)  | `operand`         | tensor of floating-point or complex type or per-tensor quantized tensor | (C1)        |
+| (I2)  | `result_accuracy` | optional `ResultAccuracyAttr` (default `DEFAULT`)                       |             |
+
+#### Outputs
+
+| Name     | Type                                                                    | Constraints |
+|----------|-------------------------------------------------------------------------|-------------|
+| `result` | tensor of floating-point or complex type or per-tensor quantized tensor | (C1)        |
+
+#### Constraints
+
+* (C1) `baseline_type(operand) = baseline_type(result)`.
+
+#### Examples
+
+```mlir
+// %operand: [[0.0, 1.0], [2.0, 3.0]]
+%result = "stablehlo.exp2"(%operand) : (tensor<2x2xf64>) -> tensor<2x2xf64>
+// %result: [[1.0, 2.0], [4.0, 8.0]]
+```
+
+---
+
+### log2
+
+#### Semantics
+
+Performs element-wise base-2 logarithm operation ($\log_2(x)$) on `operand` tensor and produces a `result` tensor. Depending on the element type, does the following:
+
+* For floats: `log2` from IEEE-754.
+* For complex numbers: complex base-2 logarithm.
+* For quantized types: `dequantize_op_quantize(log2, operand, type(result))`.
+
+#### Inputs
+
+| Label | Name              | Type                                                                    | Constraints |
+|-------|-------------------|-------------------------------------------------------------------------|-------------|
+| (I1)  | `operand`         | tensor of floating-point or complex type or per-tensor quantized tensor | (C1)        |
+| (I2)  | `result_accuracy` | optional `ResultAccuracyAttr` (default `DEFAULT`)                       |             |
+
+#### Outputs
+
+| Name     | Type                                                                    | Constraints |
+|----------|-------------------------------------------------------------------------|-------------|
+| `result` | tensor of floating-point or complex type or per-tensor quantized tensor | (C1)        |
+
+#### Constraints
+
+* (C1) `baseline_type(operand) = baseline_type(result)`.
+
+#### Examples
+
+```mlir
+// %operand: [[1.0, 2.0], [4.0, 8.0]]
+%result = "stablehlo.log2"(%operand) : (tensor<2x2xf64>) -> tensor<2x2xf64>
+// %result: [[0.0, 1.0], [2.0, 3.0]]
+```
+
+## Exp2Op, Log2Op, and Compatibility
+
+* **VHLO Serialization**: StableHLO version `1.21.0` introduces `VHLO_Exp2OpV1` (`exp2_v1`) and `VHLO_Log2OpV1` (`log2_v1`).
+* **Forward Compatibility & Decomposition**: For runtimes targeting StableHLO versions prior to `1.21.0`, compatibility expansion lowers `exp2(x)` to `exponential(multiply(x, constant(ln(2))))` and `log2(x)` to `divide(log(x), constant(ln(2)))`.


### PR DESCRIPTION
Adds first-class `exp2` (`Exp2Op`) and `log2` (`Log2Op`) unary elementwise operations with optional `result_accuracy` attributes to StableHLO. Avoids accuracy loss from scaling by `ln(2)` and allows backends to emit single-instruction hardware base-2 operations directly.